### PR TITLE
Implemented different logLevel per each logger

### DIFF
--- a/Lumberjack/DDASLLogger.m
+++ b/Lumberjack/DDASLLogger.m
@@ -64,6 +64,10 @@ static DDASLLogger *sharedInstance;
 
 - (void)logMessage:(DDLogMessage *)logMessage
 {
+    if (![self shouldLogMessage:logMessage]) {
+        return;
+    }
+    
 	NSString *logMsg = logMessage->logMsg;
 	
 	if (formatter)

--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -848,6 +848,10 @@
 
 - (void)logMessage:(DDLogMessage *)logMessage
 {
+    if (![self shouldLogMessage:logMessage]) {
+        return;
+    }
+    
 	NSString *logMsg = logMessage->logMsg;
 	
 	if (formatter)

--- a/Lumberjack/DDLog.h
+++ b/Lumberjack/DDLog.h
@@ -591,8 +591,15 @@ typedef int DDLogMessageOptions;
 	dispatch_queue_t loggerQueue;
 }
 
+/**
+ *  Each logger can have a different logLevel, ignoring messages that are beyond this level
+ */
+@property (nonatomic, assign) int logLevel;
+
 - (id <DDLogFormatter>)logFormatter;
 - (void)setLogFormatter:(id <DDLogFormatter>)formatter;
+
+- (BOOL)shouldLogMessage:(DDLogMessage *)logMessage;
 
 // For thread-safety assertions
 - (BOOL)isOnGlobalLoggingQueue;

--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -961,7 +961,15 @@ static char *dd_str_copy(const char *str)
 
 - (void)logMessage:(DDLogMessage *)logMessage
 {
-	// Override me
+	// Override me and use shouldLogMessage for filtering
+}
+
+- (BOOL)shouldLogMessage:(DDLogMessage *)logMessage {
+    // if the logLevel was not set (0 is default), then we don't need to filter anything, otherwise no logs will pass the following validation
+    if (self.logLevel == 0) {
+        return YES;
+    }
+    return (logMessage->logFlag <= self.logLevel);
 }
 
 - (id <DDLogFormatter>)logFormatter

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -1165,6 +1165,10 @@ static DDTTYLogger *sharedInstance;
 
 - (void)logMessage:(DDLogMessage *)logMessage
 {
+    if (![self shouldLogMessage:logMessage]) {
+        return;
+    }
+    
 	NSString *logMsg = logMessage->logMsg;
 	BOOL isFormatted = NO;
 	


### PR DESCRIPTION
Different log levels per loggers can be very useful. In all the projects I used CocoaLumberjack, I wanted to have different levels for each XCode configuration (Debug vsAdHoc vs AppStore), but also different for each logger.
Potential reasons:
- TTY logs are not needed on AppStore builds
- ASL are slow (even with the improvement from CocoaLumberjack), so I tend to set Warning level only for those in AppStore builds, as where the file logging will use a more permissive setting (like info)
- if you use a custom logger (like I do for Crashlytics logs), chance is you want a different log level there too
