### PR TITLE
Fix for warning from Xcode 6.1

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -393,7 +393,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * If no formatter is set, the logger simply logs the message as it is given in logMessage,
  * or it may use its own built in formatting style.
  **/
-@property id <DDLogFormatter> logFormatter;
+@property (strong) id <DDLogFormatter> logFormatter;
 
 @optional
 


### PR DESCRIPTION
Declaration is now same as in default implementation in DDAbstractLogger
