### PR TITLE
Undeprecate lumberjack for iOS 8.

### DIFF
--- a/Lumberjack/DDASLLogCapture.m
+++ b/Lumberjack/DDASLLogCapture.m
@@ -158,14 +158,14 @@ static int _captureLogLevel = LOG_LEVEL_VERBOSE;
                                          // Iterate over new messages.
                                          aslmsg msg;
                                          aslresponse response = asl_search(NULL, query);
-                                         while ((msg = aslresponse_next(response)))
+                                         while ((msg = asl_next(response)))
                                          {
                                              [DDASLLogCapture aslMessageRecieved:msg];
                                              
                                              // Keep track of which messages we've seen.
                                              lastSeenID = atoll(asl_get(msg, ASL_KEY_MSG_ID));
                                          }
-                                         aslresponse_free(response);
+                                         asl_release(response);
                                          
                                          if(_cancel)
                                          {

--- a/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -100,7 +100,7 @@
             [threadUnsafeDateFormatter setDateFormat:dateFormatString];
         }
         
-        [threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+        [threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
         return [threadUnsafeDateFormatter stringFromDate:date];
     }
     else
@@ -122,7 +122,7 @@
             threadDictionary[key] = dateFormatter;
         }
         
-        [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+        [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
         return [dateFormatter stringFromDate:date];
     }
 }


### PR DESCRIPTION
Replace 1 to 1 method calls for new names, hopefully not breaking anything.
