### PR TITLE
Fix two retain cycles through self.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -388,9 +388,10 @@
         
         // Report failure to class via logging thread/queue
         
+        CompressingLogFileManager* __weak weakSelf = self;
         dispatch_async([DDLog loggingQueue], ^{ @autoreleasepool {
             
-            [self compressionDidFail:logFile];
+            [weakSelf compressionDidFail:logFile];
         }});
     }
     else
@@ -417,9 +418,10 @@
         
         // Report success to class via logging thread/queue
         
+        CompressingLogFileManager* __weak weakSelf = self;
         dispatch_async([DDLog loggingQueue], ^{ @autoreleasepool {
             
-            [self compressionDidSucceed:compressedLogFile];
+            [weakSelf compressionDidSucceed:compressedLogFile];
         }});
     }
     


### PR DESCRIPTION
These uses of self inside a block can cause a retain cycle if
CompressingLogFileManager retains anything that retains the loggingQueue.
