### PR TITLE
Allow disabling of specific levels per-logger.

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -652,7 +652,7 @@ static unsigned int numProcessors;
         {
             // skip the loggers that shouldn't write this message based on the logLevel
 
-            if (logMessage->logFlag > loggerNode.logLevel)
+            if (!(logMessage->logFlag & loggerNode.logLevel))
                 continue;
 
             dispatch_group_async(loggingGroup, loggerNode->loggerQueue, ^{ @autoreleasepool {
@@ -672,7 +672,7 @@ static unsigned int numProcessors;
         {
             // skip the loggers that shouldn't write this message based on the logLevel
             
-            if (logMessage->logFlag > loggerNode.logLevel)
+            if (!(logMessage->logFlag & loggerNode.logLevel))
                 continue;
 
             dispatch_sync(loggerNode->loggerQueue, ^{ @autoreleasepool {


### PR DESCRIPTION
My team's usage of LumberJack had the following setup:
- four loggers, `DDTTYLogger` and `DDFileLogger,` a crash logger, and an
  analytics logger
- globally-defined ddLogLevel = `LOG_LEVEL_DEBUG`

Our file logger is added with `LOG_LEVEL_INFO.`
Our TTY logger is added with `LOG_LEVEL_DEBUG.`

We use "INFO" events HEAVILY, as they are placed in the file logger and
crash logger to help us know everything that happened leading up to a
bug.

As a requirement, The file logger CANNOT log DEBUG events.

At the same time, because we have such a high volume of INFO events, it
is challenging to see any of the `DEBUG` events in the TTY logger.

We need to be configure our `DDTTYLogger` to at the DEBUG level, but omit `INFO` events.

Essentially: `[DDLog addLogger:ttyLogger withLogLevel:(LOG_LEVEL_DEBUG & (~LOG_FLAG_INFO)];`

However, this isn't possible in the current implementation of
`+[DDLogger lt_log]`

When iterating through registered loggers, `lt_log:`
performs the check, "if (logMessage->logFlag > loggerNode.logLevel) continue;"

Because our TTY logger's highest-set bit is `LOG_FLAG_DEBUG`, all info
events are processed, even though we've unset the `LOG_FLAG_INFO` event.

My proposed change configures `lt_log:` to examine whether a `DDLogMessage`'s
specific `LOG_FLAG_..*` is set in `loggerNode->logLevel`.

---

Thank you!
