### PR TITLE
aslmsg not freed and causing memory leak

### DIFF
--- a/Lumberjack/DDASLLogCapture.m
+++ b/Lumberjack/DDASLLogCapture.m
@@ -172,6 +172,7 @@ static int _captureLogLevel = LOG_LEVEL_VERBOSE;
                                              notify_cancel(notifyToken);
                                              return;
                                          }
+                                         free(query);
                                      }
                                  });
     }


### PR DESCRIPTION
The `aslmsg query = asl_new(ASL_TYPE_QUERY);` is causing leak which can be seen by running the instruments. After releasing the memory manually, the memory leak disappears.
