### PR TITLE
Add subdirectories under 'Lumberjack' to the podspec source files

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
                   'atomic operations, and the dynamic nature of the objective-c runtime.'
 
   s.requires_arc = true
-  s.source_files = 'Lumberjack'
+  s.source_files = 'Lumberjack/**/*'
   s.preserve_paths = 'Benchmarking', 'Xcode'
 end


### PR DESCRIPTION
Subdirectories aren't specified in the podspec source_files list, so the entire "Extensions" is omitted from anyone taking the latest CocoaLumberjack pod.
