### PR TITLE
Update podspec

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -6,14 +6,16 @@ Pod::Spec.new do |s|
   s.homepage = 'https://github.com/robbiehanson/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
   s.source   = { :git => 'https://github.com/robbiehanson/CocoaLumberjack.git',
-                 :tag => '1.6.2' }
+                 :tag => "#{s.version}" }
 
   s.description = 'It is similar in concept to other popular logging frameworks such as log4j, '   \
                   'yet is designed specifically for objective-c, and takes advantage of features ' \
                   'such as multi-threading, grand central dispatch (if available), lockless '      \
                   'atomic operations, and the dynamic nature of the objective-c runtime.'
 
-  s.requires_arc = true
-  s.source_files = 'Lumberjack/**/*.{h,m}'
-  s.preserve_paths = 'Benchmarking', 'Xcode'
+  s.requires_arc   = true
+  s.ios.platform   = :ios, '5.0'
+  s.osx.platform   = :osx, '10.7'
+  s.source_files   = 'Lumberjack/**/*.{h,m}'
+  s.preserve_paths = 'Lumberjack/**/README*'
 end


### PR DESCRIPTION
Supersedes #143.
- Deduce tag from Pod version.
- Fix `pod spec lint` warnings.
- Remove files not directly related to the static library (Benchmarking, Demos) as Pods normally do.
- Add platform requirements (#116).
