### PR TITLE
Fix a rare crash caused by an unchecked return value.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -272,6 +272,10 @@
         NSUInteger inputBufferLength = inputDataLength - inputDataSize;
         
         NSInteger readLength = [inputStream read:(uint8_t *)inputBuffer maxLength:inputBufferLength];
+        if (readLength < 0) {
+            error = [inputStream streamError];
+            break;
+        }
         
         NSLogVerbose(@"CompressingLogFileManager: Read %li bytes from file", (long)readLength);
         


### PR DESCRIPTION
Fix a rare crash in CompressingLogFileManager caused by an
unchecked result from read.  If the read fails, it returns -1.
This was then added to inputDataSize, which in turn is added to
inputRemaining further down the function, and used as an input
to memmove (and is unsigned to boot, so it'll be very large rather than
negative).  This means that the memmove stomps all over memory,
and we crash not long afterwards (often when an autorelease pool is
freed).

This crash is rare because it depends on the read call failing.

Fix this by checking the return value from NSStream.read, and leaving
the loop immediately if there's an error.
