### PR TITLE
Support iOS6 SDK (Xcode 4.4+) issue

### DIFF
--- a/Lumberjack/DDLog.h
+++ b/Lumberjack/DDLog.h
@@ -285,6 +285,9 @@ NSString *DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 
 #define THIS_METHOD NSStringFromSelector(_cmd)
 
+#ifndef NSFoundationVersionNumber_iOS_6_0
+#define NSFoundationVersionNumber_iOS_6_0 993.00
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -


### PR DESCRIPTION
NSFoundationVersionNumber_iOS_6_0 is not defined under iOS6 SDK. (Some applications still need to be built under this sdk for iOS7 etc). Please, fix this issue and update cocoapods;) Thanks.
