### PR TITLE
Fixing DDLogMessage to work according to the documentation

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -898,8 +898,13 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy) {
         _level        = level;
         _flag         = flag;
         _context      = context;
-        _file         = file;
-        _function     = function;
+
+        BOOL copyFile = (options & DDLogMessageCopyFile) == DDLogMessageCopyFile;
+        _file = copyFile ? [file copy] : file;
+
+        BOOL copyFunction = (options & DDLogMessageCopyFunction) == DDLogMessageCopyFunction;
+        _function = copyFunction ? [function copy] : function;
+
         _line         = line;
         _tag          = tag;
         _options      = options;


### PR DESCRIPTION
DDLogMessage constructor describes the behaviour which has not been implemented. I've added the tests and this pull requests implements the behaviour so the test passes.