### PR TITLE
Tests for DDLogmessage

### DIFF
--- a/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */; };
 		6DC1C69BDFE9F353B9031B42 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 817EFE4778751A16EFC482E2 /* libPods-ios.a */; };
 		E36E283FA66CB42E5B441755 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 359D6F3033BA9595543EAB1C /* libPods-osx.a */; };
+		E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */; };
+		E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +25,7 @@
 		817EFE4778751A16EFC482E2 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABA969AD38E11503DDCF9624 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		DA1B17371AB067EF004705E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLogMessageTests.m; sourceTree = "<group>"; };
 		F04FA52AE01B89E56599B55E /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -70,6 +73,7 @@
 			isa = PBXGroup;
 			children = (
 				432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */,
+				E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -255,6 +259,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534D1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -263,6 +268,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/DDLogMessageTests.m
+++ b/Tests/Tests/DDLogMessageTests.m
@@ -25,8 +25,9 @@ static NSString * const kDefaultMessage = @"Log message";
 @interface DDLogMessage (TestHelpers)
 + (DDLogMessage *)test_message;
 + (DDLogMessage *)test_messageWithMessage:(NSString *)message;
-+ (DDLogMessage *)test_messageWithFunction:(NSString *)function;
-+ (DDLogMessage *)test_messageWithFile:(NSString *)file;
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function options:(DDLogMessageOptions)options;
++ (DDLogMessage *)test_messageWithFile:(NSString *)file options:(DDLogMessageOptions)options;
+
 @end
 
 @implementation DDLogMessage (TestHelpers)
@@ -56,7 +57,8 @@ static NSString * const kDefaultMessage = @"Log message";
                                        timestamp:nil];
 }
 
-+ (DDLogMessage *)test_messageWithFunction:(NSString *)function {
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function
+                                   options:(DDLogMessageOptions)options {
     return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
                                            level:DDLogLevelDebug
                                             flag:DDLogFlagError
@@ -69,7 +71,8 @@ static NSString * const kDefaultMessage = @"Log message";
                                        timestamp:nil];
 }
 
-+ (DDLogMessage *)test_messageWithFile:(NSString *)file {
++ (DDLogMessage *)test_messageWithFile:(NSString *)file
+                               options:(DDLogMessageOptions)options {
     return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
                                            level:DDLogLevelDebug
                                             flag:DDLogFlagError
@@ -167,7 +170,7 @@ static NSString * const kDefaultMessage = @"Log message";
 }
 
 - (void)testInitSetsFileNameToFilenameIfItHasNotExtension {
-    self.message = [DDLogMessage test_messageWithFile:@"no-extenstion"];
+    self.message = [DDLogMessage test_messageWithFile:@"no-extenstion" options:(DDLogMessageOptions)0];
     XCTAssertEqualObjects(self.message.fileName, @"no-extenstion");
 }
 
@@ -180,7 +183,7 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testInitAssignsFileParameterWithoutCopyFileOption {
     NSMutableString *file = [NSMutableString stringWithString:@"file"];
-    self.message = [DDLogMessage test_messageWithFile:file];
+    self.message = [DDLogMessage test_messageWithFile:file options:(DDLogMessageOptions)0];
     XCTAssertEqualObjects(self.message.file, @"file");
     [file appendString:@"file"];
     XCTAssertEqualObjects(self.message.file, @"filefile");
@@ -188,7 +191,7 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testInitCopyFileParameterWithCopyFileOption {
     NSMutableString *file = [NSMutableString stringWithString:@"file"];
-    self.message = [DDLogMessage test_messageWithFile:file];
+    self.message = [DDLogMessage test_messageWithFile:file options:DDLogMessageCopyFile];
     XCTAssertEqualObjects(self.message.file, @"file");
     [file appendString:@"file"];
     XCTAssertEqualObjects(self.message.file, @"file");
@@ -196,7 +199,7 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testInitAssignFunctionParameterWithoutCopyFunctionOption {
     NSMutableString *function = [NSMutableString stringWithString:@"function"];
-    self.message = [DDLogMessage test_messageWithFunction:function];
+    self.message = [DDLogMessage test_messageWithFunction:function options:(DDLogMessageOptions)0];
     XCTAssertEqualObjects(self.message.function, @"function");
     [function appendString:@"function"];
     XCTAssertEqualObjects(self.message.function, @"functionfunction");
@@ -204,7 +207,7 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testInitCopyFunctionParameterWithCopyFunctionOption {
     NSMutableString *function = [NSMutableString stringWithString:@"function"];
-    self.message = [DDLogMessage test_messageWithFunction:function];
+    self.message = [DDLogMessage test_messageWithFunction:function options:DDLogMessageCopyFunction];
     XCTAssertEqualObjects(self.message.function, @"function");
     [function appendString:@"function"];
     XCTAssertEqualObjects(self.message.function, @"function");

--- a/Tests/Tests/DDLogMessageTests.m
+++ b/Tests/Tests/DDLogMessageTests.m
@@ -1,0 +1,231 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2014-2015, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+//
+//  Created by Pavel Kunc on 18/04/2015.
+//
+
+@import XCTest;
+#import <Expecta.h>
+#import "DDLog.h"
+
+static NSString * const kDefaultMessage = @"Log message";
+
+@interface DDLogMessage (TestHelpers)
++ (DDLogMessage *)test_message;
++ (DDLogMessage *)test_messageWithMessage:(NSString *)message;
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function;
++ (DDLogMessage *)test_messageWithFile:(NSString *)file;
+@end
+
+@implementation DDLogMessage (TestHelpers)
++ (DDLogMessage *)test_message {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithMessage:(NSString *)message {
+    return [[DDLogMessage alloc] initWithMessage:message
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:function
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithFile:(NSString *)file {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:file
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithTimestamp:(NSDate *)timestamp {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:timestamp];
+}
+
+@end
+
+
+@interface DDLogMessageTests : XCTestCase
+@property (nonatomic, strong, readwrite) DDLogMessage *message;
+@end
+
+@implementation DDLogMessageTests
+
+- (void)setUp {
+    [super setUp];
+    self.message = [DDLogMessage test_message];
+}
+
+- (void)tearDown {
+    [super tearDown];
+
+    self.message = nil;
+}
+
+#pragma mark - Message creation
+
+- (void)testInitSetsAllPassedParameters {
+    NSDate *referenceDate  = [NSDate dateWithTimeIntervalSince1970:0];
+    self.message =
+        [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                        level:DDLogLevelDebug
+                                         flag:DDLogFlagError
+                                      context:1
+                                         file:@"DDLogMessageTests.m"
+                                     function:@"testInitSetsAllPassedParameters"
+                                         line:50
+                                          tag:NULL
+                                         options:DDLogMessageCopyFile
+                                         timestamp:referenceDate];
+
+    XCTAssertEqualObjects(self.message.message, @"Log message");
+    XCTAssertEqual(self.message.level, DDLogLevelDebug);
+    XCTAssertEqual(self.message.flag, DDLogFlagError);
+    XCTAssertEqual(self.message.context, 1);
+    XCTAssertEqual(self.message.file, @"DDLogMessageTests.m");
+    XCTAssertEqual(self.message.function, @"testInitSetsAllPassedParameters");
+    XCTAssertEqual(self.message.line, 50);
+    XCTAssertEqual(self.message.tag, NULL);
+    XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
+    XCTAssertEqualObjects(self.message.timestamp, referenceDate);
+}
+
+- (void)testInitCopyMessageParameter {
+    NSMutableString *message = [NSMutableString stringWithString:@"Log message"];
+    self.message = [DDLogMessage test_messageWithMessage:message];
+    [message appendString:@" changed"];
+    XCTAssertEqualObjects(self.message.message, @"Log message");
+}
+
+- (void)testInitSetsCurrentDateToTimestampIfItIsNotProvided {
+    XCTAssertLessThanOrEqual(fabs([self.message.timestamp timeIntervalSinceNow]), 5);
+}
+
+- (void)testInitSetsThreadIDToCurrentThreadID {
+    XCTAssertNotNil(self.message.threadID);
+}
+
+- (void)testInitSetsThreadNameToCurrentThreadName {
+    XCTAssertEqualObjects(self.message.threadName, NSThread.currentThread.name);
+}
+
+- (void)testInitSetsFileNameToFilenameWithoutExtensionIfItHasExtension {
+    XCTAssertEqualObjects(self.message.fileName, @"DDLogMessageTests");
+}
+
+- (void)testInitSetsFileNameToFilenameIfItHasNotExtension {
+    self.message = [DDLogMessage test_messageWithFile:@"no-extenstion"];
+    XCTAssertEqualObjects(self.message.fileName, @"no-extenstion");
+}
+
+//TODO: How to test this for different SDK versions? (pavel, Sat 18 Apr 15:35:46 2015)
+- (void)testInitSetsQueueLabelToQueueWeCurrentlyRun {
+    // We're running on main thread
+    XCTAssertEqualObjects(self.message.queueLabel, @"com.apple.main-thread");
+}
+
+
+- (void)testInitAssignsFileParameterWithoutCopyFileOption {
+    NSMutableString *file = [NSMutableString stringWithString:@"file"];
+    self.message = [DDLogMessage test_messageWithFile:file];
+    XCTAssertEqualObjects(self.message.file, @"file");
+    [file appendString:@"file"];
+    XCTAssertEqualObjects(self.message.file, @"filefile");
+}
+
+- (void)testInitCopyFileParameterWithCopyFileOption {
+    NSMutableString *file = [NSMutableString stringWithString:@"file"];
+    self.message = [DDLogMessage test_messageWithFile:file];
+    XCTAssertEqualObjects(self.message.file, @"file");
+    [file appendString:@"file"];
+    XCTAssertEqualObjects(self.message.file, @"file");
+}
+
+- (void)testInitAssignFunctionParameterWithoutCopyFunctionOption {
+    NSMutableString *function = [NSMutableString stringWithString:@"function"];
+    self.message = [DDLogMessage test_messageWithFunction:function];
+    XCTAssertEqualObjects(self.message.function, @"function");
+    [function appendString:@"function"];
+    XCTAssertEqualObjects(self.message.function, @"functionfunction");
+}
+
+- (void)testInitCopyFunctionParameterWithCopyFunctionOption {
+    NSMutableString *function = [NSMutableString stringWithString:@"function"];
+    self.message = [DDLogMessage test_messageWithFunction:function];
+    XCTAssertEqualObjects(self.message.function, @"function");
+    [function appendString:@"function"];
+    XCTAssertEqualObjects(self.message.function, @"function");
+}
+
+- (void)testCopyWithZoneCreatesValidCopy {
+    DDLogMessage *copy = [self.message copy];
+    XCTAssertEqualObjects(self.message.message, copy.message);
+    XCTAssertEqual(self.message.level, copy.level);
+    XCTAssertEqual(self.message.flag, copy.flag);
+    XCTAssertEqual(self.message.context, copy.context);
+    XCTAssertEqualObjects(self.message.file, copy.file);
+    XCTAssertEqualObjects(self.message.fileName, copy.fileName);
+    XCTAssertEqualObjects(self.message.function, copy.function);
+    XCTAssertEqual(self.message.line, copy.line);
+    XCTAssertEqual(self.message.tag, copy.tag);
+    XCTAssertEqual(self.message.options, copy.options);
+    XCTAssertEqualObjects(self.message.timestamp, copy.timestamp);
+    XCTAssertEqualObjects(self.message.threadID, copy.threadID);
+    XCTAssertEqualObjects(self.message.threadName, copy.threadName);
+    XCTAssertEqualObjects(self.message.queueLabel, copy.queueLabel);
+}
+
+@end

--- a/Tests/Tests/DDLogMessageTests.m
+++ b/Tests/Tests/DDLogMessageTests.m
@@ -67,7 +67,7 @@ static NSString * const kDefaultMessage = @"Log message";
                                         function:function
                                             line:__LINE__
                                              tag:NULL
-                                         options:(DDLogMessageOptions)0
+                                         options:options
                                        timestamp:nil];
 }
 
@@ -81,7 +81,7 @@ static NSString * const kDefaultMessage = @"Log message";
                                         function:@(__func__)
                                             line:__LINE__
                                              tag:NULL
-                                         options:(DDLogMessageOptions)0
+                                         options:options
                                        timestamp:nil];
 }
 

--- a/Tests/Tests/DDLogMessageTests.m
+++ b/Tests/Tests/DDLogMessageTests.m
@@ -134,101 +134,101 @@ static NSString * const kDefaultMessage = @"Log message";
                                          options:DDLogMessageCopyFile
                                          timestamp:referenceDate];
 
-    XCTAssertEqualObjects(self.message.message, @"Log message");
-    XCTAssertEqual(self.message.level, DDLogLevelDebug);
-    XCTAssertEqual(self.message.flag, DDLogFlagError);
-    XCTAssertEqual(self.message.context, 1);
-    XCTAssertEqual(self.message.file, @"DDLogMessageTests.m");
-    XCTAssertEqual(self.message.function, @"testInitSetsAllPassedParameters");
-    XCTAssertEqual(self.message.line, 50);
-    XCTAssertEqual(self.message.tag, NULL);
-    XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
-    XCTAssertEqualObjects(self.message.timestamp, referenceDate);
+    expect(self.message.message).to.equal(@"Log message");
+    expect(self.message.level).to.equal(DDLogLevelDebug);
+    expect(self.message.flag).to.equal(DDLogFlagError);
+    expect(self.message.context).to.equal(1);
+    expect(self.message.file).to.equal(@"DDLogMessageTests.m");
+    expect(self.message.function).to.equal(@"testInitSetsAllPassedParameters");
+    expect(self.message.line).to.equal(50);
+    expect(self.message.tag).to.equal(NULL);
+    expect(self.message.options).to.equal(DDLogMessageCopyFile);
+    expect(self.message.timestamp).to.equal(referenceDate);
 }
 
 - (void)testInitCopyMessageParameter {
     NSMutableString *message = [NSMutableString stringWithString:@"Log message"];
     self.message = [DDLogMessage test_messageWithMessage:message];
     [message appendString:@" changed"];
-    XCTAssertEqualObjects(self.message.message, @"Log message");
+    expect(self.message.message).to.equal(@"Log message");
 }
 
 - (void)testInitSetsCurrentDateToTimestampIfItIsNotProvided {
-    XCTAssertLessThanOrEqual(fabs([self.message.timestamp timeIntervalSinceNow]), 5);
+    expect(fabs([self.message.timestamp timeIntervalSinceNow])).to.beLessThanOrEqualTo(5);
 }
 
 - (void)testInitSetsThreadIDToCurrentThreadID {
-    XCTAssertNotNil(self.message.threadID);
+    expect(self.message.threadID).notTo.beNil();
 }
 
 - (void)testInitSetsThreadNameToCurrentThreadName {
-    XCTAssertEqualObjects(self.message.threadName, NSThread.currentThread.name);
+    expect(self.message.threadName).to.equal(NSThread.currentThread.name);
 }
 
 - (void)testInitSetsFileNameToFilenameWithoutExtensionIfItHasExtension {
-    XCTAssertEqualObjects(self.message.fileName, @"DDLogMessageTests");
+    expect(self.message.fileName).to.equal(@"DDLogMessageTests");
 }
 
 - (void)testInitSetsFileNameToFilenameIfItHasNotExtension {
     self.message = [DDLogMessage test_messageWithFile:@"no-extenstion" options:(DDLogMessageOptions)0];
-    XCTAssertEqualObjects(self.message.fileName, @"no-extenstion");
+    expect(self.message.fileName).to.equal(@"no-extenstion");
 }
 
 //TODO: How to test this for different SDK versions? (pavel, Sat 18 Apr 15:35:46 2015)
 - (void)testInitSetsQueueLabelToQueueWeCurrentlyRun {
     // We're running on main thread
-    XCTAssertEqualObjects(self.message.queueLabel, @"com.apple.main-thread");
+    expect(self.message.queueLabel).to.equal(@"com.apple.main-thread");
 }
 
 
 - (void)testInitAssignsFileParameterWithoutCopyFileOption {
     NSMutableString *file = [NSMutableString stringWithString:@"file"];
     self.message = [DDLogMessage test_messageWithFile:file options:(DDLogMessageOptions)0];
-    XCTAssertEqualObjects(self.message.file, @"file");
+    expect(self.message.file).to.equal(@"file");
     [file appendString:@"file"];
-    XCTAssertEqualObjects(self.message.file, @"filefile");
+    expect(self.message.file).to.equal(@"filefile");
 }
 
 - (void)testInitCopyFileParameterWithCopyFileOption {
     NSMutableString *file = [NSMutableString stringWithString:@"file"];
     self.message = [DDLogMessage test_messageWithFile:file options:DDLogMessageCopyFile];
-    XCTAssertEqualObjects(self.message.file, @"file");
+    expect(self.message.file).to.equal(@"file");
     [file appendString:@"file"];
-    XCTAssertEqualObjects(self.message.file, @"file");
+    expect(self.message.file).to.equal(@"file");
 }
 
 - (void)testInitAssignFunctionParameterWithoutCopyFunctionOption {
     NSMutableString *function = [NSMutableString stringWithString:@"function"];
     self.message = [DDLogMessage test_messageWithFunction:function options:(DDLogMessageOptions)0];
-    XCTAssertEqualObjects(self.message.function, @"function");
+    expect(self.message.function).to.equal(@"function");
     [function appendString:@"function"];
-    XCTAssertEqualObjects(self.message.function, @"functionfunction");
+    expect(self.message.function).to.equal(@"functionfunction");
 }
 
 - (void)testInitCopyFunctionParameterWithCopyFunctionOption {
     NSMutableString *function = [NSMutableString stringWithString:@"function"];
     self.message = [DDLogMessage test_messageWithFunction:function options:DDLogMessageCopyFunction];
-    XCTAssertEqualObjects(self.message.function, @"function");
+    expect(self.message.function).to.equal(@"function");
     [function appendString:@"function"];
-    XCTAssertEqualObjects(self.message.function, @"function");
+    expect(self.message.function).to.equal(@"function");
 }
 
 - (void)testCopyWithZoneCreatesValidCopy {
     DDLogMessage *copy = [self.message copy];
-    XCTAssertEqualObjects(self.message.message, copy.message);
-    XCTAssertEqual(self.message.level, copy.level);
-    XCTAssertEqual(self.message.flag, copy.flag);
-    XCTAssertEqual(self.message.context, copy.context);
-    XCTAssertEqualObjects(self.message.file, copy.file);
-    XCTAssertEqualObjects(self.message.fileName, copy.fileName);
-    XCTAssertEqualObjects(self.message.function, copy.function);
-    XCTAssertEqual(self.message.line, copy.line);
-    XCTAssertEqual(self.message.tag, copy.tag);
-    XCTAssertEqual(self.message.options, copy.options);
-    XCTAssertEqualObjects(self.message.timestamp, copy.timestamp);
-    XCTAssertEqualObjects(self.message.threadID, copy.threadID);
-    XCTAssertEqualObjects(self.message.threadName, copy.threadName);
-    XCTAssertEqualObjects(self.message.queueLabel, copy.queueLabel);
+    expect(self.message.message).to.equal(copy.message);
+    expect(self.message.level).to.equal(copy.level);
+    expect(self.message.flag).to.equal(copy.flag);
+    expect(self.message.context).to.equal(copy.context);
+    expect(self.message.file).to.equal(copy.file);
+    expect(self.message.fileName).to.equal(copy.fileName);
+    expect(self.message.function).to.equal(copy.function);
+    expect(self.message.line).to.equal(copy.line);
+    expect(self.message.tag).to.equal(copy.tag);
+    expect(self.message.options).to.equal(copy.options);
+    expect(self.message.timestamp).to.equal(copy.timestamp);
+    expect(self.message.threadID).to.equal(copy.threadID);
+    expect(self.message.threadName).to.equal(copy.threadName);
+    expect(self.message.queueLabel).to.equal(copy.queueLabel);
 }
 
 @end


### PR DESCRIPTION
Hi from Cocoapods TestJam,

I'm trying to add some test coverage for the project. Started with the DDLogMessage as it was simple enough.

There are 2 failing tests because I've wrote tests according to the documentation which mentions using DDLogMessageOptions to force copy the file & function strings but the code is actually missing in the implementation.