### PR TITLE
include QuartzCore/QuartzCore.h to propper support CGFloat

### DIFF
--- a/Classes/CLI/CLIColor.h
+++ b/Classes/CLI/CLIColor.h
@@ -14,6 +14,7 @@
 //   prior written permission of Deusty, LLC.
 
 #import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
 
 /**
  * This class represents an NSColor replacement for CLI projects that don't link with AppKit


### PR DESCRIPTION
should fix #371 

While creating a test project i only ran into this missing include.
It seams that QuarzCore headers are no longer included by default.
I had compiler issues with the CGRect macro.
