### PR TITLE
Allow customizing the naming convention for log files to use timestamps.

### DIFF
--- a/Lumberjack/DDFileLogger.h
+++ b/Lumberjack/DDFileLogger.h
@@ -29,6 +29,12 @@
 #define DEFAULT_LOG_ROLLING_FREQUENCY (60 * 60 * 24)  // 24 Hours
 #define DEFAULT_LOG_MAX_NUM_LOG_FILES (5)             //  5 Files
 
+// How should we produce unique file names? by UUID or timestamp?
+typedef enum {
+    DDLogFileNamingConventionUUID,
+    DDLogFileNamingConventionTimestamp
+} DDLogFileNamingConvention;
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
@@ -118,6 +124,8 @@
 	NSUInteger maximumNumberOfLogFiles;
 	NSString *_logsDirectory;
 }
+
+@property (readwrite, assign) DDLogFileNamingConvention fileNamingConvention;
 
 - (id)init;
 - (instancetype)initWithLogsDirectory:(NSString *)logsDirectory;


### PR DESCRIPTION
We find UUIDs to quite awkward in the field because the files cannot be
sorted in chronological order by filename. This patch adds an optional
convention to the DDLogFileManagerDefault class which uses timestamps
instead. The existing UUID-based naming convention is retained as the
default convention for backwards compatibility.

Timestamps are formatted as RFC 3339 dates in the UTC time zone.
