### PR TITLE
More useful to log the errno value when setxattr() fails?

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -1423,7 +1423,10 @@ static int exception_count = 0;
     
     if (result < 0)
     {
-        NSLogError(@"DDLogFileInfo: setxattr(%@, %@): error = %i", attrName, self.fileName, errno);
+        NSLogError(@"DDLogFileInfo: setxattr(%@, %@): error = %s",
+                   attrName,
+                   self.fileName,
+                   strerror(errno));
     }
 }
 
@@ -1436,7 +1439,10 @@ static int exception_count = 0;
     
     if (result < 0 && errno != ENOATTR)
     {
-        NSLogError(@"DDLogFileInfo: removexattr(%@, %@): error = %i", attrName, self.fileName, errno);
+        NSLogError(@"DDLogFileInfo: removexattr(%@, %@): error = %s",
+                   attrName,
+                   self.fileName,
+                   strerror(errno));
     }
 }
 


### PR DESCRIPTION
Hi there,

According to the documentation of `setxattr()`:

```
On success, 0 is returned.  On failure, -1 is returned and the global variable errno is set as follows...
```

Therefore logging the value of `result` at this point is redundant and not useful for debugging purposes. Surely better to log `errno` so that the user can find the source of the problem in `errno.h`?

Thanks!
