### PR TITLE
Bug fix

### DIFF
--- a/Xcode/LogFileCompressor/CompressingLogFileManager.m
+++ b/Xcode/LogFileCompressor/CompressingLogFileManager.m
@@ -92,6 +92,7 @@
     if (count == 0)
     {
         // Nothing to compress
+        upToDate = YES;
         return;
     }
     


### PR DESCRIPTION
CompresingLogFileManager will stop compressing files once there exist
no .log files.
