### PR TITLE
Spaces changed to tabs for all files in Lumberjack folder

### DIFF
--- a/Lumberjack/DDAbstractDatabaseLogger.m
+++ b/Lumberjack/DDAbstractDatabaseLogger.m
@@ -28,7 +28,7 @@
 {
 	if ((self = [super init]))
 	{
-        saveThreshold = 500;
+		saveThreshold = 500;
 		saveInterval = 60;           // 60 seconds
 		maxAge = (60 * 60 * 24 * 7); //  7 days
 		deleteInterval = (60 * 5);   //  5 minutes
@@ -194,18 +194,18 @@
 	if ((deleteTimer == NULL) && (deleteInterval > 0.0) && (maxAge > 0.0))
 	{
 		deleteTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, loggerQueue);
-
-        if (deleteTimer != NULL) {
-            dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
-
-                [self performDelete];
-
-            }});
-
-            [self updateDeleteTimer];
-            
-            if (deleteTimer != NULL) dispatch_resume(deleteTimer);
-        }
+		
+		if (deleteTimer != NULL) {
+			dispatch_source_set_event_handler(deleteTimer, ^{ @autoreleasepool {
+				
+				[self performDelete];
+				
+			}});
+			
+			[self updateDeleteTimer];
+			
+			if (deleteTimer != NULL) dispatch_resume(deleteTimer);
+		}
 	}
 }
 

--- a/Lumberjack/DDFileLogger.h
+++ b/Lumberjack/DDFileLogger.h
@@ -31,8 +31,8 @@
 
 // How should we produce unique file names? by UUID or timestamp?
 typedef enum {
-    DDLogFileNamingConventionUUID,
-    DDLogFileNamingConventionTimestamp
+	DDLogFileNamingConventionUUID,
+	DDLogFileNamingConventionTimestamp
 } DDLogFileNamingConvention;
 
 

--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -85,13 +85,13 @@
 
 - (void)dealloc
 {
-    // try-catch because the observer might be removed or never added. In this case, removeObserver throws and exception
-    @try {
-        [self removeObserver:self forKeyPath:@"maximumNumberOfLogFiles"];
-    }
-    @catch (NSException *exception) {
-        
-    }
+	// try-catch because the observer might be removed or never added. In this case, removeObserver throws and exception
+	@try {
+		[self removeObserver:self forKeyPath:@"maximumNumberOfLogFiles"];
+	}
+	@catch (NSException *exception) {
+		
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -197,15 +197,15 @@
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
 	NSString *baseDir = ([paths count] > 0) ? [paths objectAtIndex:0] : nil;
 	NSString *logsDirectory = [baseDir stringByAppendingPathComponent:@"Logs"];
-    
+	
 #else
 	NSString *appName = [[NSProcessInfo processInfo] processName];
 	NSArray *paths = NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES);
 	NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : NSTemporaryDirectory();
 	NSString *logsDirectory = [[basePath stringByAppendingPathComponent:@"Logs"] stringByAppendingPathComponent:appName];
-
+	
 #endif
-
+	
 	return logsDirectory;
 }
 
@@ -377,40 +377,40 @@
 **/
 - (NSString *)generateLogFileNameWithConvention:(DDLogFileNamingConvention)convention attempt:(NSUInteger)attempt
 {
-    NSString *uniquePart = nil;
-    
-    switch(convention) {
-        case DDLogFileNamingConventionUUID: {
-            CFUUIDRef uuid = CFUUIDCreate(NULL);
-            
-            CFStringRef fullStr = CFUUIDCreateString(NULL, uuid);
-            uniquePart = (__bridge_transfer NSString *)CFStringCreateWithSubstring(NULL, fullStr, CFRangeMake(0, 6));
-            
-            CFRelease(fullStr);
-            CFRelease(uuid);
-            
-            break;
-        }
-
-        case DDLogFileNamingConventionTimestamp: {
-            NSDate *now = [NSDate date];
-            
-            // RFC 3339 format, UTC time
-            NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-            [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
-            [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
-            
-            NSString *formattedDate = [dateFormatter stringFromDate:now];
-            
-            if (attempt == 1) {
-                uniquePart = formattedDate;
-            } else {
-                uniquePart = [NSString stringWithFormat:@"%@ %lu", formattedDate, (unsigned long)attempt];
-            }
-            
-            break;
-        }
-    }
+	NSString *uniquePart = nil;
+	
+	switch(convention) {
+		case DDLogFileNamingConventionUUID: {
+			CFUUIDRef uuid = CFUUIDCreate(NULL);
+			
+			CFStringRef fullStr = CFUUIDCreateString(NULL, uuid);
+			uniquePart = (__bridge_transfer NSString *)CFStringCreateWithSubstring(NULL, fullStr, CFRangeMake(0, 6));
+			
+			CFRelease(fullStr);
+			CFRelease(uuid);
+			
+			break;
+		}
+		
+		case DDLogFileNamingConventionTimestamp: {
+			NSDate *now = [NSDate date];
+			
+			// RFC 3339 format, UTC time
+			NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+			[dateFormatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+			[dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+			
+			NSString *formattedDate = [dateFormatter stringFromDate:now];
+			
+			if (attempt == 1) {
+				uniquePart = formattedDate;
+			} else {
+				uniquePart = [NSString stringWithFormat:@"%@ %lu", formattedDate, (unsigned long)attempt];
+			}
+			
+			break;
+		}
+	}
 	
 	return [NSString stringWithFormat:@"log-%@.txt", uniquePart];
 }
@@ -423,7 +423,7 @@
 	// Generate a random log file name, and create the file (if there isn't a collision)
 	
 	NSString *logsDirectory = [self logsDirectory];
-    NSUInteger attempt = 1;
+	NSUInteger attempt = 1;
 	do
 	{
 		NSString *fileName = [self generateLogFileNameWithConvention:self.fileNamingConvention attempt:attempt];
@@ -441,8 +441,8 @@
 			
 			return filePath;
 		} else {
-            attempt++;
-        }
+	        attempt++;
+	    }
 		
 	} while(YES);
 }

--- a/Lumberjack/DDLog.h
+++ b/Lumberjack/DDLog.h
@@ -540,7 +540,7 @@ typedef int DDLogMessageOptions;
 	char *function;
 	int lineNumber;
 	mach_port_t machThreadID;
-    char *queueLabel;
+	char *queueLabel;
 	NSString *threadName;
 	
 	// For 3rd party extensions to the framework, where flags and contexts aren't enough.

--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -62,7 +62,7 @@ static void *const GlobalLoggingQueueIdentityKey = (void *)&GlobalLoggingQueueId
 @public 
 	id <DDLogger> logger;	
 	dispatch_queue_t loggerQueue;
-    int logLevel;
+	int logLevel;
 }
 
 @property (nonatomic, assign, readonly) int logLevel;
@@ -186,13 +186,13 @@ static unsigned int numProcessors;
 
 + (void)addLogger:(id <DDLogger>)logger
 {
-    [self addLogger:logger withLogLevel:LOG_LEVEL_VERBOSE];
+	[self addLogger:logger withLogLevel:LOG_LEVEL_VERBOSE];
 }
 
 + (void)addLogger:(id <DDLogger>)logger withLogLevel:(int)logLevel
 {
-    if (logger == nil) return;
-    
+	if (logger == nil) return;
+	
 	dispatch_async(loggingQueue, ^{ @autoreleasepool {
 		
 		[self lt_addLogger:logger logLevel:logLevel];
@@ -623,7 +623,7 @@ static unsigned int numProcessors;
 + (void)lt_log:(DDLogMessage *)logMessage
 {
 	// Execute the given log message on each of our loggers.
-    
+	
 	if (numProcessors > 1)
 	{
 		// Execute each logger concurrently, each within its own queue.
@@ -656,7 +656,7 @@ static unsigned int numProcessors;
 		for (DDLoggerNode *loggerNode in loggers)
 		{
 			// skip the loggers that shouldn't write this message based on the logLevel
-            
+			
 			if (logMessage->logFlag > loggerNode.logLevel)
 				continue;
 
@@ -808,7 +808,7 @@ NSString *DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy)
 			dispatch_retain(loggerQueue);
 			#endif
 		}
-        logLevel = aLogLevel;
+		logLevel = aLogLevel;
 	}
 	return self;
 }
@@ -879,47 +879,47 @@ static char *dd_str_copy(const char *str)
 		timestamp = [[NSDate alloc] init];
 		
 		machThreadID = pthread_mach_thread_np(pthread_self());
-
-        // Try to get the current queue's label
-        
-        // a) Compiling against newer SDK's (iOS 7+/OS X 10.9+) where DISPATCH_CURRENT_QUEUE_LABEL is defined
-        //    on a (iOS 7.0+/OS X 10.9+) runtime version
-        BOOL gotLabel = NO;
-        #ifdef DISPATCH_CURRENT_QUEUE_LABEL
-        if (
-            #if TARGET_OS_IPHONE
-            	floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_0
-            #else
-            	[[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // No nice way to check for OS X 10.9+
-            #endif
-            ) {
-            queueLabel = dd_str_copy(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL));
-            gotLabel = YES;
-        }
-        #endif
-        
-        // b) Systems where dispatch_get_current_queue is not yet deprecated and won't crash (< iOS 6.0/OS X 10.9)
-        //    dispatch_get_current_queue(void); __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_6,__MAC_10_9,__IPHONE_4_0,__IPHONE_6_0)
-        if (!gotLabel &&
-        #if TARGET_OS_IPHONE
-            floor(NSFoundationVersionNumber) < NSFoundationVersionNumber_iOS_6_0
-        #else
-            ![[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // < OS X 10.9
-        #endif
-            ) {
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            dispatch_queue_t currentQueue = dispatch_get_current_queue();
-            #pragma clang diagnostic pop
-            
-            queueLabel = dd_str_copy(dispatch_queue_get_label(currentQueue));
-            gotLabel = YES;
-        }
-        
-        // c) Give up
-        if (!gotLabel) {
-            queueLabel = dd_str_copy("");
-        }
+		
+		// Try to get the current queue's label
+		
+		// a) Compiling against newer SDK's (iOS 7+/OS X 10.9+) where DISPATCH_CURRENT_QUEUE_LABEL is defined
+		//    on a (iOS 7.0+/OS X 10.9+) runtime version
+		BOOL gotLabel = NO;
+		#ifdef DISPATCH_CURRENT_QUEUE_LABEL
+		if (
+			#if TARGET_OS_IPHONE
+				floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_6_0
+			#else
+				[[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // No nice way to check for OS X 10.9+
+			#endif
+			) {
+			queueLabel = dd_str_copy(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL));
+			gotLabel = YES;
+		}
+		#endif
+		
+		// b) Systems where dispatch_get_current_queue is not yet deprecated and won't crash (< iOS 6.0/OS X 10.9)
+		//    dispatch_get_current_queue(void); __OSX_AVAILABLE_BUT_DEPRECATED(__MAC_10_6,__MAC_10_9,__IPHONE_4_0,__IPHONE_6_0)
+		if (!gotLabel &&
+		#if TARGET_OS_IPHONE
+			floor(NSFoundationVersionNumber) < NSFoundationVersionNumber_iOS_6_0
+		#else
+			![[NSApplication sharedApplication] respondsToSelector:@selector(occlusionState)] // < OS X 10.9
+		#endif
+			) {
+			#pragma clang diagnostic push
+			#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			dispatch_queue_t currentQueue = dispatch_get_current_queue();
+			#pragma clang diagnostic pop
+			
+			queueLabel = dd_str_copy(dispatch_queue_get_label(currentQueue));
+			gotLabel = YES;
+		}
+		
+		// c) Give up
+		if (!gotLabel) {
+			queueLabel = dd_str_copy("");
+		}
 		
 		threadName = [[NSThread currentThread] name];
 	}

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -1193,22 +1193,22 @@ static DDTTYLogger *sharedInstance;
 				{
 					if (logMessage->logFlag & cp->mask)
 					{
-                        // Color profile set for this context?
-                        if (logMessage->logContext == cp->context)
-                        {
-                            colorProfile = cp;
-                            
-                            // Stop searching
-                            break;
-                        }
+						// Color profile set for this context?
+						if (logMessage->logContext == cp->context)
+						{
+							colorProfile = cp;
+							
+							// Stop searching
+							break;
+						}
 						
-                        // Check if LOG_CONTEXT_ALL was specified as a default color for this flag
-                        if (cp->context == LOG_CONTEXT_ALL)
-                        {
-                            colorProfile = cp;
-                            
-                            // We don't break to keep searching for more specific color profiles for the context
-                        }
+						// Check if LOG_CONTEXT_ALL was specified as a default color for this flag
+						if (cp->context == LOG_CONTEXT_ALL)
+						{
+							colorProfile = cp;
+							
+							// We don't break to keep searching for more specific color profiles for the context
+						}
 					}
 				}
 			}

--- a/Lumberjack/Extensions/DispatchQueueLogFormatter.m
+++ b/Lumberjack/Extensions/DispatchQueueLogFormatter.m
@@ -100,7 +100,7 @@
 			[threadUnsafeDateFormatter setDateFormat:dateFormatString];
 		}
 		
-        [threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+		[threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
 		return [threadUnsafeDateFormatter stringFromDate:date];
 	}
 	else
@@ -122,7 +122,7 @@
 			threadDictionary[key] = dateFormatter;
 		}
 		
-        [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+		[dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
 		return [dateFormatter stringFromDate:date];
 	}
 }


### PR DESCRIPTION
There were spaces instead of tabs in some places. If someone's tab size doesn't equal 4 spaces the code would look ugly (and it looks ugly on github now).

On the other hand those changes would break `git blame` command, so I'm not sure if it is a good idea to merge them.
