### PR TITLE
New log file is always created at app launch on simulator

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -953,7 +953,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
             if (!_doNotReuseLogFiles && doesAppRunInBackground()) {
                 NSString *key = mostRecentLogFileInfo.fileAttributes[NSFileProtectionKey];
 
-                if (!([key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication] || [key isEqualToString:NSFileProtectionNone])) {
+                if ([key length] > 0 && !([key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication] || [key isEqualToString:NSFileProtectionNone])) {
                     shouldArchiveMostRecent = YES;
                 }
             }


### PR DESCRIPTION
When an app that is capable of running in the background runs on the simulator, the most recent log file is always archived, regardless of file size or age. A new log file is created on each app launch because `NSFileProtectionKey` is not present.

This pull request checks whether there is a value for `NSFileProtectionKey` in the log file's attributes. If there is no file protection value present, it will not force a new log file to be created.  