### PR TITLE
Do not reuse the last logfile if it was already archived

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -956,7 +956,7 @@ BOOL doesAppRunInBackground(void);
             }
         #endif
 
-            if (!_doNotReuseLogFiles && !shouldArchiveMostRecent)
+            if (!_doNotReuseLogFiles && !mostRecentLogFileInfo.isArchived && !shouldArchiveMostRecent)
             {
                 NSLogVerbose(@"DDFileLogger: Resuming logging with file %@", mostRecentLogFileInfo.fileName);
                 


### PR DESCRIPTION
We are running into issue where logfiles are not correctly rotated. The details of the issue are at
 https://github.com/CocoaLumberjack/CocoaLumberjack/issues/243

This commit fixes the log rotation issue.

The issue was introduced by this commit bb167eb
