### PR TITLE
Change flag and lvl check from bitwise & to &&

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -645,7 +645,7 @@ static unsigned int numProcessors;
         for (DDLoggerNode *loggerNode in loggers) {
             // skip the loggers that shouldn't write this message based on the logLevel
 
-            if (!(logMessage->logFlag & loggerNode.logLevel)) {
+            if (!(logMessage->logFlag && loggerNode.logLevel)) {
                 continue;
             }
 
@@ -661,7 +661,7 @@ static unsigned int numProcessors;
         for (DDLoggerNode *loggerNode in loggers) {
             // skip the loggers that shouldn't write this message based on the logLevel
 
-            if (!(logMessage->logFlag & loggerNode.logLevel)) {
+            if (!(logMessage->logFlag && loggerNode.logLevel)) {
                 continue;
             }
 


### PR DESCRIPTION
I was thinking about submitting an issue but thought it made more sense to have the code at hand. `logFlag` and `logLevel` are both type `int` but we're doing a bitwise comparison to determine whether or not a given logger should log a message. That means for many values of `logFlag` we simply aren't going to log, no matter what the logLevel is. Maybe I'm misunderstanding the reason for the flag?
