### PR TITLE
Replace deprecated identifiers

### DIFF
--- a/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Lumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -100,7 +100,7 @@
             [threadUnsafeDateFormatter setDateFormat:dateFormatString];
         }
         
-        [threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+        [threadUnsafeDateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
         return [threadUnsafeDateFormatter stringFromDate:date];
     }
     else
@@ -122,7 +122,7 @@
             threadDictionary[key] = dateFormatter;
         }
         
-        [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSGregorianCalendar]];
+        [dateFormatter setCalendar:[[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian]];
         return [dateFormatter stringFromDate:date];
     }
 }


### PR DESCRIPTION
Xcode 6 was unhappy before this change.
