### PR TITLE
Check and log some errors.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -243,7 +243,7 @@
     NSUInteger inputDataSize = 0;
     
     BOOL done = YES;
-    BOOL error = NO;
+    NSError* error = nil;
     do
     {
         @autoreleasepool {
@@ -328,7 +328,7 @@
             
             if (writeLength < 0)
             {
-                error = YES;
+                error = [outputStream streamError];
             }
             else
             {
@@ -365,7 +365,7 @@
         
         } // end @autoreleasepool
         
-    } while (!done && !error);
+    } while (!done && error == nil);
     
     // STEP 9
     
@@ -383,8 +383,12 @@
     {
         // Remove output file.
         // Our compression attempt failed.
-        
-        [[NSFileManager defaultManager] removeItemAtPath:tempOutputFilePath error:nil];
+
+        NSLogError(@"Compression of %@ failed: %@", inputFilePath, error);
+        error = nil;
+        BOOL ok = [[NSFileManager defaultManager] removeItemAtPath:tempOutputFilePath error:&error];
+        if (!ok)
+            NSLogError(@"Failed to clean up %@ after failed compression: %@", tempOutputFilePath, error);
         
         // Report failure to class via logging thread/queue
         
@@ -397,8 +401,11 @@
     {
         // Remove original input file.
         // It will be replaced with the new compressed version.
-        
-        [[NSFileManager defaultManager] removeItemAtPath:inputFilePath error:nil];
+
+        error = nil;
+        BOOL ok = [[NSFileManager defaultManager] removeItemAtPath:inputFilePath error:&error];
+        if (!ok)
+            NSLogWarn(@"Warning: failed to remove original file %@ after compression: %@", inputFilePath, error);
         
         // Mark the compressed file as archived,
         // and then move it into its final destination.


### PR DESCRIPTION
Log the streamError whenever we fail to write during compression,
and log any failures when removing the original file or cleaning up
the temporary file after compression failed.
