### PR TITLE
Support for deleting all old log files at runtime

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -194,12 +194,10 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
         }
     }
 
-    if (maxNumLogFiles) {
-        if (firstIndexToDelete == NSNotFound) {
-            firstIndexToDelete = maxNumLogFiles;
-        } else {
-            firstIndexToDelete = MIN(firstIndexToDelete, maxNumLogFiles);
-        }
+    if (firstIndexToDelete == NSNotFound) {
+        firstIndexToDelete = maxNumLogFiles;
+    } else {
+        firstIndexToDelete = MIN(firstIndexToDelete, maxNumLogFiles);
     }
 
     if (firstIndexToDelete == 0) {


### PR DESCRIPTION
Setting maximumNumberOfLogFiles to 0 did not delete all files including current log file.
It is now possible to delete all log files at runtime using this approach:

```
[fileLogger rollLogFileWithCompletionBlock:^{
        // forcing maximum number of log files to 0 will delete old files
        fileLogger.logFileManager.maximumNumberOfLogFiles = 0;

        [fileLogger rollLogFileWithCompletionBlock:^{
            fileLogger.logFileManager.maximumNumberOfLogFiles = MaxNumberOfLogFiles;
        }];
    }];
```