### PR TITLE
Default ddLogLevel set to DDLogLevelVerbose

### DIFF
--- a/Classes/DDLogMacros.h
+++ b/Classes/DDLogMacros.h
@@ -24,7 +24,11 @@
  * The constant/variable/method responsible for controlling the current log level.
  **/
 #ifndef LOG_LEVEL_DEF
-    #define LOG_LEVEL_DEF ddLogLevel
+    #ifdef ddLogLevel
+        #define LOG_LEVEL_DEF ddLogLevel
+    #else
+        #define LOG_LEVEL_DEF DDLogLevelVerbose
+    #endif
 #endif
 
 /**


### PR DESCRIPTION
To avoid 
> Requiring apps to create an arbitrary named variable just to start using CocoaLumberjack is clumsy. 

we can define the global log level to **Verbose** unless it's already defined.