### PR TITLE
fix locale for dateFormatter to provide fixed output date format.

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -317,6 +317,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 
     if (dateFormatter == nil) {
         dateFormatter = [[NSDateFormatter alloc] init];
+        [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
         [dateFormatter setDateFormat:dateFormat];
         [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
         dictionary[key] = dateFormatter;


### PR DESCRIPTION
If the locale is not specified, then the expected format can be overridden in iOS
by the 'use 24hr clock' setting.

This causes filenames with am/pm format, which then fail the isLogFile
test.

This in turn causes sortedLogFilePaths and friends to return zero
entries.

(this bug also exists in the 1.9 branch)

for more detail, see:
https://developer.apple.com/library/ios/qa/qa1480/_index.html