### PR TITLE
Prevent duplicate log entries when both DDASLLogCapture and DDASLLogger are used

### DIFF
--- a/Classes/DDASLLogCapture.m
+++ b/Classes/DDASLLogCapture.m
@@ -95,6 +95,9 @@ static void (*dd_asl_release)(aslresponse obj);
     const char param[] = "7";  // ASL_LEVEL_DEBUG, which is everything. We'll rely on regular DDlog log level to filter
     
     asl_set_query(query, ASL_KEY_LEVEL, param, ASL_QUERY_OP_LESS_EQUAL | ASL_QUERY_OP_NUMERIC);
+
+    // Don't retrieve logs from our own DDASLLogger
+    asl_set_query(query, kDDASLKeyDDLog, kDDASLDDLogValue, ASL_QUERY_OP_NOT_EQUAL);
     
 #if !TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
     int processId = [[NSProcessInfo processInfo] processIdentifier];

--- a/Classes/DDASLLogger.h
+++ b/Classes/DDASLLogger.h
@@ -22,6 +22,12 @@
 
 #import "DDLog.h"
 
+// Custom key set on messages sent to ASL
+extern const char* const kDDASLKeyDDLog;
+
+// Value set for kDDASLKeyDDLog
+extern const char* const kDDASLDDLogValue;
+
 /**
  * This class provides a logger for the Apple System Log facility.
  *

--- a/Classes/DDASLLogger.m
+++ b/Classes/DDASLLogger.m
@@ -20,6 +20,10 @@
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+const char* const kDDASLKeyDDLog = "DDLog";
+
+const char* const kDDASLDDLogValue = "1";
+
 static DDASLLogger *sharedInstance;
 
 @interface DDASLLogger () {
@@ -100,7 +104,8 @@ static DDASLLogger *sharedInstance;
         if (m != NULL) {
             if (asl_set(m, ASL_KEY_LEVEL, level_strings[aslLogLevel]) == 0 &&
                 asl_set(m, ASL_KEY_MSG, msg) == 0 &&
-                asl_set(m, ASL_KEY_READ_UID, readUIDString) == 0) {
+                asl_set(m, ASL_KEY_READ_UID, readUIDString) == 0 &&
+                asl_set(m, kDDASLKeyDDLog, kDDASLDDLogValue) == 0) {
                 asl_send(_client, m);
             }
             asl_free(m);


### PR DESCRIPTION
When both `DDASLLogCapture` and `DDASLLogger` are active and you have another logger (for instance the file or tty logger),
using a `DDLog(xxx)` statement would result in 2 log entries with the same message in other loggers.

Indeed, the first (expected) entry would be sent to the registered loggers and then the `DDASLLogger` would send it to the ASL facility, after that the `DDASLLogCapture` would pick it up and it would again be sent to the registered loggers (note that in that case `DDASLLogger` would rightfully skip it since it comes from the capture).

So here I've marked messages sent by `DDASLLogger` with a custom key that's used for filtering in `DDASLLogCapture`. Hence preventing the duplicate messages.