### PR TITLE
Store NSDateFormatters in thread-attached storage to avoid wasteful + ex...

### DIFF
--- a/Lumberjack/DDFileLogger.m
+++ b/Lumberjack/DDFileLogger.m
@@ -300,11 +300,12 @@ BOOL doesAppRunInBackground(void);
 {
     NSMutableDictionary *dictionary = [[NSThread currentThread]
                                        threadDictionary];
-    NSString *key = @"yyyy'-'MM'-'dd' 'HH'-'mm'";
+    NSString *dateFormat = @"yyyy'-'MM'-'dd' 'HH'-'mm'";
+    NSString *key = [NSString stringWithFormat:@"logFileDateFormatter.%@", dateFormat];
     NSDateFormatter *dateFormatter = [dictionary objectForKey:key];
     if (dateFormatter == nil) {
         NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-        [dateFormatter setDateFormat:@"yyyy'-'MM'-'dd' 'HH'-'mm'"];
+        [dateFormatter setDateFormat:dateFormat];
         [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
         [dictionary setObject:dateFormatter
                        forKey:key];


### PR DESCRIPTION
...pensive recreation of these objects.

In my experience, it can be very costly to instantiate `NSDateFormatter` objects and there is no need since they are almost-always (like here) created using constant input parameters. We use thread-attached storage here because the formatter objects are documented as being _non_ thread-safe, thus the best we can do is once instance per thread.
