### PR TITLE
Fix for potential crasher in [DDFileLogger description]

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -1017,14 +1017,14 @@
 
 - (NSString *)description
 {
-	return [@{@"filePath": self.filePath,
-		@"fileName": self.fileName,
-		@"fileAttributes": self.fileAttributes,
-		@"creationDate": self.creationDate,
-		@"modificationDate": self.modificationDate,
-		@"fileSize": @(self.fileSize),
-		@"age": @(self.age),
-		@"isArchived": @(self.isArchived)} description];
+    return [@{@"filePath": (self.filePath ? self.filePath : [NSNull null]),
+              @"fileName": (self.fileName ? self.fileName : [NSNull null]),
+              @"fileAttributes": (self.fileAttributes ? self.fileAttributes : [NSNull null]),
+              @"creationDate": (self.creationDate ? self.creationDate : [NSNull null]),
+              @"modificationDate": (self.modificationDate ? self.modificationDate : [NSNull null]),
+              @"fileSize": @(self.fileSize),
+              @"age": @(self.age),
+              @"isArchived": @(self.isArchived)} description];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
While checking my project for errors, I discovered an issue in [DDFileLogger description]:

```
/CocoaLumberjack/Lumberjack/DDFileLogger.m:1020:13: Dictionary value
```

cannot be nil

Here's a fix ready for review.
