### PR TITLE
Fix warnings

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -526,7 +526,11 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
 }
 
 @property (nonatomic, strong)            id <DDLogFormatter> logFormatter;
-@property (nonatomic, readwrite, strong) dispatch_queue_t loggerQueue;
+#if OS_OBJECT_HAVE_OBJC_SUPPORT
+@property (nonatomic, strong) dispatch_queue_t loggerQueue;
+#else
+@property (nonatomic, assign) dispatch_queue_t loggerQueue;
+#endif
 
 // For thread-safety assertions
 @property (nonatomic, readonly, getter=isOnGlobalLoggingQueue)  BOOL onGlobalLoggingQueue;


### PR DESCRIPTION
- DDLog.h:529:1: No 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed.
- DDLog.h:529:1: Default property attribute 'assign' not appropriate for non-GC object.
