### PR TITLE
DDFileLogger: adding `logFilesDiskQuota` property. Fixes #195

### DIFF
--- a/Lumberjack/DDFileLogger.h
+++ b/Lumberjack/DDFileLogger.h
@@ -22,12 +22,14 @@
 // maximumFileSize         -> DEFAULT_LOG_MAX_FILE_SIZE
 // rollingFrequency        -> DEFAULT_LOG_ROLLING_FREQUENCY
 // maximumNumberOfLogFiles -> DEFAULT_LOG_MAX_NUM_LOG_FILES
+// logFilesDiskQuota       -> DEFAULT_LOG_FILES_DISK_QUOTA
 // 
 // You should carefully consider the proper configuration values for your application.
 
-#define DEFAULT_LOG_MAX_FILE_SIZE     (1024 * 1024)   //  1 MB
-#define DEFAULT_LOG_ROLLING_FREQUENCY (60 * 60 * 24)  // 24 Hours
-#define DEFAULT_LOG_MAX_NUM_LOG_FILES (5)             //  5 Files
+#define DEFAULT_LOG_MAX_FILE_SIZE     (1024 * 1024)      //  1 MB
+#define DEFAULT_LOG_ROLLING_FREQUENCY (60 * 60 * 24)     // 24 Hours
+#define DEFAULT_LOG_MAX_NUM_LOG_FILES (5)                //  5 Files
+#define DEFAULT_LOG_FILES_DISK_QUOTA  (20 * 1024 * 1024) // 20 MB
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -67,9 +69,17 @@
  * then the LogFileManager will only keep 3 archived log files (plus the current active log file) on disk.
  * Once the active log file is rolled/archived, then the oldest of the existing 3 rolled/archived log files is deleted.
  * 
- * You may optionally disable deleting old/rolled/archived log files by setting this property to zero.
+ * You may optionally disable this option by setting it to zero.
 **/
 @property (readwrite, assign, atomic) NSUInteger maximumNumberOfLogFiles;
+
+/**
+ * The maximum space that logs can take. On rolling logfile all old logfiles that exceed logFilesDiskQuota will
+ * be deleted.
+ *
+ * You may optionally disable this option by setting it to zero.
+**/
+@property (readwrite, assign, atomic) unsigned long long logFilesDiskQuota;
 
 // Public methods
 
@@ -116,6 +126,7 @@
 @interface DDLogFileManagerDefault : NSObject <DDLogFileManager>
 {
     NSUInteger maximumNumberOfLogFiles;
+    unsigned long long logFilesDiskQuota;
     NSString *_logsDirectory;
 #if TARGET_OS_IPHONE
     NSString* _defaultFileProtectionLevel;
@@ -170,6 +181,7 @@
 /* Inherited from DDLogFileManager protocol:
 
 @property (readwrite, assign, atomic) NSUInteger maximumNumberOfLogFiles;
+@property (readwrite, assign, atomic) NSUInteger logFilesDiskQuota;
 
 - (NSString *)logsDirectory;
 


### PR DESCRIPTION
Now users have an option to set disk quota for log files. 20 MB is used by default, which seems enough.
