### PR TITLE
Remove dispatch_get_current_queue() iOS6 deprecation notices.

### DIFF
--- a/Lumberjack/DDAbstractDatabaseLogger.m
+++ b/Lumberjack/DDAbstractDatabaseLogger.m
@@ -239,7 +239,7 @@
 
 - (NSUInteger)saveThreshold
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 	{
 		return saveThreshold;
 	}
@@ -279,7 +279,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -287,7 +287,7 @@
 
 - (NSTimeInterval)saveInterval
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 	{
 		return saveInterval;
 	}
@@ -362,7 +362,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -370,7 +370,7 @@
 
 - (NSTimeInterval)maxAge
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 	{
 		return maxAge;
 	}
@@ -451,7 +451,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -459,7 +459,7 @@
 
 - (NSTimeInterval)deleteInterval
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 	{
 		return deleteInterval;
 	}
@@ -533,7 +533,7 @@
 		}
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -541,7 +541,7 @@
 
 - (BOOL)deleteOnEverySave
 {
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 	{
 		return deleteOnEverySave;
 	}
@@ -564,7 +564,7 @@
 		deleteOnEverySave = flag;
 	};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -581,7 +581,7 @@
 		[self performSaveAndSuspendSaveTimer];
 	}};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);
@@ -594,7 +594,7 @@
 		[self performDelete];
 	}};
 	
-	if (dispatch_get_current_queue() == loggerQueue)
+	if (dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0) == loggerQueue)
 		block();
 	else
 		dispatch_async(loggerQueue, block);

--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -528,7 +528,7 @@
 	// Note: The internal implementation should access the maximumFileSize variable directly,
 	// but if we forget to do this, then this method should at least work properly.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		return maximumFileSize;
@@ -562,7 +562,7 @@
 		
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -586,7 +586,7 @@
 	// Note: The internal implementation should access the rollingFrequency variable directly,
 	// but if we forget to do this, then this method should at least work properly.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		return rollingFrequency;
@@ -620,7 +620,7 @@
 		
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -700,7 +700,7 @@
 		[self rollLogFileNow];
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();

--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -868,7 +868,7 @@ static char *dd_str_copy(const char *str)
 		
 		machThreadID = pthread_mach_thread_np(pthread_self());
 		
-		queueLabel = dd_str_copy(dispatch_queue_get_label(dispatch_get_current_queue()));
+		queueLabel = dd_str_copy(dispatch_queue_get_label(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)));
 		
 		threadName = [[NSThread currentThread] name];
 	}
@@ -996,7 +996,7 @@ static char *dd_str_copy(const char *str)
 	// So direct access to the formatter is only available if requested from the loggerQueue.
 	// In all other circumstances we need to go through the loggingQueue to get the proper value.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		return formatter;
@@ -1038,7 +1038,7 @@ static char *dd_str_copy(const char *str)
 		}
 	}};
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -867,7 +867,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of this method is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		return colorsEnabled;
@@ -903,7 +903,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -956,7 +956,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -992,7 +992,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -1037,7 +1037,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -1065,7 +1065,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -1091,7 +1091,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -1117,7 +1117,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();
@@ -1144,7 +1144,7 @@ static DDTTYLogger *sharedInstance;
 	// The design of the setter logic below is taken from the DDAbstractLogger implementation.
 	// For documentation please refer to the DDAbstractLogger implementation.
 	
-	dispatch_queue_t currentQueue = dispatch_get_current_queue();
+	dispatch_queue_t currentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 	if (currentQueue == loggerQueue)
 	{
 		block();


### PR DESCRIPTION
dispatch_get_current_queue is deprecated in iOS6. Change all occurances
of that method to dispatch_get_global_queue() with a default priority,
which essentially does the same thing.
