### PR TITLE
New DDAssert macros

### DIFF
--- a/Lumberjack/DDAssert.h
+++ b/Lumberjack/DDAssert.h
@@ -1,0 +1,16 @@
+//
+//  DDAssert.h
+//  CocoaLumberjack
+//
+//  Created by Ernesto Rivera on 2014/07/07.
+//
+//
+
+#import "DDLog.h"
+
+#define DDAssert(condition, frmt, ...) if (!(condition)) {                                                           \
+                                           NSString * description = [NSString stringWithFormat:frmt, ##__VA_ARGS__]; \
+                                           DDLogError(@"%@", description);                                           \
+                                           NSAssert(NO, description); }
+#define DDAssertCondition(condition) DDAssert(condition, @"Condition not satisfied: %s", #condition)
+


### PR DESCRIPTION
I started to use `NSAssert` and realized the need for some CocoaLumberjack customization as first asked in #23 by @hartbit.

`DDAssert` macros besides calling `NSAssert` log with `DDLogError` so we get output even when  assertions are disabled (default Xcode settings for Release builds). Also these macros have a more flexible format specifier than Apple's ones.

The only thing that annoys me is that somehow `NSAssert` silences some Analyzer warnings that `DDAssert` doesn't.
