### PR TITLE
Removes Static Analyzer Warning

### DIFF
--- a/Lumberjack/DDAbstractDatabaseLogger.m
+++ b/Lumberjack/DDAbstractDatabaseLogger.m
@@ -220,16 +220,18 @@
 	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxAge > 0.0))
 	{
 		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, loggerQueue);
-		
-		dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
-			
-			[self performDelete];
-			
-		}});
-		
-		[self updateDeleteTimer];
-		
-		dispatch_resume(deleteTimer);
+
+        if (deleteTimer != NULL) {
+            dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
+
+                [self performDelete];
+
+            }});
+
+            [self updateDeleteTimer];
+            
+            dispatch_resume(deleteTimer);
+        }
 	}
 }
 


### PR DESCRIPTION
The function dispatch_source_create can return NULL and clang's static analyzer complains about this.

The code is moved inside a if-branch to execute it only when deleteTimer is not NULL.
