### PR TITLE
Changed public header location to match framework.

### DIFF
--- a/Xcode/LumberjackFramework/Mobile/Lumberjack.xcodeproj/project.pbxproj
+++ b/Xcode/LumberjackFramework/Mobile/Lumberjack.xcodeproj/project.pbxproj
@@ -392,7 +392,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Lumberjack/Lumberjack-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/Lumberjack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/Lumberjack;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -404,7 +406,9 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Lumberjack/Lumberjack-Prefix.pch";
 				OTHER_LDFLAGS = "-ObjC";
+				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include/Lumberjack;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/Lumberjack;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;


### PR DESCRIPTION
When a user wants to include lumberjack in a source file for both ios and mac, they previously had to use two different imports:

Now, the ios build puts the headers in a "Lumberjack" directory so that consumers can do a single import for both platforms:
