### PR TITLE
Refactoring DDLog: changing comments to NSAssert.

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -539,13 +539,13 @@ static unsigned int numProcessors;
 #pragma mark Logging Thread
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/**
- * This method should only be run on the logging thread/queue.
-**/
 + (void)lt_addLogger:(id <DDLogger>)logger logLevel:(int)logLevel
 {
     // Add to loggers array.
     // Need to create loggerQueue if loggerNode doesn't provide one.
+
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
     
     dispatch_queue_t loggerQueue = NULL;
     
@@ -582,12 +582,12 @@ static unsigned int numProcessors;
     }
 }
 
-/**
- * This method should only be run on the logging thread/queue.
-**/
 + (void)lt_removeLogger:(id <DDLogger>)logger
 {
     // Find associated loggerNode in list of added loggers
+
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
     
     DDLoggerNode *loggerNode = nil;
     
@@ -621,13 +621,13 @@ static unsigned int numProcessors;
     [loggers removeObject:loggerNode];
 }
 
-/**
- * This method should only be run on the logging thread/queue.
-**/
 + (void)lt_removeAllLoggers
 {
     // Notify all loggers
     
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
+
     for (DDLoggerNode *loggerNode in loggers)
     {
         if ([loggerNode->logger respondsToSelector:@selector(willRemoveLogger)])
@@ -644,11 +644,11 @@ static unsigned int numProcessors;
     [loggers removeAllObjects];
 }
 
-/**
- * This method should only be run on the logging thread/queue.
-**/
 + (NSArray *)lt_allLoggers
 {
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
+
     NSMutableArray *theLoggers = [NSMutableArray new];
 
     for (DDLoggerNode *loggerNode in loggers)
@@ -659,12 +659,12 @@ static unsigned int numProcessors;
     return [theLoggers copy];
 }
 
-/**
- * This method should only be run on the logging thread/queue.
-**/
 + (void)lt_log:(DDLogMessage *)logMessage
 {
     // Execute the given log message on each of our loggers.
+
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
     
     if (numProcessors > 1)
     {
@@ -727,15 +727,15 @@ static unsigned int numProcessors;
     dispatch_semaphore_signal(queueSemaphore);
 }
 
-/**
- * This method should only be run on the background logging thread.
-**/
 + (void)lt_flush
 {
     // All log statements issued before the flush method was invoked have now been executed.
     // 
     // Now we need to propogate the flush request to any loggers that implement the flush method.
     // This is designed for loggers that buffer IO.
+
+    NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+            @"This method should only be run on the logging thread/queue");
         
     for (DDLoggerNode *loggerNode in loggers)
     {


### PR DESCRIPTION
All `lt_` methods should be executed only on logging queue. This was mentioned in comments
before each method. Now explicitly checking it with NSAssert.
