### PR TITLE
Updating naming convention

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -108,7 +108,7 @@ Here's all it takes to convert your log statements:
 #import "Sprocket.h"
 #import "DDLog.h"
 
-static const int ddLogLevel = LOG_LEVEL_VERBOSE;
+static const int ddLogLevel = DDLogLevelVerbose;
 
 @implementation Sprocket
 

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -106,9 +106,9 @@ Here's all it takes to convert your log statements:
 // TO THIS
 
 #import "Sprocket.h"
-#import "DDLog.h"
+#import "CocoaLumberjack.h"
 
-static const int ddLogLevel = DDLogLevelVerbose;
+static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
 
 @implementation Sprocket
 


### PR DESCRIPTION
Changing from legacy LOG_LEVEL_VERBOSE to Lumberjack 2.x DDLogLevelVerbose naming