### PR TITLE
Minor fix in DDLogMessage.

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -871,7 +871,7 @@ static char *dd_str_copy(const char *str)
 			file = (char *)aFile;
 		
 		if (options & DDLogMessageCopyFunction)
-			file = dd_str_copy(aFunction);
+			function = dd_str_copy(aFunction);
 		else
 			function = (char *)aFunction;
 		


### PR DESCRIPTION
...ction is specified

Fixes an issue where the function name passed to DDLogMessage would be
copied to the file name if DDLogMessageCopyFunction is specified in the
options.
