### PR TITLE
- Fix for issue #278 where really large log files can keep growing

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -940,7 +940,7 @@ BOOL doesAppRunInBackground(void);
             }
         #endif
 
-            if (!_doNotReuseLogFiles)
+            if (!_doNotReuseLogFiles && !shouldArchiveMostRecent)
             {
                 NSLogVerbose(@"DDFileLogger: Resuming logging with file %@", mostRecentLogFileInfo.fileName);
                 


### PR DESCRIPTION
This resolves an issue I was seeing in a case where a file is too large (I have it setup for 8MB and the file was 500MB in size), and it keeps reusing the file if "doNotReuseLogFiles" is set to NO.
