### PR TITLE
Add armv7s to static library

### DIFF
--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -1250,6 +1250,10 @@
 		18F3BFE91A81E06E00692297 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1267,6 +1271,10 @@
 		18F3BFEA1A81E06E00692297 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				ENABLE_NS_ASSERTIONS = NO;


### PR DESCRIPTION
I'm using Cocoa Lumberjack in a static framework distributed to other developers. I want to include armv7s in that framework in case developers want to use armv7s in their own Apps. However, the standard architectures in Xcode 6 and up don't include armv7s, and so the Cocoa Lumberjack targets don't compile for it.

For the dynamic framework the extra architecture consumes more space in the App bundle (750 KB vs 533 KB without), but for the static library I don't think there is any argument against including it as it will be stripped from the final App if not needed.

In this pull request I've just added armv7s to the static library target.