### PR TITLE
Set NSFileProtectionKey on the temporary file created during compression.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -183,10 +183,13 @@
     
     NSString *tempOutputFilePath = [logFile tempFilePathByAppendingPathExtension:@"gz"];
     
-    if ([[NSFileManager defaultManager] fileExistsAtPath:tempOutputFilePath])
-    {
-        [[NSFileManager defaultManager] createFileAtPath:tempOutputFilePath contents:nil attributes:nil];
-    }
+    // We use the same protection as the original file.  This means that it has the same security characteristics.
+    // Also, if the app can run in the background, this means that it gets
+    // NSFileProtectionCompleteUntilFirstUserAuthentication so that we can do this compression even with the
+    // device locked.  c.f. DDFileLogger.doesAppRunInBackground.
+    NSString* protection = logFile.fileAttributes[NSFileProtectionKey];
+    NSDictionary* attributes = protection == nil ? nil : @{NSFileProtectionKey: protection};
+    [[NSFileManager defaultManager] createFileAtPath:tempOutputFilePath contents:nil attributes:attributes];
     
     // STEP 2 & 3
     


### PR DESCRIPTION
This uses the same protection for the temporary file as is used on
the log file itself.  This means that it has the same security
characteristics.  Also, if the app can run in the background, this
means that it gets NSFileProtectionCompleteUntilFirstUserAuthentication
so that we can do this compression even with the device locked.

This means that in effect we pick up the same decision as used in
DDFileLogger around doesAppRunInBackground.
