### PR TITLE
tag 1.6.1 & update podspec to coincide

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name     = 'CocoaLumberjack'
-  s.version  = '1.6'
+  s.version  = '1.6.1'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
   s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
-                 :tag => '1.6' }
+                 :tag => '1.6.1' }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \
                   'yet is designed specifically for objective-c, and takes advantage of features ' \


### PR DESCRIPTION
The podspec at the head points to version 1.6 - a version that still gives dispatch_get_current_queue() warnings.  This pull request tags version 1.6.1 and updates the podspec accordingly.
