### PR TITLE
The sharedInstance variable should not be set before init is called.

### DIFF
--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -807,7 +807,7 @@ static DDTTYLogger *sharedInstance;
 		NSLogInfo(@"DDTTYLogger: isaColor256TTY: %@", (isaColor256TTY ? @"YES" : @"NO"));
 		NSLogInfo(@"DDTTYLogger: isaXcodeColorTTY: %@", (isaXcodeColorTTY ? @"YES" : @"NO"));
 		
-        DDTTYLogger *objInstance = [[[self class] alloc] init];
+		DDTTYLogger *objInstance = [[[self class] alloc] init];
 		sharedInstance = objInstance;
 	}
 }


### PR DESCRIPTION
Hi,

I found that sharedInstance variable will not be initialized properly because in init method there is a check for sharedInstance, and if it is already set return nil.
So the end result will be the sharedInstance s nil (return value from init) and initialized is set to YES.

Thanks
ZDima
