### PR TITLE
Warning fixes & type standardization

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -157,7 +157,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 + (void)log:(BOOL)synchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -173,7 +173,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 + (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -188,7 +188,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
     message:(NSString *)message
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -443,7 +443,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
     NSString *_message;
     DDLogLevel _level;
     DDLogFlag _flag;
-    NSUInteger _context;
+    NSInteger _context;
     NSString *_file;
     NSString *_fileName;
     NSString *_function;
@@ -474,7 +474,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
 - (instancetype)initWithMessage:(NSString *)message
                           level:(DDLogLevel)level
                            flag:(DDLogFlag)flag
-                        context:(NSUInteger)context
+                        context:(NSInteger)context
                            file:(NSString *)file
                        function:(NSString *)function
                            line:(NSUInteger)line
@@ -488,7 +488,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
 @property (readonly, nonatomic) NSString *message;
 @property (readonly, nonatomic) DDLogLevel level;
 @property (readonly, nonatomic) DDLogFlag flag;
-@property (readonly, nonatomic) NSUInteger context;
+@property (readonly, nonatomic) NSInteger context;
 @property (readonly, nonatomic) NSString *file;
 @property (readonly, nonatomic) NSString *fileName;
 @property (readonly, nonatomic) NSString *function;

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -303,7 +303,7 @@ static NSUInteger _numProcessors;
 + (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -332,7 +332,7 @@ static NSUInteger _numProcessors;
 + (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -358,7 +358,7 @@ static NSUInteger _numProcessors;
     message:(NSString *)message
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
-    context:(NSUInteger)context
+    context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
@@ -881,7 +881,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy) {
 - (instancetype)initWithMessage:(NSString *)message
                           level:(DDLogLevel)level
                            flag:(DDLogFlag)flag
-                        context:(NSUInteger)context
+                        context:(NSInteger)context
                            file:(NSString *)file
                        function:(NSString *)function
                            line:(NSUInteger)line

--- a/Classes/DDTTYLogger.h
+++ b/Classes/DDTTYLogger.h
@@ -132,7 +132,7 @@
  * Logging context's are explained in further detail here:
  * Documentation/CustomContext.md
  **/
-- (void)setForegroundColor:(DDColor *)txtColor backgroundColor:(DDColor *)bgColor forFlag:(DDLogFlag)mask context:(NSUInteger)ctxt;
+- (void)setForegroundColor:(DDColor *)txtColor backgroundColor:(DDColor *)bgColor forFlag:(DDLogFlag)mask context:(NSInteger)ctxt;
 
 /**
  * Similar to the methods above, but allows you to map DDLogMessage->tag to a particular color profile.
@@ -163,7 +163,7 @@
  * Clearing color profiles.
  **/
 - (void)clearColorsForFlag:(DDLogFlag)mask;
-- (void)clearColorsForFlag:(DDLogFlag)mask context:(NSUInteger)context;
+- (void)clearColorsForFlag:(DDLogFlag)mask context:(NSInteger)context;
 - (void)clearColorsForTag:(id <NSCopying>)tag;
 - (void)clearColorsForAllFlags;
 - (void)clearColorsForAllTags;

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -81,7 +81,7 @@
 @interface DDTTYLoggerColorProfile : NSObject {
     @public
     DDLogFlag mask;
-    NSUInteger context;
+    NSInteger context;
 
     uint8_t fg_r;
     uint8_t fg_g;
@@ -107,7 +107,7 @@
     size_t resetCodeLen;
 }
 
-- (instancetype)initWithForegroundColor:(DDColor *)fgColor backgroundColor:(DDColor *)bgColor flag:(DDLogFlag)mask context:(NSUInteger)ctxt;
+- (instancetype)initWithForegroundColor:(DDColor *)fgColor backgroundColor:(DDColor *)bgColor flag:(DDLogFlag)mask context:(NSInteger)ctxt;
 
 @end
 
@@ -946,7 +946,7 @@ static DDTTYLogger *sharedInstance;
     [self setForegroundColor:txtColor backgroundColor:bgColor forFlag:mask context:LOG_CONTEXT_ALL];
 }
 
-- (void)setForegroundColor:(DDColor *)txtColor backgroundColor:(DDColor *)bgColor forFlag:(DDLogFlag)mask context:(NSUInteger)ctxt {
+- (void)setForegroundColor:(DDColor *)txtColor backgroundColor:(DDColor *)bgColor forFlag:(DDLogFlag)mask context:(NSInteger)ctxt {
     dispatch_block_t block = ^{
         @autoreleasepool {
             DDTTYLoggerColorProfile *newColorProfile =
@@ -1026,7 +1026,7 @@ static DDTTYLogger *sharedInstance;
     [self clearColorsForFlag:mask context:0];
 }
 
-- (void)clearColorsForFlag:(DDLogFlag)mask context:(NSUInteger)context {
+- (void)clearColorsForFlag:(DDLogFlag)mask context:(NSInteger)context {
     dispatch_block_t block = ^{
         @autoreleasepool {
             NSUInteger i = 0;
@@ -1365,7 +1365,7 @@ static DDTTYLogger *sharedInstance;
 
 @implementation DDTTYLoggerColorProfile
 
-- (instancetype)initWithForegroundColor:(DDColor *)fgColor backgroundColor:(DDColor *)bgColor flag:(DDLogFlag)aMask context:(NSUInteger)ctxt {
+- (instancetype)initWithForegroundColor:(DDColor *)fgColor backgroundColor:(DDColor *)bgColor flag:(DDLogFlag)aMask context:(NSInteger)ctxt {
     if ((self = [super init])) {
         mask = aMask;
         context = ctxt;
@@ -1469,8 +1469,8 @@ static DDTTYLogger *sharedInstance;
 
 - (NSString *)description {
     return [NSString stringWithFormat:
-            @"<DDTTYLoggerColorProfile: %p mask:%i ctxt:%lu fg:%u,%u,%u bg:%u,%u,%u fgCode:%@ bgCode:%@>",
-            self, (int)mask, (unsigned long)context, fg_r, fg_g, fg_b, bg_r, bg_g, bg_b, fgCodeRaw, bgCodeRaw];
+            @"<DDTTYLoggerColorProfile: %p mask:%i ctxt:%ld fg:%u,%u,%u bg:%u,%u,%u fgCode:%@ bgCode:%@>",
+            self, (int)mask, (long)context, fg_r, fg_g, fg_b, bg_r, bg_g, bg_b, fgCodeRaw, bgCodeRaw];
 }
 
 @end


### PR DESCRIPTION
- I've switched all the "context" variables/parameters to use NSInteger
- "line" uses NSUInteger
- I've also added a couple casts for enum types to stop clang complaining about bitmask values not being in the  enum

I've not changed any of the project files to actually use compiler warnings that would surface these, but when integrating to other projects with stricter warnings, it's nice to have these go away.
