### PR TITLE
Fixed compile errors in Xcode 7 with Swift 2.0

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -18,7 +18,7 @@ import CocoaLumberjack
 
 extension DDLogFlag {
     public static func fromLogLevel(logLevel: DDLogLevel) -> DDLogFlag {
-        return DDLogFlag(logLevel.rawValue)
+        return DDLogFlag(rawValue: logLevel.rawValue)
     }
     
     ///returns the log level, or the lowest equivalant.
@@ -26,16 +26,17 @@ extension DDLogFlag {
         if let ourValid = DDLogLevel(rawValue: self.rawValue) {
             return ourValid
         } else {
-            let logFlag = self
-            if logFlag & .Verbose == .Verbose {
+            let logFlag:DDLogFlag = self
+            
+            if logFlag.contains(.Verbose) {
                 return .Verbose
-            } else if logFlag & .Debug == .Debug {
+            } else if logFlag.contains(.Debug) {
                 return .Debug
-            } else if logFlag & .Info == .Info {
+            } else if logFlag.contains(.Info) {
                 return .Info
-            } else if logFlag & .Warning == .Warning {
+            } else if logFlag.contains(.Warning) {
                 return .Warning
-            } else if logFlag & .Error == .Error {
+            } else if logFlag.contains(.Error) {
                 return .Error
             } else {
                 return .Off
@@ -46,7 +47,7 @@ extension DDLogFlag {
 
 extension DDMultiFormatter {
     public var formatterArray: [DDLogFormatter] {
-        return self.formatters as [DDLogFormatter]
+        return self.formatters as! [DDLogFormatter]
     }
 }
 
@@ -56,32 +57,32 @@ public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Verbose
 }
 
-public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, #string: @autoclosure () -> String) {
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String) {
     if level.rawValue & flg.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it. Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
-        let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: "\(file)", function: "\(function)", line: line, tag: tag, options: .CopyFile | .CopyFunction, timestamp: nil)
+        let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: "\(file)", function: "\(function)", line: line, tag: tag, options: [.CopyFile, .CopyFunction], timestamp: nil)
         DDLog.log(isAsynchronous, message: logMessage)
     }
 }
 
-public func DDLogDebug(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level, flag: .Debug, file: file, function: function, line: line, string: logText)
+public func DDLogDebug(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Debug, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogInfo(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level, flag: .Info, file: file, function: function, line: line, string: logText)
+public func DDLogInfo(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Info, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogWarn(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level, flag: .Warning, file: file, function: function, line: line, string: logText)
+public func DDLogWarn(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Warning, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogVerbose(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level, flag: .Verbose, file: file, function: function, line: line, string: logText)
+public func DDLogVerbose(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Verbose, file: file, function: function, line: line, string: logText)
 }
 
-public func DDLogError(logText: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = false) {
-    SwiftLogMacro(async, level, flag: .Error, file: file, function: function, line: line, string: logText)
+public func DDLogError(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = false) {
+    SwiftLogMacro(async, level: level, flag: .Error, file: file, function: function, line: line, string: logText)
 }
 
 /// Analogous to the C preprocessor macro THIS_FILE

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -774,6 +774,7 @@
 		DCB3184714EB418D001CFBEE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0600;
 				TargetAttributes = {
 					18F3BF5E1A81DD2E00692297 = {


### PR DESCRIPTION
When trying to use the CocoaLumberjackSwift target inside the newly released Xcode 7, several compile-time errors occur due to syntactical changes made in Swift 2.0. I ran Xcode's automatic Swift syntax upgrading assistant, and then manually fixed the change to use OptionSetType rather than bit testing on the DDLogFlag type.

(This is the same as #533, but submitted to the correct branch per @rivera-ernesto 's suggestion.)