### PR TITLE
Add a constructor override for initWithLogsDirectory.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -40,7 +40,12 @@
 
 - (id)init
 {
-    if ((self = [super init]))
+    return [self initWithLogsDirectory:nil];
+}
+
+- (id)initWithLogsDirectory:(NSString *)aLogsDirectory
+{
+    if ((self = [super initWithLogsDirectory:aLogsDirectory]))
     {
         upToDate = NO;
         


### PR DESCRIPTION
This is so that callers using that constructor from
DDLogFileManagerDefault don't bypass the code in
CompressingLogFileManager.init.
