### PR TITLE
Fix seemingly obvious typo in the toLogLevel function

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -28,7 +28,7 @@ extension DDLogFlag {
         } else {
             let logFlag = self
             if logFlag & .Verbose == .Verbose {
-                return .Error
+                return .Verbose
             } else if logFlag & .Debug == .Debug {
                 return .Debug
             } else if logFlag & .Info == .Info {
@@ -36,7 +36,7 @@ extension DDLogFlag {
             } else if logFlag & .Warning == .Warning {
                 return .Warning
             } else if logFlag & .Error == .Error {
-                return .Verbose
+                return .Error
             } else {
                 return .Off
             }


### PR DESCRIPTION
The logFlags for Verbose and Error seems to be transposed. Correcting on master, should probably be on the swift_support branch too