### PR TITLE
Move DD_LEGACY_MACROS check to DDLegacyMacros.h

### DIFF
--- a/Classes/DDLegacyMacros.h
+++ b/Classes/DDLegacyMacros.h
@@ -18,6 +18,7 @@
  *
  * Imported by default when importing a DDLog.h directly and DD_LEGACY_MACROS is not defined and set to 0.
  **/
+#if DD_LEGACY_MACROS
 
 #warning CocoaLumberjack 1.9.x legacy macros enabled. \
 Disable legacy macros by importing CocoaLumberjack.h or DDLogMacros.h instead of DDLog.h or add `#define DD_LEGACY_MACROS 0` before importing DDLog.h.
@@ -71,3 +72,4 @@ Disable legacy macros by importing CocoaLumberjack.h or DDLogMacros.h instead of
 #define DDLogDebug(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_DEBUG,   LOG_LEVEL_DEF, LOG_FLAG_DEBUG,   0, frmt, ##__VA_ARGS__)
 #define DDLogVerbose(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_VERBOSE, LOG_LEVEL_DEF, LOG_FLAG_VERBOSE, 0, frmt, ##__VA_ARGS__)
 
+#endif

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -19,9 +19,8 @@
 #ifndef DD_LEGACY_MACROS
     #define DD_LEGACY_MACROS 1
 #endif
-#if DD_LEGACY_MACROS
-    #import "DDLegacyMacros.h"
-#endif
+// DD_LEGACY_MACROS is checked in the file itself
+#import "DDLegacyMacros.h"
 
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong


### PR DESCRIPTION
When applying the new `use_frameworks!` option in Cocoapods, a bridging header
is automatically generated. This bridging header must import `DDLegacyMacros.h`
directly.
This leads to `CocoaLumberjack 1.9.x legacy macros enabled.` and `macro
redefined` warnings.

Therefore it is not enough to merely check the flag in DDLog.h.