### PR TITLE
Revert "Refactor > Convert to modern Objective-C syntax"

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -1042,14 +1042,16 @@
 
 - (NSString *)description
 {
-	return [@{@"filePath": self.filePath,
-		@"fileName": self.fileName,
-		@"fileAttributes": self.fileAttributes,
-		@"creationDate": self.creationDate,
-		@"modificationDate": self.modificationDate,
-		@"fileSize": @(self.fileSize),
-		@"age": @(self.age),
-		@"isArchived": @(self.isArchived)} description];
+	return [[NSDictionary dictionaryWithObjectsAndKeys:
+		self.filePath, @"filePath",
+		self.fileName, @"fileName",
+		self.fileAttributes, @"fileAttributes",
+		self.creationDate, @"creationDate",
+		self.modificationDate, @"modificationDate",
+		[NSNumber numberWithUnsignedLongLong:self.fileSize], @"fileSize",
+		[NSNumber numberWithDouble:self.age], @"age",
+		[NSNumber numberWithBool:self.isArchived], @"isArchived",
+	nil] description];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Lumberjack/Extensions/ContextFilterLogFormatter.m
+++ b/Lumberjack/Extensions/ContextFilterLogFormatter.m
@@ -148,7 +148,7 @@
 {
 	OSSpinLockLock(&lock);
 	{
-		[set addObject:@(loggingContext)];
+		[set addObject:[NSNumber numberWithInt:loggingContext]];
 	}
 	OSSpinLockUnlock(&lock);
 }
@@ -157,7 +157,7 @@
 {
 	OSSpinLockLock(&lock);
 	{
-		[set removeObject:@(loggingContext)];
+		[set removeObject:[NSNumber numberWithInt:loggingContext]];
 	}
 	OSSpinLockUnlock(&lock);
 }
@@ -181,7 +181,7 @@
 	
 	OSSpinLockLock(&lock);
 	{
-		result = [set containsObject:@(loggingContext)];
+		result = [set containsObject:[NSNumber numberWithInt:loggingContext]];
 	}
 	OSSpinLockUnlock(&lock);
 	

--- a/Lumberjack/Extensions/DispatchQueueLogFormatter.m
+++ b/Lumberjack/Extensions/DispatchQueueLogFormatter.m
@@ -166,7 +166,7 @@
 		NSString *abrvLabel;
 		
 		if (useQueueLabel)
-			fullLabel = @(logMessage->queueLabel);
+			fullLabel = [NSString stringWithUTF8String:logMessage->queueLabel];
 		else
 			fullLabel = logMessage->threadName;
 		


### PR DESCRIPTION
This reverts commit 147b5006330d1873120d93abe390293c24951aae

Long story short, this commit breaks compatibility with XCode 4.2. Considering it is only a syntax change, there is no reason this project should be breaking compatibility with slightly older versions of build tools for such a trivial change. 

Maybe after iOS 6 is released and XCode 4.2 is officially "out of date" we can reconsider how to support older development tools, but we're not quite out of date so please don't abandon us yet.
