### PR TITLE
Change iOS logging directory to use /Library/Caches

### DIFF
--- a/Lumberjack/DDFileLogger.h
+++ b/Lumberjack/DDFileLogger.h
@@ -97,7 +97,7 @@
 // All log files are placed inside the logsDirectory.
 // If a specific logsDirectory isn't specified, the default directory is used.
 // On Mac, this is in ~/Library/Application Support/<Application Name>/Logs.
-// On iPhone, this is in ~/Documents/Logs.
+// On iPhone, this is in ~/Library/Caches/Logs.
 // 
 // Log files are named "log-<uuid>.txt",
 // where uuid is a 6 character hexadecimal consisting of the set [0123456789ABCDEF].

--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -180,7 +180,7 @@
 - (NSString *)defaultLogsDirectory
 {
 #if TARGET_OS_IPHONE
-	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 	NSString *baseDir = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
 	NSString *logsDirectory = [baseDir stringByAppendingPathComponent:@"Logs"];
     


### PR DESCRIPTION
Since the content of the documents directory is part of the iCloud backup, log files should not be stored in there by default any more. This commit changes it to store the log files in /Library/Caches directory instead by default.
