### PR TITLE
DDTTYLogger: By default apply setForegroundColor:backgroundColor:forFlag: to LOG_CONTEXT_ALL

### DIFF
--- a/Lumberjack/DDTTYLogger.h
+++ b/Lumberjack/DDTTYLogger.h
@@ -105,7 +105,7 @@
  * If you run the application from a shell, then DDTTYLogger will automatically map the given color to
  * the closest available color. (xterm-256color or xterm-color which have 256 and 16 supported colors respectively.)
  * 
- * This method invokes setForegroundColor:backgroundColor:forFlag:context: and passes the default context (0).
+ * This method invokes setForegroundColor:backgroundColor:forFlag:context: and applies it to `LOG_CONTEXT_ALL`.
 **/
 #if TARGET_OS_IPHONE
 - (void)setForegroundColor:(UIColor *)txtColor backgroundColor:(UIColor *)bgColor forFlag:(int)mask;

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -931,7 +931,7 @@ static DDTTYLogger *sharedInstance;
 
 - (void)setForegroundColor:(OSColor *)txtColor backgroundColor:(OSColor *)bgColor forFlag:(int)mask
 {
-	[self setForegroundColor:txtColor backgroundColor:bgColor forFlag:mask context:0];
+	[self setForegroundColor:txtColor backgroundColor:bgColor forFlag:mask context:LOG_CONTEXT_ALL];
 }
 
 - (void)setForegroundColor:(OSColor *)txtColor backgroundColor:(OSColor *)bgColor forFlag:(int)mask context:(int)ctxt


### PR DESCRIPTION
Until now this method applied to only the default context `(0)`.

Follows #146.
