### PR TITLE
Fix LOG_CONTEXT_ALL define for OS X

### DIFF
--- a/Lumberjack/DDTTYLogger.h
+++ b/Lumberjack/DDTTYLogger.h
@@ -7,7 +7,7 @@
 
 #import "DDLog.h"
 
-#define LOG_CONTEXT_ALL NSIntegerMax
+#define LOG_CONTEXT_ALL INT_MAX
 
 /**
  * Welcome to Cocoa Lumberjack!


### PR DESCRIPTION
Change from `NSIntegerMax` to `INT_MAX` to fix " Implicit conversion from 'long' to 'int' changes 9223372036854775807 to -1" error.
