### PR TITLE
Add CocoaPods pod spec.

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name     = 'CocoaLumberjack'
+  s.version  = '1.2.1'
+  s.license  = 'BSD'
+  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
+  s.homepage = 'http://code.google.com/p/cocoalumberjack/'
+  s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
+  s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
+                 :tag => '1.2.1' }
+
+  s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \
+                  'yet is designed specifically for objective-c, and takes advantage of features ' \
+                  'such as multi-threading, grand central dispatch (if available), lockless '      \
+                  'atomic operations, and the dynamic nature of the objective-c runtime.'
+
+  s.source_files = 'Lumberjack'
+  s.clean_paths = 'Benchmarking', 'Xcode'
+end


### PR DESCRIPTION
Hey Robbie, thought it was time for a spec in the root of your repo, which makes it easier to keep it up-to-date with source changes and allows users to install the bleeding-edge version directly from your repo.

You now also have push access to the [specs repo](https://github.com/CocoaPods/Specs), so that you can add a new version whenever you release one :)
