### PR TITLE
Some small improvements + a compile fix

### DIFF
--- a/Classes/CocoaLumberjack.h
+++ b/Classes/CocoaLumberjack.h
@@ -63,7 +63,14 @@
 #import "DDLogMacros.h"
 #import "DDAssertMacros.h"
 
+#import "DDASLLogCapture.h"
+#import "DDLog+LOGV.h"
+
 // Loggers
 #import "DDTTYLogger.h"
 #import "DDASLLogger.h"
 #import "DDFileLogger.h"
+#import "DDAbstractDatabaseLogger.h"
+#import "DDContextFilterLogFormatter.h"
+#import "DDDispatchQueueLogFormatter.h"
+#import "DDMultiFormatter.h"

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -194,7 +194,7 @@ typedef NS_ENUM(NSUInteger, DDLogLevel) {
 #define LOG_FLAG_VERBOSE  DDLogFlagVerbose
 
 #define LOG_LEVEL_OFF     DDLogLevelOff
-#define LOG_LEVEL_ERROR   DDLogLeveError
+#define LOG_LEVEL_ERROR   DDLogLevelError
 #define LOG_LEVEL_WARN    DDLogLevelWarning
 #define LOG_LEVEL_INFO    DDLogLevelInfo
 #define LOG_LEVEL_DEBUG   DDLogLevelDebug

--- a/Framework/Desktop/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
+++ b/Framework/Desktop/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
@@ -35,7 +35,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">


### PR DESCRIPTION
- Added a number of headers to the umbrella header or XCode 6.1 will warn about missing headers.
- Fixed a typo that would prevent compilation.
- Set default build configuration in OSX build scheme to release.
