### PR TITLE
A fix from a security static analysis

### DIFF
--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -838,7 +838,7 @@ static DDTTYLogger *sharedInstance;
         // Initialze 'app' variable (char *)
         
         appName = [[NSProcessInfo processInfo] processName];
-
+        
         appLen = [appName lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
         if (appLen == 0) {
             appName = @"<UnnamedApp>";


### PR DESCRIPTION
Fix the remaining case in which getCString:maxLength:encoding is not checked for returning NO before using the result.
