### PR TITLE
The DISPATCH_QUEUE_REFERENCE_TYPE check is incorrect

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -19,7 +19,7 @@
     #import "DDLegacy.h"
 #endif
 
-#if OS_OBJECT_HAVE_OBJC_SUPPORT && !defined(COCOAPODS)
+#if OS_OBJECT_HAVE_OBJC_SUPPORT
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong
 #else
     #define DISPATCH_QUEUE_REFERENCE_TYPE assign


### PR DESCRIPTION
There's no need to switch based on the use of COCOAPODS. The correct type is defined by OS_OBJECT_HAVE_OBJC_SUPPORT period.
