### PR TITLE
DDFileLogger: fixing comments and small refactoring

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -87,7 +87,7 @@
 {
     // try-catch because the observer might be removed or never added. In this case, removeObserver throws and exception
     @try {
-        [self removeObserver:self forKeyPath:@"maximumNumberOfLogFiles"];
+        [self removeObserver:self forKeyPath:NSStringFromSelector(@selector(maximumNumberOfLogFiles))];
     }
     @catch (NSException *exception) {
         
@@ -112,7 +112,7 @@
         return;
     }
     
-    if ([keyPath isEqualToString:@"maximumNumberOfLogFiles"])
+    if ([keyPath isEqualToString:NSStringFromSelector(@selector(maximumNumberOfLogFiles))])
     {
         NSLogInfo(@"DDFileLogManagerDefault: Responding to configuration change: maximumNumberOfLogFiles");
         


### PR DESCRIPTION
- Fixed wrong/outdated comments.
- KeyPath `@"maximumNumberOfLogFiles"` changed to `NSStringFromSelector(@selector(maximumNumberOfLogFiles))`
  - to be convenient with line 78
  - it saves from typo in case of renaming property
