### PR TITLE
Guide updates for CL 2.x

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -106,7 +106,7 @@ Here's all it takes to convert your log statements:
 // TO THIS
 
 #import "Sprocket.h"
-#import "DDLog.h"
+#import "CocoaLumberjack.h"
 
 static const int ddLogLevel = LOG_LEVEL_VERBOSE;
 


### PR DESCRIPTION
changing include from DDLog.h to CocoaLumberjack.h
