### PR TITLE
Use the official OS X logs directory in FileLogger.

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -203,17 +203,18 @@
 {
 #if TARGET_OS_IPHONE
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *baseDir = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+	NSString *baseDir = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
+	NSString *logsDirectory = [basePath stringByAppendingPathComponent:@"Logs"];
+    
 #else
-	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
-    NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : NSTemporaryDirectory();
-	
 	NSString *appName = [[NSProcessInfo processInfo] processName];
-	
-	NSString *baseDir = [basePath stringByAppendingPathComponent:appName];
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
+	NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : NSTemporaryDirectory();
+	NSString *logsDirectory = [[basePath stringByAppendingPathComponent:@"Logs"] stringByAppendingPathComponent:appName];
+
 #endif
-	
-	return [baseDir stringByAppendingPathComponent:@"Logs"];
+
+	return logsDirectory;
 }
 
 - (NSString *)logsDirectory


### PR DESCRIPTION
Do not use the Application Support directory for log files on Mac OS X. The official directory for logs (in the user domain) is:

`$HOME/Library/Logs/$APPLICATION_NAME`

If put there, it will also show up in the sidebar in the Console app.
