### PR TITLE
SwiftLogMacro context parameter type updated

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -58,11 +58,11 @@ public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Warning
 }
 
-public func SwiftLogMacro(async: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: UInt = 0, file: String = __FILE__, function: String = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, #format: String, #args: CVaListPointer) {
+public func SwiftLogMacro(async: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: String = __FILE__, function: String = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, #format: String, #args: CVaListPointer) {
     let string = NSString(format: format, arguments: args) as String
     SwiftLogMacro(async, level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, string)
 }
-public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: UInt = 0, file: String = __FILE__, function: String = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, string: String) {
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: String = __FILE__, function: String = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, string: String) {
     // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
 	let logMessage = DDLogMessage(message: string, level: level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, options: .CopyFile | .CopyFunction, timestamp: nil)
     DDLog.log(isAsynchronous, message: logMessage)


### PR DESCRIPTION
SwiftLogMacro context parameter type updated to confirm DDLogMessage context type.
Fix for Issue #422