### PR TITLE
Replaced macros with consts

### DIFF
--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -24,17 +24,17 @@
 
 // Default configuration and safety/sanity values.
 //
-// maximumFileSize         -> DEFAULT_LOG_MAX_FILE_SIZE
-// rollingFrequency        -> DEFAULT_LOG_ROLLING_FREQUENCY
-// maximumNumberOfLogFiles -> DEFAULT_LOG_MAX_NUM_LOG_FILES
-// logFilesDiskQuota       -> DEFAULT_LOG_FILES_DISK_QUOTA
+// maximumFileSize         -> kDDDefaultLogMaxFileSize
+// rollingFrequency        -> kDDDefaultLogRollingFrequency
+// maximumNumberOfLogFiles -> kDDDefaultLogMaxNumLogFiles
+// logFilesDiskQuota       -> kDDDefaultLogFilesDiskQuota
 //
 // You should carefully consider the proper configuration values for your application.
 
-extern unsigned long long const DEFAULT_LOG_MAX_FILE_SIZE;
-extern NSTimeInterval const DEFAULT_LOG_ROLLING_FREQUENCY;
-extern NSUInteger const DEFAULT_LOG_MAX_NUM_LOG_FILES;
-extern unsigned long long const DEFAULT_LOG_FILES_DISK_QUOTA;
+extern unsigned long long const kDDDefaultLogMaxFileSize;
+extern NSTimeInterval     const kDDDefaultLogRollingFrequency;
+extern NSUInteger         const kDDDefaultLogMaxNumLogFiles;
+extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -44,10 +44,10 @@
 BOOL doesAppRunInBackground(void);
 #endif
 
-unsigned long long const DEFAULT_LOG_MAX_FILE_SIZE    = 1024 * 1024;      //  1 MB
-NSTimeInterval const DEFAULT_LOG_ROLLING_FREQUENCY    = 60 * 60 * 24;     // 26 Hours
-NSUInteger const DEFAULT_LOG_MAX_NUM_LOG_FILES        = 5;                // 5 Files
-unsigned long long const DEFAULT_LOG_FILES_DISK_QUOTA = 20 * 1024 * 1024; // 20 MB
+unsigned long long const kDDDefaultLogMaxFileSize      = 1024 * 1024;      //  1 MB
+NSTimeInterval     const kDDDefaultLogRollingFrequency = 60 * 60 * 24;     // 26 Hours
+NSUInteger         const kDDDefaultLogMaxNumLogFiles   = 5;                // 5 Files
+unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20 MB
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
@@ -79,8 +79,8 @@ unsigned long long const DEFAULT_LOG_FILES_DISK_QUOTA = 20 * 1024 * 1024; // 20 
 
 - (instancetype)initWithLogsDirectory:(NSString *)aLogsDirectory {
     if ((self = [super init])) {
-        _maximumNumberOfLogFiles = DEFAULT_LOG_MAX_NUM_LOG_FILES;
-        _logFilesDiskQuota = DEFAULT_LOG_FILES_DISK_QUOTA;
+        _maximumNumberOfLogFiles = kDDDefaultLogMaxNumLogFiles;
+        _logFilesDiskQuota = kDDDefaultLogFilesDiskQuota;
 
         if (aLogsDirectory) {
             _logsDirectory = [aLogsDirectory copy];
@@ -612,8 +612,8 @@ unsigned long long const DEFAULT_LOG_FILES_DISK_QUOTA = 20 * 1024 * 1024; // 20 
 
 - (instancetype)initWithLogFileManager:(id <DDLogFileManager>)aLogFileManager {
     if ((self = [super init])) {
-        _maximumFileSize = DEFAULT_LOG_MAX_FILE_SIZE;
-        _rollingFrequency = DEFAULT_LOG_ROLLING_FREQUENCY;
+        _maximumFileSize = kDDDefaultLogMaxFileSize;
+        _rollingFrequency = kDDDefaultLogRollingFrequency;
         _automaticallyAppendNewlineForCustomFormatters = YES;
 
         logFileManager = aLogFileManager;
@@ -1068,9 +1068,9 @@ static int exception_count = 0;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #if TARGET_IPHONE_SIMULATOR
-    NSString * const XATTR_ARCHIVED_NAME = @"archived";
+    NSString * const kDDXAttrArchivedName = @"archived";
 #else
-    NSString * const XATTR_ARCHIVED_NAME = @"lumberjack.log.archived";
+    NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 #endif
 
 @interface DDLogFileInfo () {
@@ -1186,11 +1186,11 @@ static int exception_count = 0;
     // So we have to use a less attractive alternative.
     // See full explanation in the header file.
 
-    return [self hasExtensionAttributeWithName:XATTR_ARCHIVED_NAME];
+    return [self hasExtensionAttributeWithName:kDDXAttrArchivedName];
 
 #else
 
-    return [self hasExtendedAttributeWithName:XATTR_ARCHIVED_NAME];
+    return [self hasExtendedAttributeWithName:kDDXAttrArchivedName];
 
 #endif
 }
@@ -1203,17 +1203,17 @@ static int exception_count = 0;
     // See full explanation in the header file.
 
     if (flag) {
-        [self addExtensionAttributeWithName:XATTR_ARCHIVED_NAME];
+        [self addExtensionAttributeWithName:kDDXAttrArchivedName];
     } else {
-        [self removeExtensionAttributeWithName:XATTR_ARCHIVED_NAME];
+        [self removeExtensionAttributeWithName:kDDXAttrArchivedName];
     }
 
 #else
 
     if (flag) {
-        [self addExtendedAttributeWithName:XATTR_ARCHIVED_NAME];
+        [self addExtendedAttributeWithName:kDDXAttrArchivedName];
     } else {
-        [self removeExtendedAttributeWithName:XATTR_ARCHIVED_NAME];
+        [self removeExtendedAttributeWithName:kDDXAttrArchivedName];
     }
 
 #endif


### PR DESCRIPTION
so the compiler can do type checks and raise errors when we accidentaly try to modify one
