### PR TITLE
Remove warning when compiled w/assertions blocked

### DIFF
--- a/Classes/DDASLLogger.m
+++ b/Classes/DDASLLogger.m
@@ -89,7 +89,11 @@ static DDASLLogger *sharedInstance;
         uid_t const readUID = geteuid();
 
         char readUIDString[16];
+#ifndef NS_BLOCK_ASSERTIONS
         int l = snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
+#else
+        snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
+#endif
 
         NSAssert(l < sizeof(readUIDString),
                  @"Formatted euid is too long.");


### PR DESCRIPTION
This is just #351 as a PR. Not to steal @rodmaz's thunder or anything, but it'd be great to get this warning cleaned up upstream and eventually into our podfile!

From #351: `When CocoaLumberjack is compiled with assertions blocked (RELEASE), a warning is generated by the system on DDASLLogger.m (line 92) as the variable l is never used.`

Thanks!
