### PR TITLE
DDLog: calling atexit_b in CLI applications, that use Foundation framework.

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -156,11 +156,14 @@ static unsigned int numProcessors;
     #else
         NSString *notificationName = nil;
 
-        if (NSClassFromString(@"NSApplication"))
-        {
+        // on Command Line Tool apps AppKit may not be avaliable
+        #ifdef NSAppKitVersionNumber10_0
+        if (NSApp) {
             notificationName = @"NSApplicationWillTerminateNotification";
         }
-        else
+        #endif
+
+        if (! notificationName)
         {
             // If there is no NSApp -> we are running Command Line Tool app.
             // In this case terminate notification wouldn't be fired, so we use workaround.


### PR DESCRIPTION
Related to #63, #184. Fixes #233.
