### PR TITLE
Replace use of NSThread.detachNewThreadSelector.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -61,8 +61,11 @@
 - (void)compressLogFile:(DDLogFileInfo *)logFile
 {
     self.isCompressing = YES;
-    
-    [NSThread detachNewThreadSelector:@selector(backgroundThread_CompressLogFile:) toTarget:self withObject:logFile];
+
+    CompressingLogFileManager* __weak weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+        [weakSelf backgroundThread_CompressLogFile:logFile];
+    });
 }
 
 - (void)compressNextLogFile


### PR DESCRIPTION
Replace use of NSThread.detachNewThreadSelector with a GCD dispatch
at DISPATCH_QUEUE_PRIORITY_BACKGROUND.

This means that the thread that's doing the compression is I/O throttled,
so it should stay out of the way of the rest of the app.

This could be important at start of day or resume from background,
because it will try and compress all the uncompressed log files it finds
in one go, and if the screen keeps getting locked before we have a
chance to complete then this can end up being a large number of files.
