### PR TITLE
Added ddLogLevel as extern in DDLog.h

### DIFF
--- a/Lumberjack/DDLog.h
+++ b/Lumberjack/DDLog.h
@@ -611,3 +611,5 @@ typedef int DDLogMessageOptions;
 - (BOOL)isOnInternalLoggerQueue;
 
 @end
+
+extern int ddLogLevel;


### PR DESCRIPTION
When loading CocoaLumberjack via Cocoapods, I've often had problems with duplicate symbol _ddLogLevel when a dependency also has depended upon CocoaLumberjack.  My solution is to declare ddLogLevel as extern in the dependency as well as CocoaLumberjack.  

Is there any disadvantage to always declaring ddLogLevel as extern in DDLog.h?

Thanks for a great library!
