### PR TITLE
DDFileLogger: using CFBundleIdentifier as a log filename prefix on both OS X and iOS.

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -484,16 +484,12 @@ BOOL doesAppRunInBackground(void);
     static dispatch_once_t onceToken;
 
     dispatch_once(&onceToken, ^{
-    #if TARGET_OS_IPHONE
-        _appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+        _appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];
 
         if (! _appName)
         {
             _appName = [[NSProcessInfo processInfo] processName];
         }
-    #else
-        _appName = [[NSProcessInfo processInfo] processName];
-    #endif
 
         if (! _appName)
         {


### PR DESCRIPTION
Related to #200.
