### PR TITLE
Update DDASLLogger.m

### DIFF
--- a/Lumberjack/DDASLLogger.m
+++ b/Lumberjack/DDASLLogger.m
@@ -88,7 +88,10 @@ static DDASLLogger *sharedInstance;
             default             : aslLogLevel = ASL_LEVEL_NOTICE;  break;
         }
         
-        asl_log(client, NULL, aslLogLevel, "%s", msg);
+        aslmsg m = asl_new(ASL_TYPE_MSG);
+        asl_set(m, ASL_KEY_READ_UID, "501");
+        asl_log(client, m, aslLogLevel, "%s", msg);
+        asl_free(m);
     }
 }
 


### PR DESCRIPTION
Fix the issue #181: when logging messages in IOS7 on a real device, `asl_search`won't retrieve them right.
