### PR TITLE
Guard around dispatch_resume() being called with null pointer, as warned by the static analyzer.

### DIFF
--- a/Lumberjack/DDAbstractDatabaseLogger.m
+++ b/Lumberjack/DDAbstractDatabaseLogger.m
@@ -204,7 +204,7 @@
 
             [self updateDeleteTimer];
             
-            dispatch_resume(deleteTimer);
+            if (deleteTimer != NULL) dispatch_resume(deleteTimer);
         }
 	}
 }


### PR DESCRIPTION
The static analyzer was warning against this possibility of calling dispatch_resume() with a null pointer. The possibility looks slim, but I think is possible given the pointer is an ivar and could potentially change between the NULL check and the call.

We don't like any warnings (analyzer or otherwise) so fixed it.

Cheers,
Chris
