### PR TITLE
Fix dispatch_queue_t properties

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -19,6 +19,12 @@
     #import "DDLegacy.h"
 #endif
 
+#if OS_OBJECT_HAVE_OBJC_SUPPORT && !defined(COCOAPODS)
+    #define DISPATCH_QUEUE_REFERENCE_TYPE strong
+#else
+    #define DISPATCH_QUEUE_REFERENCE_TYPE assign
+#endif
+
 @class DDLogMessage;
 @protocol DDLogger;
 @protocol DDLogFormatter;
@@ -331,7 +337,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * Thus, a dedicated dispatch queue is used for each logger.
  * Logger implementations may optionally choose to provide their own dispatch queue.
  **/
-@property (nonatomic, readonly) dispatch_queue_t loggerQueue;
+@property (nonatomic, DISPATCH_QUEUE_REFERENCE_TYPE, readonly) dispatch_queue_t loggerQueue;
 
 /**
  * If the logger implementation does not choose to provide its own queue,
@@ -525,12 +531,8 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
     dispatch_queue_t _loggerQueue;
 }
 
-@property (nonatomic, strong)            id <DDLogFormatter> logFormatter;
-#if OS_OBJECT_HAVE_OBJC_SUPPORT
-@property (nonatomic, strong) dispatch_queue_t loggerQueue;
-#else
-@property (nonatomic, assign) dispatch_queue_t loggerQueue;
-#endif
+@property (nonatomic, strong) id <DDLogFormatter> logFormatter;
+@property (nonatomic, DISPATCH_QUEUE_REFERENCE_TYPE) dispatch_queue_t loggerQueue;
 
 // For thread-safety assertions
 @property (nonatomic, readonly, getter=isOnGlobalLoggingQueue)  BOOL onGlobalLoggingQueue;


### PR DESCRIPTION
[Seems](http://stackoverflow.com/q/27267865/1049134) like CocoaPods somehow prevents `dispatch_queue_t` to be objects in iOS 6+/OS X 10.8+ projects.

Seems to be related to https://github.com/CocoaPods/CocoaPods/issues/1001, https://github.com/CocoaPods/Specs/issues/1730 and https://github.com/CocoaPods/Specs/issues/4323.

Closes #410.
