### PR TITLE
Account for missing NSFileProtectionKey file attribute key.

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -475,7 +475,6 @@ BOOL doesAppRunInBackground(void);
 
             NSString *key = doesAppRunInBackground() ?
                 NSFileProtectionCompleteUntilFirstUserAuthentication : NSFileProtectionCompleteUnlessOpen;
-            NSLog(@"Lumberjack -> key (476): %@", key);
 
             attributes = @{ NSFileProtectionKey : key };
         #endif
@@ -937,12 +936,15 @@ BOOL doesAppRunInBackground(void);
             // a new one.
 
             if (useExistingLogFile && doesAppRunInBackground()) {
-                NSString *key = mostRecentLogFileInfo.fileAttributes[NSFileProtectionKey];
-                NSLog(@"Lumberjack -> key (939): %@", key);
+                // The NSFileProtectionKey is not returned in the file attributes dictionary when running in the iOS
+                // simulator. Therefore, resume the previous log file if NSFileProtectionKey is not specified.
+                if ([mostRecentLogFileInfo.fileAttributes.allKeys containsObject:NSFileProtectionKey]) {
+                    NSString *key = mostRecentLogFileInfo.fileAttributes[NSFileProtectionKey];
 
-                if (! [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication]) {
-                    useExistingLogFile = NO;
-                    shouldArchiveMostRecent = YES;
+                    if (! [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication]) {
+                        useExistingLogFile = NO;
+                        shouldArchiveMostRecent = YES;
+                    }
                 }
             }
         #endif
@@ -1529,7 +1531,7 @@ BOOL doesAppRunInBackground()
     NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];
 
     for (NSString *mode in backgroundModes) {
-        if (mode.length > 0 && ![mode isEqualToString:@"external-accessory"]) {
+        if (mode.length > 0) {
             answer = YES;
             break;
         }


### PR DESCRIPTION
Ok, after doing a bit of testing, it appears that the NSFileProtectedKey is not included in the file attributes dictionary while running on the iOS simulator. It _does_ get returned on a device, however. I tested on iOS 7.0.6.

When the key is missing, it forces a new log file to always be created, due to the test `if (! [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication]) {` near line ~946.

Therefore, this patch will assume that we can reuse the existing log file if the NSFileProtectedKey is missing. If you're not comfortable with this, we could add checks for #if TARGET_IPHONE_SIMULATOR to fine-tune this condition.

Thanks!
