### PR TITLE
Rectify mapping to ASL log level

### DIFF
--- a/Lumberjack/DDASLLogger.m
+++ b/Lumberjack/DDASLLogger.m
@@ -76,15 +76,15 @@ static DDASLLogger *sharedInstance;
 		const char *msg = [logMsg UTF8String];
 		
 		int aslLogLevel;
-		switch (logMessage->logLevel)
+		switch (logMessage->logFlag)
 		{
 			// Note: By default ASL will filter anything above level 5 (Notice).
 			// So our mappings shouldn't go above that level.
 			
-			case 1  : aslLogLevel = ASL_LEVEL_CRIT;    break;
-			case 2  : aslLogLevel = ASL_LEVEL_ERR;     break;
-			case 3  : aslLogLevel = ASL_LEVEL_WARNING; break;
-			default : aslLogLevel = ASL_LEVEL_NOTICE;  break;
+			case LOG_FLAG_ERROR : aslLogLevel = ASL_LEVEL_CRIT;    break;
+			case LOG_FLAG_WARN  : aslLogLevel = ASL_LEVEL_ERR;     break;
+			case LOG_FLAG_INFO  : aslLogLevel = ASL_LEVEL_WARNING; break;
+			default             : aslLogLevel = ASL_LEVEL_NOTICE;  break;
 		}
 		
 		asl_log(client, NULL, aslLogLevel, "%s", msg);


### PR DESCRIPTION
I found a couple minor bugs in `DDASLLogger`. This pull request includes a single commit that makes the following changes when mapping to ASL log level:
1. Switch on `logFlag` rather than `logLevel`. `logFlag` varies per log messages, while `logLevel` is constant at file or even global scope.
2. Use the `LOG_FLAG_*` constants for each case clause.
