### PR TITLE
Replaced warnings when ARC was not enabled with errors

### DIFF
--- a/Lumberjack/DDASLLogger.m
+++ b/Lumberjack/DDASLLogger.m
@@ -13,7 +13,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 static DDASLLogger *sharedInstance;

--- a/Lumberjack/DDAbstractDatabaseLogger.m
+++ b/Lumberjack/DDAbstractDatabaseLogger.m
@@ -12,7 +12,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 @interface DDAbstractDatabaseLogger ()

--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -16,7 +16,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 // We probably shouldn't be using DDLog() statements within the DDLog implementation.

--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -22,7 +22,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 // We probably shouldn't be using DDLog() statements within the DDLog implementation.

--- a/Lumberjack/DDTTYLogger.m
+++ b/Lumberjack/DDTTYLogger.m
@@ -14,7 +14,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 // We probably shouldn't be using DDLog() statements within the DDLog implementation.

--- a/Lumberjack/Extensions/DDContextFilterLogFormatter.m
+++ b/Lumberjack/Extensions/DDContextFilterLogFormatter.m
@@ -12,7 +12,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 @interface DDLoggingContextSet : NSObject

--- a/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -12,7 +12,7 @@
 **/
 
 #if ! __has_feature(objc_arc)
-#warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
 

--- a/Lumberjack/Extensions/DDMultiFormatter.m
+++ b/Lumberjack/Extensions/DDMultiFormatter.m
@@ -27,6 +27,11 @@
 #endif
 
 
+#if ! __has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+
 @interface DDMultiFormatter ()
 
 - (DDLogMessage *)logMessageForLine:(NSString *)line originalMessage:(DDLogMessage *)message;


### PR DESCRIPTION
Related to #281 and #282 (this pull request was not complete and the author did not respond in time).

It's mandatory that CocoaLumberjack is compiled with ARC enabled (even if only for the CL files using -f-objc-arc).
