### PR TITLE
Temporary fix for modules.

### DIFF
--- a/Framework/Desktop/Lumberjack/CocoaLumberjack.modulemap
+++ b/Framework/Desktop/Lumberjack/CocoaLumberjack.modulemap
@@ -4,6 +4,11 @@ framework module CocoaLumberjack {
 	export *
 	module * { export * }
 	
+	//Until Xcode adds support for textual headers
+	//textual header "DDLogMacros.h"
+	//We have to use config_macros and define ddLogLevel on the command line
+	config_macros ddLogLevel
+	
 	exclude header "DDLog+LOGV.h"
 	exclude header "DDLegacyMacros.h"
 }


### PR DESCRIPTION
Temporary fix for #481.
Note that you will need to declare `ddLogLevel` as a preprocessor macro on the command line.

Hopefully Xcode 6.3 will add support for the `textual header` module syntax.