### PR TITLE
Add swift to podspec

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.default_subspecs = 'Default', 'Extensions'
 
   s.subspec 'Default' do |ss|
-    ss.source_files = 'Classes/CocoaLumberjack.{h,m}'
+    ss.source_files = 'Classes/CocoaLumberjack.{h,m,swift}'
     ss.dependency 'CocoaLumberjack/Core'
   end
 


### PR DESCRIPTION
Hello,

CocoaPods is going to support swift in 0.36.0.
As stated CocoaPods/CocoaPods#2835 is searching for testing the work in progress.
For testing purpose, I updated your podspec to add the swift file.
And it's pretty well working.

Thanks for all you did,

Lionel Schinckus