### PR TITLE
Have the Swift debug functions not take variable arguments.

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -56,35 +56,30 @@ public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Warning
 }
 
-public func SwiftLogMacro(async: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, #format: String, #args: CVaListPointer) {
-    let string = NSString(format: format, arguments: args) as String
-    SwiftLogMacro(async, level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, string: string)
-}
-
 public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, #string: @autoclosure () -> String) {
     // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
-	let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: file.stringValue, function: function.stringValue, line: UInt(line), tag: tag, options: .CopyFile | .CopyFunction, timestamp: nil)
+	let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: file.stringValue, function: function.stringValue, line: line, tag: tag, options: .CopyFile | .CopyFunction, timestamp: nil)
     DDLog.log(isAsynchronous, message: logMessage)
 }
 
-public func DDLogDebug(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true, #args: CVarArgType...) {
-    SwiftLogMacro(async, level, flag: .Debug, file: file, function: function, line: line, format: logText(), args: getVaList(args))
+public func DDLogDebug(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level, flag: .Debug, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogInfo(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true, #args: CVarArgType...) {
-    SwiftLogMacro(async, level, flag: .Info, file: file, function: function, line: line, format: logText(), args: getVaList(args))
+public func DDLogInfo(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level, flag: .Info, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogWarn(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true, #args: CVarArgType...) {
-    SwiftLogMacro(async, level, flag: .Warning, file: file, function: function, line: line, format: logText(), args: getVaList(args))
+public func DDLogWarn(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level, flag: .Warning, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogVerbose(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true, #args: CVarArgType...) {
-    SwiftLogMacro(async, level, flag: .Verbose, file: file, function: function, line: line, format: logText(), args: getVaList(args))
+public func DDLogVerbose(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level, flag: .Verbose, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogError(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = false, #args: CVarArgType...) {
-    SwiftLogMacro(async, level, flag: .Error, file: file, function: function, line: line, format: logText(), args: getVaList(args))
+public func DDLogError(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = false) {
+    SwiftLogMacro(async, level, flag: .Error, file: file, function: function, line: line, string: logText)
 }
 
 /// Analogous to the C preprocessor macro THIS_FILE


### PR DESCRIPTION
Now, if you need to pass a string that does use valists under Swift, either switch to using them in a string constant ( "\(aVal)" ), or creating a string manually that uses it ( String(format: "%@", aVal) ).

Should fix #448.