### PR TITLE
Explicitly declare a few properties as atomic.

### DIFF
--- a/Lumberjack/DDFileLogger.h
+++ b/Lumberjack/DDFileLogger.h
@@ -69,7 +69,7 @@
  * 
  * You may optionally disable deleting old/rolled/archived log files by setting this property to zero.
 **/
-@property (readwrite, assign) NSUInteger maximumNumberOfLogFiles;
+@property (readwrite, assign, atomic) NSUInteger maximumNumberOfLogFiles;
 
 // Public methods
 
@@ -152,7 +152,7 @@
 
 /* Inherited from DDLogFileManager protocol:
 
-@property (readwrite, assign) NSUInteger maximumNumberOfLogFiles;
+@property (readwrite, assign, atomic) NSUInteger maximumNumberOfLogFiles;
 
 - (NSString *)logsDirectory;
 
@@ -246,7 +246,7 @@
 **/
 @property (readwrite, assign) unsigned long long maximumFileSize;
 @property (readwrite, assign) NSTimeInterval rollingFrequency;
-@property (readwrite, assign) BOOL doNotReuseLogFiles;
+@property (readwrite, assign, atomic) BOOL doNotReuseLogFiles;
 
 /**
  * The DDLogFileManager instance can be used to retrieve the list of log files,

--- a/Lumberjack/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Lumberjack/Extensions/DDDispatchQueueLogFormatter.h
@@ -79,7 +79,7 @@
  * If you want every [detail box] to have the exact same width,
  * set both minQueueLength and maxQueueLength to the same value.
 **/
-@property (assign) NSUInteger minQueueLength;
+@property (assign, atomic) NSUInteger minQueueLength;
 
 /**
  * The maxQueueLength restricts the number of characters that will be inside the [detail box].
@@ -99,7 +99,7 @@
  * If you want every [detail box] to have the exact same width,
  * set both minQueueLength and maxQueueLength to the same value.
 **/
-@property (assign) NSUInteger maxQueueLength;
+@property (assign, atomic) NSUInteger maxQueueLength;
 
 /**
  * Sometimes queue labels have long names like "com.apple.main-queue",


### PR DESCRIPTION
These are already implicitly atomic, so this doesn't change the
semantics.  It does silence some warnings though (from
CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES).
