### PR TITLE
Skip over 'external-accessory' background mode.

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -1527,7 +1527,7 @@ BOOL doesAppRunInBackground()
     NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
 
     for (NSString *mode in backgroundModes) {
-        if (mode.length > 0) {
+        if (mode.length > 0 && ![mode isEqualToString:@"external-accessory"]) {
             answer = YES;
             break;
         }


### PR DESCRIPTION
In one of my projects that uses Lumberjack, I have to set the external-accessory background mode to connect to a hardware device. However, this causes a new log file to be created each time my app is launched, regardless of rolling settings.

If this change does not break anything, please consider skipping over this one background mode so that the same log file can be appended to. Other background modes will still cause the same Lumberjack behavior as before.
