### PR TITLE
Use an absolute path to identify the modulemap.

### DIFF
--- a/Framework/Desktop/Lumberjack.xcodeproj/project.pbxproj
+++ b/Framework/Desktop/Lumberjack.xcodeproj/project.pbxproj
@@ -882,7 +882,7 @@
 				INFOPLIST_FILE = "Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = Lumberjack/CocoaLumberjack.modulemap;
+				MODULEMAP_FILE = "$(PROJECT_DIR)/Lumberjack/CocoaLumberjack.modulemap";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
@@ -908,7 +908,7 @@
 				INFOPLIST_FILE = "Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = Lumberjack/CocoaLumberjack.modulemap;
+				MODULEMAP_FILE = "$(PROJECT_DIR)/Lumberjack/CocoaLumberjack.modulemap";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";


### PR DESCRIPTION
In some cases when adding CocoaLumberjack as a submodule, Xcode can get confused and attempts to find the modulemap file in the wrong directory (e.g. `Mobile/Lumberjack/CocoaLumberjack.modulemap`, which does not exist). I'm not sure why happens or in exactly which situations, but using an absolute path (via `$PROJECT_DIR`) makes our intention more explicit and avoids this problem.