### PR TITLE
DDTTYLogger: Allow to set default color profiles for all contexts at once

### DIFF
--- a/Lumberjack/DDTTYLogger.h
+++ b/Lumberjack/DDTTYLogger.h
@@ -7,6 +7,8 @@
 
 #import "DDLog.h"
 
+#define LOG_CONTEXT_ALL NSIntegerMax
+
 /**
  * Welcome to Cocoa Lumberjack!
  * 
@@ -116,6 +118,8 @@
  * 
  * A logging context is often used to identify log messages coming from a 3rd party framework,
  * although logging context's can be used for many different functions.
+ * 
+ * Use LOG_CONTEXT_ALL to set the deafult color for all contexts that have no specific color set defined.
  * 
  * Logging context's are explained in further detail here:
  * https://github.com/robbiehanson/CocoaLumberjack/wiki/CustomContext

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -1182,10 +1182,24 @@ static DDTTYLogger *sharedInstance;
 			{
 				for (DDTTYLoggerColorProfile *cp in colorProfilesArray)
 				{
-					if ((logMessage->logFlag & cp->mask) && (logMessage->logContext == cp->context))
+					if (logMessage->logFlag & cp->mask)
 					{
-						colorProfile = cp;
-						break;
+                        // Color profile set for this context?
+                        if (logMessage->logContext == cp->context)
+                        {
+                            colorProfile = cp;
+                            
+                            // Stop searching
+                            break;
+                        }
+						
+                        // Check if LOG_CONTEXT_ALL was specified as a default color for this flag
+                        if (cp->context == LOG_CONTEXT_ALL)
+                        {
+                            colorProfile = cp;
+                            
+                            // We don't break to keep searching for more specific color profiles for the context
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
- Using `LOG_CONTEXT_ALL` will associate a color profile log messages from all contexts.
- Specific contexts can still set a different color profile on top.

In the future `setForegroundColor:backgroundColor:forFlag:(int)mask` could set the value for `LOG_CONTEXT_ALL` instead of context `(0)`.
