### PR TITLE
Undef NSLog* macros before defining them locally.

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -10,6 +10,10 @@
 
 #define LOG_LEVEL 4
 
+#undef NSLogError
+#undef NSLogWarn
+#undef NSLogInfo
+#undef NSLogVerbose
 #define NSLogError(frmt, ...)    do{ if(LOG_LEVEL >= 1) NSLog(frmt, ##__VA_ARGS__); } while(0)
 #define NSLogWarn(frmt, ...)     do{ if(LOG_LEVEL >= 2) NSLog(frmt, ##__VA_ARGS__); } while(0)
 #define NSLogInfo(frmt, ...)     do{ if(LOG_LEVEL >= 3) NSLog(frmt, ##__VA_ARGS__); } while(0)


### PR DESCRIPTION
This means that these definitions don't clash with any that might be
picked up from a .pch.
