### PR TITLE
Removed all the "C" log macros - PR for 2.0 branch

### DIFF
--- a/Lumberjack/DDLog.h
+++ b/Lumberjack/DDLog.h
@@ -79,20 +79,11 @@
 #define LOG_OBJC_MACRO(async, lvl, flg, ctx, frmt, ...) \
              LOG_MACRO(async, lvl, flg, ctx, nil, sel_getName(_cmd), frmt, ##__VA_ARGS__)
 
-#define LOG_C_MACRO(async, lvl, flg, ctx, frmt, ...) \
-          LOG_MACRO(async, lvl, flg, ctx, nil, __FUNCTION__, frmt, ##__VA_ARGS__)
-
 #define  SYNC_LOG_OBJC_MACRO(lvl, flg, ctx, frmt, ...) \
               LOG_OBJC_MACRO( NO, lvl, flg, ctx, frmt, ##__VA_ARGS__)
 
 #define ASYNC_LOG_OBJC_MACRO(lvl, flg, ctx, frmt, ...) \
               LOG_OBJC_MACRO(YES, lvl, flg, ctx, frmt, ##__VA_ARGS__)
-
-#define  SYNC_LOG_C_MACRO(lvl, flg, ctx, frmt, ...) \
-              LOG_C_MACRO( NO, lvl, flg, ctx, frmt, ##__VA_ARGS__)
-
-#define ASYNC_LOG_C_MACRO(lvl, flg, ctx, frmt, ...) \
-              LOG_C_MACRO(YES, lvl, flg, ctx, frmt, ##__VA_ARGS__)
 
 /**
  * Define version of the macro that only execute if the logLevel is above the threshold.
@@ -118,22 +109,13 @@
   do { if(lvl & flg) LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-             LOG_MAYBE(async, lvl, flg, ctx, sel_getName(_cmd), frmt, ##__VA_ARGS__)
-
-#define LOG_C_MAYBE(async, lvl, flg, ctx, frmt, ...) \
-          LOG_MAYBE(async, lvl, flg, ctx, __FUNCTION__, frmt, ##__VA_ARGS__)
+             LOG_MAYBE(async, lvl, flg, ctx, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
 #define  SYNC_LOG_OBJC_MAYBE(lvl, flg, ctx, frmt, ...) \
               LOG_OBJC_MAYBE( NO, lvl, flg, ctx, frmt, ##__VA_ARGS__)
 
 #define ASYNC_LOG_OBJC_MAYBE(lvl, flg, ctx, frmt, ...) \
               LOG_OBJC_MAYBE(YES, lvl, flg, ctx, frmt, ##__VA_ARGS__)
-
-#define  SYNC_LOG_C_MAYBE(lvl, flg, ctx, frmt, ...) \
-              LOG_C_MAYBE( NO, lvl, flg, ctx, frmt, ##__VA_ARGS__)
-
-#define ASYNC_LOG_C_MAYBE(lvl, flg, ctx, frmt, ...) \
-              LOG_C_MAYBE(YES, lvl, flg, ctx, frmt, ##__VA_ARGS__)
 
 /**
  * Define versions of the macros that also accept tags.
@@ -146,19 +128,13 @@
 **/
 
 #define LOG_OBJC_TAG_MACRO(async, lvl, flg, ctx, tag, frmt, ...) \
-                 LOG_MACRO(async, lvl, flg, ctx, tag, sel_getName(_cmd), frmt, ##__VA_ARGS__)
-
-#define LOG_C_TAG_MACRO(async, lvl, flg, ctx, tag, frmt, ...) \
-              LOG_MACRO(async, lvl, flg, ctx, tag, __FUNCTION__, frmt, ##__VA_ARGS__)
+                 LOG_MACRO(async, lvl, flg, ctx, tag, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
 #define LOG_TAG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) \
   do { if(lvl & flg) LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_OBJC_TAG_MAYBE(async, lvl, flg, ctx, tag, frmt, ...) \
-             LOG_TAG_MAYBE(async, lvl, flg, ctx, tag, sel_getName(_cmd), frmt, ##__VA_ARGS__)
-
-#define LOG_C_TAG_MAYBE(async, lvl, flg, ctx, tag, frmt, ...) \
-          LOG_TAG_MAYBE(async, lvl, flg, ctx, tag, __FUNCTION__, frmt, ##__VA_ARGS__)
+             LOG_TAG_MAYBE(async, lvl, flg, ctx, tag, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
 /**
  * Define the standard options.
@@ -256,12 +232,6 @@
 #define DDLogInfo(frmt, ...)    LOG_OBJC_MAYBE(LOG_ASYNC_INFO,    LOG_LEVEL_DEF, LOG_FLAG_INFO,    0, frmt, ##__VA_ARGS__)
 #define DDLogDebug(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_DEBUG,   LOG_LEVEL_DEF, LOG_FLAG_DEBUG,   0, frmt, ##__VA_ARGS__)
 #define DDLogVerbose(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_VERBOSE, LOG_LEVEL_DEF, LOG_FLAG_VERBOSE, 0, frmt, ##__VA_ARGS__)
-
-#define DDLogCError(frmt, ...)   LOG_C_MAYBE(LOG_ASYNC_ERROR,   LOG_LEVEL_DEF, LOG_FLAG_ERROR,   0, frmt, ##__VA_ARGS__)
-#define DDLogCWarn(frmt, ...)    LOG_C_MAYBE(LOG_ASYNC_WARN,    LOG_LEVEL_DEF, LOG_FLAG_WARN,    0, frmt, ##__VA_ARGS__)
-#define DDLogCInfo(frmt, ...)    LOG_C_MAYBE(LOG_ASYNC_INFO,    LOG_LEVEL_DEF, LOG_FLAG_INFO,    0, frmt, ##__VA_ARGS__)
-#define DDLogCDebug(frmt, ...)   LOG_C_MAYBE(LOG_ASYNC_DEBUG,   LOG_LEVEL_DEF, LOG_FLAG_DEBUG,   0, frmt, ##__VA_ARGS__)
-#define DDLogCVerbose(frmt, ...) LOG_C_MAYBE(LOG_ASYNC_VERBOSE, LOG_LEVEL_DEF, LOG_FLAG_VERBOSE, 0, frmt, ##__VA_ARGS__)
 
 /**
  * The THIS_FILE macro gives you an NSString of the file name.

--- a/Xcode/LumberjackFramework/Mobile/LibTest/AppDelegate.m
+++ b/Xcode/LumberjackFramework/Mobile/LibTest/AppDelegate.m
@@ -2,9 +2,18 @@
 #import "ViewController.h"
 
 #import <Lumberjack/Lumberjack.h>
+#import "Formatter.h"
 
 // Log levels: off, error, warn, info, verbose
 static const int ddLogLevel = LOG_LEVEL_VERBOSE;
+
+static void printSomething() {
+    DDLogVerbose(@"Verbose");
+    DDLogDebug(@"Debug");
+    DDLogInfo(@"Info");
+    DDLogWarn(@"Warn");
+    DDLogError(@"Error");
+}
 
 
 @implementation AppDelegate
@@ -14,12 +23,17 @@ static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+    Formatter *formatter = [[Formatter alloc] init];
+    [[DDTTYLogger sharedInstance] setLogFormatter:formatter];
     [DDLog addLogger:[DDTTYLogger sharedInstance]];
     
     DDLogVerbose(@"Verbose");
+    DDLogDebug(@"Debug");
     DDLogInfo(@"Info");
     DDLogWarn(@"Warn");
     DDLogError(@"Error");
+    
+    printSomething();
     
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     self.viewController = [[ViewController alloc] initWithNibName:@"ViewController" bundle:nil];

--- a/Xcode/LumberjackFramework/Mobile/LibTest/Formatter.h
+++ b/Xcode/LumberjackFramework/Mobile/LibTest/Formatter.h
@@ -1,0 +1,5 @@
+#import <Lumberjack/Lumberjack.h>
+
+@interface Formatter : DDDispatchQueueLogFormatter<DDLogFormatter>
+
+@end

--- a/Xcode/LumberjackFramework/Mobile/LibTest/Formatter.m
+++ b/Xcode/LumberjackFramework/Mobile/LibTest/Formatter.m
@@ -1,0 +1,46 @@
+#import "Formatter.h"
+
+@interface Formatter ()
+
+@property (nonatomic, strong) NSDateFormatter *threadUnsafeDateFormatter;   // for date/time formatting
+
+@end
+
+
+@implementation Formatter
+
+- (id)init {
+    if (self = [super init]) {
+        _threadUnsafeDateFormatter = [[NSDateFormatter alloc] init];
+		[_threadUnsafeDateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
+        [_threadUnsafeDateFormatter setDateFormat:@"HH:mm:ss.SSS"];
+    }
+    
+    return self;
+}
+
+- (NSString *)formatLogMessage:(DDLogMessage *)logMessage {
+    NSString *dateAndTime = [self.threadUnsafeDateFormatter stringFromDate:(logMessage->timestamp)];
+    
+    NSString *logLevel = nil;
+    switch (logMessage->logFlag) {
+        case LOG_FLAG_ERROR     : logLevel = @"E"; break;
+        case LOG_FLAG_WARN      : logLevel = @"W"; break;
+        case LOG_FLAG_INFO      : logLevel = @"I"; break;
+        case LOG_FLAG_DEBUG     : logLevel = @"D"; break;
+		case LOG_FLAG_VERBOSE   : logLevel = @"V"; break;
+        default                 : logLevel = @"?"; break;
+    }
+    
+    NSString *formattedLog = [NSString stringWithFormat:@"%@ |%@| [%@ %@] #%d: %@",
+                              dateAndTime,
+                              logLevel,
+                              logMessage.fileName,
+                              logMessage.methodName,
+                              logMessage->lineNumber,
+                              logMessage->logMsg];
+    
+    return formattedLog;
+}
+
+@end

--- a/Xcode/LumberjackFramework/Mobile/Lumberjack.xcodeproj/project.pbxproj
+++ b/Xcode/LumberjackFramework/Mobile/Lumberjack.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		DA3130A01844B265002E953B /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA31309E1844B265002E953B /* DDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA3130A11844B265002E953B /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA31309F1844B265002E953B /* DDMultiFormatter.m */; };
+		DA455A1518B5E7F100D1E13A /* Formatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA455A1418B5E7F100D1E13A /* Formatter.m */; };
 		DC58E48C14DC70CF006B16E2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC58E48B14DC70CF006B16E2 /* Foundation.framework */; };
 		DC58E4AB14DC7176006B16E2 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DC58E49B14DC7176006B16E2 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC58E4AC14DC7176006B16E2 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DC58E49C14DC7176006B16E2 /* DDAbstractDatabaseLogger.m */; };
@@ -50,6 +51,8 @@
 /* Begin PBXFileReference section */
 		DA31309E1844B265002E953B /* DDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDMultiFormatter.h; sourceTree = "<group>"; };
 		DA31309F1844B265002E953B /* DDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDMultiFormatter.m; sourceTree = "<group>"; };
+		DA455A1318B5E7F100D1E13A /* Formatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Formatter.h; sourceTree = "<group>"; };
+		DA455A1418B5E7F100D1E13A /* Formatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Formatter.m; sourceTree = "<group>"; };
 		DADEC5BA182CE2D5003DF172 /* DDLog+LOGV.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "DDLog+LOGV.h"; path = "../../../../Lumberjack/DDLog+LOGV.h"; sourceTree = "<group>"; };
 		DC58E48814DC70CF006B16E2 /* libLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC58E48B14DC70CF006B16E2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -190,6 +193,8 @@
 				DC58E4D514DC8BE2006B16E2 /* ViewController.m */,
 				DC58E4D714DC8BE2006B16E2 /* ViewController.xib */,
 				DC58E4C914DC8BE2006B16E2 /* Supporting Files */,
+				DA455A1318B5E7F100D1E13A /* Formatter.h */,
+				DA455A1418B5E7F100D1E13A /* Formatter.m */,
 			);
 			path = LibTest;
 			sourceTree = "<group>";
@@ -323,6 +328,7 @@
 			files = (
 				DC58E4CF14DC8BE2006B16E2 /* main.m in Sources */,
 				DC58E4D314DC8BE2006B16E2 /* AppDelegate.m in Sources */,
+				DA455A1518B5E7F100D1E13A /* Formatter.m in Sources */,
 				DC58E4D614DC8BE2006B16E2 /* ViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
By replacing `sel_getName(_cmd)` with `__PRETTY_FUNCTION__`, there is not need for the separation of Obj-C and C macros. 
Original suggestion #220. **Thanks to @petedemoreuille**.

Updated the Mobile libtest project to demonstrate that it's working (had to use a formatter so the function/method names are used).

_Note:_ This change is **not backwards compatible**, so it should go into 2.0.

_Note:_ This PR replaces #228
