### PR TITLE
Ignore deprecated warning for dispatch_get_current_queue

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -907,7 +907,11 @@ static char *dd_str_copy(const char *str)
             ![[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // < OS X 10.9
         #endif
             ) {
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
             dispatch_queue_t currentQueue = dispatch_get_current_queue();
+            #pragma clang diagnostic pop
+            
             queueLabel = dd_str_copy(dispatch_queue_get_label(currentQueue));
             gotLabel = YES;
         }


### PR DESCRIPTION
This function is never executed on devices where it's deprecated anyway.

Closes #165.
