### PR TITLE
Fix #433 CocoaLumberjack 2.0.0-rc does not build with Pods

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -23,7 +23,7 @@
     #import "DDLegacyMacros.h"
 #endif
 
-#if OS_OBJECT_HAVE_OBJC_SUPPORT || __IPHONE_OS_VERSION_MIN_REQUIRED >= 60000
+#if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong
 #else
     #define DISPATCH_QUEUE_REFERENCE_TYPE assign


### PR DESCRIPTION
More details on OS_OBJECT_USE_OBJC  and CocoaPods
http://guides.cocoapods.org/syntax/podspec.html#deployment_target