### PR TITLE
Remove unnecessary NULL check before free()

### DIFF
--- a/Lumberjack/DDLog.m
+++ b/Lumberjack/DDLog.m
@@ -1046,8 +1046,7 @@ static char *dd_str_copy(const char *str)
     if (function && (options & DDLogMessageCopyFunction))
         free(function);
     
-    if (queueLabel)
-        free(queueLabel);
+    free(queueLabel);
 }
 
 


### PR DESCRIPTION
Passing NULL to free is a no-op.
