### PR TITLE
Match NSLog read UID functionality in DDASLLogger

### DIFF
--- a/Classes/DDASLLogger.m
+++ b/Classes/DDASLLogger.m
@@ -97,15 +97,14 @@ static DDASLLogger *sharedInstance;
                  @"Unhandled ASL log level.");
 
         aslmsg m = asl_new(ASL_TYPE_MSG);
-        if (__builtin_expect(m != NULL, 1)) {
-            if (__builtin_expect(asl_set(m, ASL_KEY_LEVEL, level_strings[aslLogLevel]) != 0, 0)) goto asl_msg_done;
-            if (__builtin_expect(asl_set(m, ASL_KEY_MSG, msg) != 0, 0)) goto asl_msg_done;
-            if (__builtin_expect(asl_set(m, ASL_KEY_READ_UID, readUIDString) != 0, 0)) goto asl_msg_done;
-            asl_send(_client, m);
-        asl_msg_done:
+        if (m != NULL) {
+            if (asl_set(m, ASL_KEY_LEVEL, level_strings[aslLogLevel]) == 0 &&
+                asl_set(m, ASL_KEY_MSG, msg) == 0 &&
+                asl_set(m, ASL_KEY_READ_UID, readUIDString) == 0) {
+                asl_send(_client, m);
+            }
             asl_free(m);
         }
-
         //TODO handle asl_* failures non-silently?
     }
 }


### PR DESCRIPTION
`NSLog` sets the read UID property of ASL messages to the current EUID.  This pull request changes `DDASLLogger` to match the `NSLog` functionality.

Currently, `DDASLLogger` _always_ sets the read UID property to 501, which I believe is typically the UID of the first user account after a fresh install of OS X.

The asl(3) library calls are also now checked for errors.

Furthermore, `asl_send` is used directly instead of `asl_log` to remove the level of indirection associated with `asl_log`.
