### PR TITLE
Xcode 5 Static Analyzer: NSDictionary can not contain nil objects

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -1017,11 +1017,11 @@
 
 - (NSString *)description
 {
-	return [@{@"filePath": self.filePath,
-		@"fileName": self.fileName,
-		@"fileAttributes": self.fileAttributes,
-		@"creationDate": self.creationDate,
-		@"modificationDate": self.modificationDate,
+	return [@{@"filePath": (self.filePath ?: @""),
+		@"fileName": (self.fileName ?: @""),
+		@"fileAttributes": (self.fileAttributes ?: @""),
+		@"creationDate": (self.creationDate ?: @""),
+		@"modificationDate": (self.modificationDate ?: @""),
 		@"fileSize": @(self.fileSize),
 		@"age": @(self.age),
 		@"isArchived": @(self.isArchived)} description];


### PR DESCRIPTION
The static analyzer in Xcode 5 complains that NSDictionary can't contain
nil objects.

Set a default empty NSString if any nil objects are found
in the DDFileLogger.
