### PR TITLE
Swift 2 fixes

### DIFF
--- a/Classes/CocoaLumberjack.modulemap
+++ b/Classes/CocoaLumberjack.modulemap
@@ -1,4 +1,0 @@
-framework module CocoaLumberjack {
-    header "CocoaLumberjack.h"
-    export *
-}

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -57,7 +57,8 @@ public func resetDefaultDebugLevel() {
 
 public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure(escaping) string: () -> String) {
     if level.rawValue & flg.rawValue != 0 {
-        // Tell the DDLogMessage constructor to copy the C strings that get passed to it. Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
+        // Tell the DDLogMessage constructor to copy the C strings that get passed to it. 
+        // Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
         let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: "\(file)", function: "\(function)", line: line, tag: tag, options: [.CopyFile, .CopyFunction], timestamp: nil)
         DDLog.log(isAsynchronous, message: logMessage)
     }

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -20,6 +20,10 @@ extension DDLogFlag {
     public static func fromLogLevel(logLevel: DDLogLevel) -> DDLogFlag {
         return DDLogFlag(rawValue: logLevel.rawValue)
     }
+	
+	public init(_ logLevel: DDLogLevel) {
+        self = DDLogFlag(rawValue: logLevel.rawValue)
+	}
     
     ///returns the log level, or the lowest equivalant.
     public func toLogLevel() -> DDLogLevel {
@@ -45,19 +49,13 @@ extension DDLogFlag {
     }
 }
 
-extension DDMultiFormatter {
-    public var formatterArray: [DDLogFormatter] {
-        return self.formatters as! [DDLogFormatter]
-    }
-}
-
 public var defaultDebugLevel = DDLogLevel.Verbose
 
 public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Verbose
 }
 
-public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String) {
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure(escaping) string: () -> String) {
     if level.rawValue & flg.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it. Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
         let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: "\(file)", function: "\(function)", line: line, tag: tag, options: [.CopyFile, .CopyFunction], timestamp: nil)
@@ -65,27 +63,27 @@ public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDL
     }
 }
 
-public func DDLogDebug(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Debug, file: file, function: function, line: line, string: logText)
+public func DDLogDebug(@autoclosure(escaping) logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Debug, context: context, file: file, function: function, line: line, tag: tag, string: logText)
 }
 
-public func DDLogInfo(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Info, file: file, function: function, line: line, string: logText)
+public func DDLogInfo(@autoclosure(escaping) logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Info, context: context, file: file, function: function, line: line, tag: tag, string: logText)
 }
 
-public func DDLogWarn(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Warning, file: file, function: function, line: line, string: logText)
+public func DDLogWarn(@autoclosure(escaping) logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Warning, context: context, file: file, function: function, line: line, tag: tag, string: logText)
 }
 
-public func DDLogVerbose(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Verbose, file: file, function: function, line: line, string: logText)
+public func DDLogVerbose(@autoclosure(escaping) logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
+    SwiftLogMacro(async, level: level, flag: .Verbose, context: context, file: file, function: function, line: line, tag: tag, string: logText)
 }
 
-public func DDLogError(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, asynchronous async: Bool = false) {
-    SwiftLogMacro(async, level: level, flag: .Error, file: file, function: function, line: line, string: logText)
+public func DDLogError(@autoclosure(escaping) logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UWord = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = false) {
+    SwiftLogMacro(async, level: level, flag: .Error, context: context, file: file, function: function, line: line, tag: tag, string: logText)
 }
 
-/// Analogous to the C preprocessor macro THIS_FILE
+/// Analogous to the C preprocessor macro `THIS_FILE`.
 public func CurrentFileName(fileName: StaticString = __FILE__) -> String {
     // Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
     return "\(fileName)".lastPathComponent.stringByDeletingPathExtension

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1080,9 +1080,9 @@ static int exception_count = 0;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 #if TARGET_IPHONE_SIMULATOR
-    NSString * const kDDXAttrArchivedName = @"archived";
+    static NSString * const kDDXAttrArchivedName = @"archived";
 #else
-    NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
+    static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 #endif
 
 @interface DDLogFileInfo () {

--- a/Classes/DDLegacyMacros.h
+++ b/Classes/DDLegacyMacros.h
@@ -18,6 +18,7 @@
  *
  * Imported by default when importing a DDLog.h directly and DD_LEGACY_MACROS is not defined and set to 0.
  **/
+#if DD_LEGACY_MACROS
 
 #warning CocoaLumberjack 1.9.x legacy macros enabled. \
 Disable legacy macros by importing CocoaLumberjack.h or DDLogMacros.h instead of DDLog.h or add `#define DD_LEGACY_MACROS 0` before importing DDLog.h.
@@ -71,3 +72,4 @@ Disable legacy macros by importing CocoaLumberjack.h or DDLogMacros.h instead of
 #define DDLogDebug(frmt, ...)   LOG_OBJC_MAYBE(LOG_ASYNC_DEBUG,   LOG_LEVEL_DEF, LOG_FLAG_DEBUG,   0, frmt, ##__VA_ARGS__)
 #define DDLogVerbose(frmt, ...) LOG_OBJC_MAYBE(LOG_ASYNC_VERBOSE, LOG_LEVEL_DEF, LOG_FLAG_VERBOSE, 0, frmt, ##__VA_ARGS__)
 
+#endif

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -19,9 +19,8 @@
 #ifndef DD_LEGACY_MACROS
     #define DD_LEGACY_MACROS 1
 #endif
-#if DD_LEGACY_MACROS
-    #import "DDLegacyMacros.h"
-#endif
+// DD_LEGACY_MACROS is checked in the file itself
+#import <CocoaLumberjack/DDLegacyMacros.h>
 
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -429,15 +429,15 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
     #define NS_DESIGNATED_INITIALIZER
 #endif
 
-/**
- * The DDLogMessage class encapsulates information about the log message.
- * If you write custom loggers or formatters, you will be dealing with objects of this class.
- **/
-
 typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
     DDLogMessageCopyFile     = 1 << 0,
     DDLogMessageCopyFunction = 1 << 1
 };
+
+/**
+ * The DDLogMessage class encapsulates information about the log message.
+ * If you write custom loggers or formatters, you will be dealing with objects of this class.
+ **/
 
 @interface DDLogMessage : NSObject <NSCopying>
 {

--- a/Classes/DDLogMacros.h
+++ b/Classes/DDLogMacros.h
@@ -24,11 +24,7 @@
  * The constant/variable/method responsible for controlling the current log level.
  **/
 #ifndef LOG_LEVEL_DEF
-    #ifdef ddLogLevel
-        #define LOG_LEVEL_DEF ddLogLevel
-    #else
-        #define LOG_LEVEL_DEF DDLogLevelVerbose
-    #endif
+    #define LOG_LEVEL_DEF ddLogLevel
 #endif
 
 /**

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -847,6 +847,7 @@ static DDTTYLogger *sharedInstance;
         BOOL processedAppName = [_appName getCString:_app maxLength:(_appLen + 1) encoding:NSUTF8StringEncoding];
 
         if (NO == processedAppName) {
+            free(_app);
             return nil;
         }
 
@@ -858,12 +859,15 @@ static DDTTYLogger *sharedInstance;
         _pid = (char *)malloc(_pidLen + 1);
 
         if (_pid == NULL) {
+            free(_app);
             return nil;
         }
 
         BOOL processedID = [_processID getCString:_pid maxLength:(_pidLen + 1) encoding:NSUTF8StringEncoding];
 
         if (NO == processedID) {
+            free(_app);
+            free(_pid);
             return nil;
         }
 

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -17,13 +17,13 @@ Pod::Spec.new do |s|
 
   s.requires_arc   = true
 
-  s.preserve_paths = 'README.md', 'Classes/CocoaLumberjack.{swift,modulemap}'
+  s.preserve_paths = 'README.md', 'Classes/CocoaLumberjack.swift', 'Framework/Lumberjack/CocoaLumberjack.modulemap'
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
   
   s.public_header_files = 'Classes/*.h'
   
-  s.module_map = 'Classes/CocoaLumberjack.modulemap'
+  s.module_map = 'Framework/Lumberjack/CocoaLumberjack.modulemap'
   s.default_subspecs = 'Default', 'Extensions'
 
   s.subspec 'Default' do |ss|
@@ -44,6 +44,12 @@ Pod::Spec.new do |s|
       ss.source_files = 'Classes/CLI/*.{h,m}'
       ss.dependency 'CocoaLumberjack/Default'
   end
+
+  s.subspec 'Swift' do |ss|
+      ss.ios.deployment_target = '8.0'
+      ss.osx.deployment_target = '10.10'
+      ss.source_files = 'Classes/CocoaLumberjack.swift'
+      ss.dependency 'CocoaLumberjack/Extensions'
+  end
   
 end
-

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name     = 'CocoaLumberjack'
-  s.version  = '2.0.0'
+  s.version  = '2.0.1'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'

--- a/Framework/Lumberjack/CocoaLumberjack.modulemap
+++ b/Framework/Lumberjack/CocoaLumberjack.modulemap
@@ -1,39 +1,36 @@
 framework module CocoaLumberjack {
 	umbrella header "CocoaLumberjack.h"
-
+	
 	export *
 	module * { export * }
 	
-	//Until Xcode adds support for textual headers
-	//textual header "DDLogMacros.h"
-	//We have to use config_macros and define ddLogLevel on the command line
-	config_macros ddLogLevel
+	textual header "DDLogMacros.h"
 	
 	exclude header "DDLog+LOGV.h"
 	exclude header "DDLegacyMacros.h"
-}
-
-explicit module CocoaLumberjack.DDContextFilterLogFormatter {
-	header "DDContextFilterLogFormatter.h"
-	export *
-}
-
-explicit module CocoaLumberjack.DDDispatchQueueLogFormatter {
-	header "DDDispatchQueueLogFormatter.h"
-	export *
-}
-
-explicit module CocoaLumberjack.DDMultiFormatter {
-	header "DDMultiFormatter.h"
-	export *
-}
-
-explicit module CocoaLumberjack.DDASLLogCapture {
-	header "DDASLLogCapture.h"
-	export *
-}
-
-explicit module CocoaLumberjack.DDAbstractDatabaseLogger {
-	header "DDAbstractDatabaseLogger.h"
-	export *
+	
+	explicit module DDContextFilterLogFormatter {
+		header "DDContextFilterLogFormatter.h"
+		export *
+	}
+	
+	explicit module DDDispatchQueueLogFormatter {
+		header "DDDispatchQueueLogFormatter.h"
+		export *
+	}
+	
+	explicit module DDMultiFormatter {
+		header "DDMultiFormatter.h"
+		export *
+	}
+	
+	explicit module DDASLLogCapture {
+		header "DDASLLogCapture.h"
+		export *
+	}
+	
+	explicit module DDAbstractDatabaseLogger {
+		header "DDAbstractDatabaseLogger.h"
+		export *
+	}
 }

--- a/Framework/Lumberjack/CocoaLumberjack.modulemap
+++ b/Framework/Lumberjack/CocoaLumberjack.modulemap
@@ -13,27 +13,27 @@ framework module CocoaLumberjack {
 	exclude header "DDLegacyMacros.h"
 }
 
-module CocoaLumberjack.DDContextFilterLogFormatter {
+explicit module CocoaLumberjack.DDContextFilterLogFormatter {
 	header "DDContextFilterLogFormatter.h"
 	export *
 }
 
-module CocoaLumberjack.DDDispatchQueueLogFormatter {
+explicit module CocoaLumberjack.DDDispatchQueueLogFormatter {
 	header "DDDispatchQueueLogFormatter.h"
 	export *
 }
 
-module CocoaLumberjack.DDMultiFormatter {
+explicit module CocoaLumberjack.DDMultiFormatter {
 	header "DDMultiFormatter.h"
 	export *
 }
 
-module CocoaLumberjack.DDASLLogCapture {
+explicit module CocoaLumberjack.DDASLLogCapture {
 	header "DDASLLogCapture.h"
 	export *
 }
 
-module CocoaLumberjack.DDAbstractDatabaseLogger {
+explicit module CocoaLumberjack.DDAbstractDatabaseLogger {
 	header "DDAbstractDatabaseLogger.h"
 	export *
 }

--- a/Framework/Lumberjack/CocoaLumberjackSwift.h
+++ b/Framework/Lumberjack/CocoaLumberjackSwift.h
@@ -1,0 +1,12 @@
+//
+//  CocoaLumberjackSwift.h
+//  Lumberjack
+//
+//  Created by C.W. Betts on 6/25/15.
+//
+//
+
+//This header is mostly blank because all of the declarations are in Swift.
+//Still, this header may still be needed so Swift doesn't complain when importing CocoaLumberjackSwift.
+
+#import <CocoaLumberjack/CocoaLumberjack.h>

--- a/Framework/Mobile/Lumberjack.xcodeproj/xcshareddata/xcschemes/LibTest.xcscheme
+++ b/Framework/Mobile/Lumberjack.xcodeproj/xcshareddata/xcschemes/LibTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -72,7 +72,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2A37F9D918E37536009FAAA7"
@@ -90,7 +91,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "2A37F9D918E37536009FAAA7"

--- a/Framework/SwiftTest/AppDelegate.swift
+++ b/Framework/SwiftTest/AppDelegate.swift
@@ -19,6 +19,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(aNotification: NSNotification) {
         DDLog.addLogger(DDTTYLogger.sharedInstance())
 		
+        defaultDebugLevel = .Warning
+
         DDLogVerbose("Verbose");
         DDLogInfo("Info");
         DDLogWarn("Warn");
@@ -30,6 +32,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DDLogInfo("Info");
         DDLogWarn("Warn");
         DDLogError("Error");
+        
+        defaultDebugLevel = .Off
         
         DDLogVerbose("Verbose", level: ourLogLevel);
         DDLogInfo("Info", level: ourLogLevel);

--- a/Framework/SwiftTest/AppDelegate.swift
+++ b/Framework/SwiftTest/AppDelegate.swift
@@ -16,7 +16,7 @@ let ourLogLevel = DDLogLevel.Verbose
 class AppDelegate: NSObject, NSApplicationDelegate {
 	@IBOutlet weak var window: NSWindow!
     
-	func applicationDidFinishLaunching(aNotification: NSNotification?) {
+	func applicationDidFinishLaunching(aNotification: NSNotification) {
         DDLog.addLogger(DDTTYLogger.sharedInstance())
 		
         DDLogVerbose("Verbose");
@@ -36,10 +36,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DDLogWarn("Warn", level: ourLogLevel);
         DDLogError("Error", level: ourLogLevel);
         
-        DDLogError("Error %i", level: ourLogLevel, args: 5);
+        DDLogError("Error \(5)", level: ourLogLevel);
     }
 
-	func applicationWillTerminate(aNotification: NSNotification?) {
+	func applicationWillTerminate(aNotification: NSNotification) {
 		// Insert code here to tear down your application
 	}
 }

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		18F3BF8C1A81DF5600692297 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BF192A0E0000AB7171 /* DDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF8D1A81DF5600692297 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CD192A0E0000AB7171 /* DDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF8E1A81DF5600692297 /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C7192A0E0000AB7171 /* DDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF8F1A81DF5600692297 /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; };
+		18F3BF8F1A81DF5600692297 /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF901A81DF5600692297 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF911A81DF5600692297 /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF921A81DF5600692297 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C8192A0E0000AB7171 /* DDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -60,6 +60,8 @@
 		5541B4161A5B5B9200A374A9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5541B4151A5B5B9200A374A9 /* InfoPlist.strings */; };
 		5541B4181A5B5C9A00A374A9 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5541B4171A5B5C9A00A374A9 /* MainMenu.xib */; };
 		5541B41E1A5B62FD00A374A9 /* CocoaLumberjack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		55C5F2891B1E39A700EBC776 /* CocoaLumberjackSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 18F3BF0F1A81D8B700692297 /* CocoaLumberjackSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		55C5F28A1B1E39EB00EBC776 /* CocoaLumberjack.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 18F3BFA71A81DF5600692297 /* CocoaLumberjack.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		55CCBF0619BA679200957A39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CCBF0519BA679200957A39 /* AppDelegate.swift */; };
 		55CCBF0819BA679200957A39 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55CCBF0719BA679200957A39 /* Images.xcassets */; };
 		55CCBF2019BA67CB00957A39 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
@@ -89,7 +91,7 @@
 		DCB318D814ED6C3B001CFBEE /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = DCB318D614ED6C3B001CFBEE /* Credits.rtf */; };
 		DCB318DB14ED6C3B001CFBEE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCB318DA14ED6C3B001CFBEE /* AppDelegate.m */; };
 		DCB318DE14ED6C3B001CFBEE /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCB318DC14ED6C3B001CFBEE /* MainMenu.xib */; };
-		E58079631A032F92008819CA /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; };
+		E58079631A032F92008819CA /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA81994749300C180CF /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA91994749300C180CF /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BAD199494B600C180CF /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
@@ -117,6 +119,13 @@
 			remoteGlobalIDString = 18F3BFA91A81DFA200692297;
 			remoteInfo = "CocoaLumberjackSwift-iOS";
 		};
+		55C5F2871B1E399100EBC776 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DCB3184714EB418D001CFBEE /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 18F3BEF61A81D8B700692297;
+			remoteInfo = CocoaLumberjackSwift;
+		};
 		DCB318E214ED6C43001CFBEE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DCB3184714EB418D001CFBEE /* Project object */;
@@ -133,6 +142,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				55C5F28A1B1E39EB00EBC776 /* CocoaLumberjack.framework in Embed Frameworks */,
 				18F3BFCF1A81DFEB00692297 /* CocoaLumberjackSwift.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -153,6 +163,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				55C5F2891B1E39A700EBC776 /* CocoaLumberjackSwift.framework in Embed Frameworks */,
 				5541B41E1A5B62FD00A374A9 /* CocoaLumberjack.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -680,6 +691,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				55C5F2881B1E399100EBC776 /* PBXTargetDependency */,
 			);
 			name = SwiftTest;
 			productName = SwiftTest;
@@ -960,6 +972,11 @@
 			target = 18F3BFA91A81DFA200692297 /* CocoaLumberjackSwift-iOS */;
 			targetProxy = 18F3BFD01A81DFEC00692297 /* PBXContainerItemProxy */;
 		};
+		55C5F2881B1E399100EBC776 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 18F3BEF61A81D8B700692297 /* CocoaLumberjackSwift */;
+			targetProxy = 55C5F2871B1E399100EBC776 /* PBXContainerItemProxy */;
+		};
 		DCB318E314ED6C43001CFBEE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DCB3185014EB418E001CFBEE /* CocoaLumberjack */;
@@ -1111,10 +1128,10 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Info.plist";
+				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack.modulemap";
+				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_NAME = CocoaLumberjack;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1138,10 +1155,10 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Info.plist";
+				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack.modulemap";
+				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_NAME = CocoaLumberjack;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -1337,6 +1354,7 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1382,6 +1400,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
@@ -1410,10 +1429,10 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Info.plist";
+				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack.modulemap";
+				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1437,10 +1456,10 @@
 				FRAMEWORK_VERSION = A;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Prefix.pch";
-				INFOPLIST_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack-Info.plist";
+				INFOPLIST_FILE = "Framework/Lumberjack/CocoaLumberjack-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "$(SRCROOT)/Framework/Lumberjack/CocoaLumberjack.modulemap";
+				MODULEMAP_FILE = Framework/Lumberjack/CocoaLumberjack.modulemap;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -7,22 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		18F3BEFA1A81D8B700692297 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CB192A0E0000AB7171 /* DDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BEFB1A81D8B700692297 /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BEFC1A81D8B700692297 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BF192A0E0000AB7171 /* DDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BEFD1A81D8B700692297 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CD192A0E0000AB7171 /* DDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BEFE1A81D8B700692297 /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C7192A0E0000AB7171 /* DDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BEFF1A81D8B700692297 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF001A81D8B700692297 /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF011A81D8B700692297 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C8192A0E0000AB7171 /* DDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF021A81D8B700692297 /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C5192A0E0000AB7171 /* DDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF031A81D8B700692297 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C1192A0E0000AB7171 /* DDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF041A81D8B700692297 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CF192A0E0000AB7171 /* DDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF061A81D8B700692297 /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C3192A0E0000AB7171 /* DDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF081A81D8B700692297 /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BCB5C619D4BB6E0096E784 /* CocoaLumberjack.swift */; };
 		18F3BF0A1A81D8B700692297 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
 		18F3BF161A81D9A400692297 /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 18F3BF151A81D9A400692297 /* CocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BF181A81D9A400692297 /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 18F3BF151A81D9A400692297 /* CocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BF641A81DD2E00692297 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F3BF631A81DD2E00692297 /* AppDelegate.swift */; };
 		18F3BF661A81DD2E00692297 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18F3BF651A81DD2E00692297 /* ViewController.swift */; };
 		18F3BF6B1A81DD2E00692297 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 18F3BF6A1A81DD2E00692297 /* Images.xcassets */; };
@@ -50,19 +37,6 @@
 		18F3BF9F1A81DF5600692297 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20D0192A0E0000AB7171 /* DDMultiFormatter.m */; };
 		18F3BFA01A81DF5600692297 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20BE192A0E0000AB7171 /* DDAbstractDatabaseLogger.m */; };
 		18F3BFA11A81DF5600692297 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20C2192A0E0000AB7171 /* DDASLLogger.m */; };
-		18F3BFAD1A81DFA200692297 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CB192A0E0000AB7171 /* DDContextFilterLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFAE1A81DFA200692297 /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = 18F3BF151A81D9A400692297 /* CocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFAF1A81DFA200692297 /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB01A81DFA200692297 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BF192A0E0000AB7171 /* DDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB11A81DFA200692297 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CD192A0E0000AB7171 /* DDDispatchQueueLogFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB21A81DFA200692297 /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C7192A0E0000AB7171 /* DDLog+LOGV.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB31A81DFA200692297 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB41A81DFA200692297 /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB51A81DFA200692297 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C8192A0E0000AB7171 /* DDTTYLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB61A81DFA200692297 /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C5192A0E0000AB7171 /* DDLog.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB71A81DFA200692297 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C1192A0E0000AB7171 /* DDASLLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB81A81DFA200692297 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20CF192A0E0000AB7171 /* DDMultiFormatter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		18F3BFB91A81DFA200692297 /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20C3192A0E0000AB7171 /* DDFileLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		18F3BFBB1A81DFA200692297 /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BCB5C619D4BB6E0096E784 /* CocoaLumberjack.swift */; };
 		18F3BFBD1A81DFA200692297 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
 		18F3BFCE1A81DFEB00692297 /* CocoaLumberjackSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18F3BFC21A81DFA200692297 /* CocoaLumberjackSwift.framework */; };
@@ -89,6 +63,8 @@
 		55CCBF0619BA679200957A39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CCBF0519BA679200957A39 /* AppDelegate.swift */; };
 		55CCBF0819BA679200957A39 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55CCBF0719BA679200957A39 /* Images.xcassets */; };
 		55CCBF2019BA67CB00957A39 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
+		55F88BF81B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		55F88BF91B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA9C20D1192A0E0000AB7171 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA9C20D2192A0E0000AB7171 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20BE192A0E0000AB7171 /* DDAbstractDatabaseLogger.m */; };
 		DA9C20D3192A0E0000AB7171 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = DA9C20BF192A0E0000AB7171 /* DDASLLogCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -214,6 +190,7 @@
 		55CCBF0219BA679200957A39 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55CCBF0519BA679200957A39 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		55CCBF0719BA679200957A39 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjackSwift.h; sourceTree = "<group>"; };
 		DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
 		DA9C20BE192A0E0000AB7171 /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
 		DA9C20BF192A0E0000AB7171 /* DDASLLogCapture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDASLLogCapture.h; sourceTree = "<group>"; };
@@ -488,6 +465,7 @@
 				555E014A19FACB600063F058 /* CocoaLumberjack.modulemap */,
 				DCB3186014EB418E001CFBEE /* CocoaLumberjack-Prefix.pch */,
 				E58078F91A01C92F008819CA /* CocoaLumberjackSwift-Info.plist */,
+				55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */,
 			);
 			name = "Supporting Files";
 			path = Framework/Lumberjack;
@@ -524,19 +502,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				18F3BEFA1A81D8B700692297 /* DDContextFilterLogFormatter.h in Headers */,
-				18F3BF181A81D9A400692297 /* CocoaLumberjack.h in Headers */,
-				18F3BEFB1A81D8B700692297 /* DDAssertMacros.h in Headers */,
-				18F3BEFC1A81D8B700692297 /* DDASLLogCapture.h in Headers */,
-				18F3BEFD1A81D8B700692297 /* DDDispatchQueueLogFormatter.h in Headers */,
-				18F3BEFE1A81D8B700692297 /* DDLog+LOGV.h in Headers */,
-				18F3BEFF1A81D8B700692297 /* DDAbstractDatabaseLogger.h in Headers */,
-				18F3BF001A81D8B700692297 /* DDLogMacros.h in Headers */,
-				18F3BF011A81D8B700692297 /* DDTTYLogger.h in Headers */,
-				18F3BF021A81D8B700692297 /* DDLog.h in Headers */,
-				18F3BF031A81D8B700692297 /* DDASLLogger.h in Headers */,
-				18F3BF041A81D8B700692297 /* DDMultiFormatter.h in Headers */,
-				18F3BF061A81D8B700692297 /* DDFileLogger.h in Headers */,
+				55F88BF81B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -565,19 +531,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				18F3BFAD1A81DFA200692297 /* DDContextFilterLogFormatter.h in Headers */,
-				18F3BFAE1A81DFA200692297 /* CocoaLumberjack.h in Headers */,
-				18F3BFAF1A81DFA200692297 /* DDAssertMacros.h in Headers */,
-				18F3BFB01A81DFA200692297 /* DDASLLogCapture.h in Headers */,
-				18F3BFB11A81DFA200692297 /* DDDispatchQueueLogFormatter.h in Headers */,
-				18F3BFB21A81DFA200692297 /* DDLog+LOGV.h in Headers */,
-				18F3BFB31A81DFA200692297 /* DDAbstractDatabaseLogger.h in Headers */,
-				18F3BFB41A81DFA200692297 /* DDLogMacros.h in Headers */,
-				18F3BFB51A81DFA200692297 /* DDTTYLogger.h in Headers */,
-				18F3BFB61A81DFA200692297 /* DDLog.h in Headers */,
-				18F3BFB71A81DFA200692297 /* DDASLLogger.h in Headers */,
-				18F3BFB81A81DFA200692297 /* DDMultiFormatter.h in Headers */,
-				18F3BFB91A81DFA200692297 /* DDFileLogger.h in Headers */,
+				55F88BF91B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1251,6 +1205,10 @@
 		18F3BFE91A81E06E00692297 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -1268,6 +1226,10 @@
 		18F3BFEA1A81E06E00692297 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = (
+					"$(ARCHS_STANDARD)",
+					armv7s,
+				);
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				ENABLE_NS_ASSERTIONS = NO;

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-iOS.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/FmwkTest.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/FmwkTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,7 +48,8 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DCB318C914ED6C3B001CFBEE"
@@ -66,7 +67,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DCB318C914ED6C3B001CFBEE"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/SwiftTest.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/SwiftTest.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 CocoaLumberjack
 ===============
-[![Build Status](http://img.shields.io/travis/CocoaLumberjack/CocoaLumberjack/master.svg?style=flat)](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack)
+[![Build Status](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack.svg)](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack)
 [![Pod Version](http://img.shields.io/cocoapods/v/CocoaLumberjack.svg?style=flat)](http://cocoadocs.org/docsets/CocoaLumberjack/)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Pod Platform](http://img.shields.io/cocoapods/p/CocoaLumberjack.svg?style=flat)](http://cocoadocs.org/docsets/CocoaLumberjack/)
 [![Pod License](http://img.shields.io/cocoapods/l/CocoaLumberjack.svg?style=flat)](http://opensource.org/licenses/BSD-3-Clause)
 [![Reference Status](https://www.versioneye.com/objective-c/cocoalumberjack/reference_badge.svg?style=flat)](https://www.versioneye.com/objective-c/cocoalumberjack/references)
@@ -29,7 +30,6 @@ pod 'CocoaLumberjack'
 #### Migrating to 2.x
 
 * Replace `DDLog.h` imports by `#import <CocoaLumberjack/CocoaLumberjack.h>`.
-* Using `ddLogLevel` to start using the library is now optional. If you define it add `#define LOG_LEVEL_DEF ddLogLevel` before `#import <CocoaLumberjack/CocoaLumberjack.h>` and make change its type to `DDLogLevel`
 
 Advanced users, third party libraries:
 

--- a/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */; };
 		6DC1C69BDFE9F353B9031B42 /* libPods-ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 817EFE4778751A16EFC482E2 /* libPods-ios.a */; };
 		E36E283FA66CB42E5B441755 /* libPods-osx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 359D6F3033BA9595543EAB1C /* libPods-osx.a */; };
+		E982AAF21AE2C25800088365 /* DDLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E982AAF11AE2C25800088365 /* DDLogTests.m */; };
+		E982AAF31AE2C25800088365 /* DDLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E982AAF11AE2C25800088365 /* DDLogTests.m */; };
+		E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */; };
+		E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +27,8 @@
 		817EFE4778751A16EFC482E2 /* libPods-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABA969AD38E11503DDCF9624 /* Pods-osx.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.release.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.release.xcconfig"; sourceTree = "<group>"; };
 		DA1B17371AB067EF004705E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E982AAF11AE2C25800088365 /* DDLogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLogTests.m; sourceTree = "<group>"; };
+		E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLogMessageTests.m; sourceTree = "<group>"; };
 		F04FA52AE01B89E56599B55E /* Pods-osx.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-osx.debug.xcconfig"; path = "Pods/Target Support Files/Pods-osx/Pods-osx.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -70,6 +76,8 @@
 			isa = PBXGroup;
 			children = (
 				432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */,
+				E982AAF11AE2C25800088365 /* DDLogTests.m */,
+				E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -255,6 +263,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E982AAF21AE2C25800088365 /* DDLogTests.m in Sources */,
+				E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534D1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -263,6 +273,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E982AAF31AE2C25800088365 /* DDLogTests.m in Sources */,
+				E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/CocoaLumberjack Tests.xcodeproj/xcshareddata/xcschemes/OS X Tests.xcscheme
+++ b/Tests/CocoaLumberjack Tests.xcodeproj/xcshareddata/xcschemes/OS X Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/CocoaLumberjack Tests.xcodeproj/xcshareddata/xcschemes/iOS Tests.xcscheme
+++ b/Tests/CocoaLumberjack Tests.xcodeproj/xcshareddata/xcschemes/iOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/Tests/DDLogMessageTests.m
+++ b/Tests/Tests/DDLogMessageTests.m
@@ -1,0 +1,234 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2014-2015, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+//
+//  Created by Pavel Kunc on 18/04/2015.
+//
+
+@import XCTest;
+#import <Expecta.h>
+#import "DDLog.h"
+
+static NSString * const kDefaultMessage = @"Log message";
+
+@interface DDLogMessage (TestHelpers)
++ (DDLogMessage *)test_message;
++ (DDLogMessage *)test_messageWithMessage:(NSString *)message;
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function options:(DDLogMessageOptions)options;
++ (DDLogMessage *)test_messageWithFile:(NSString *)file options:(DDLogMessageOptions)options;
+
+@end
+
+@implementation DDLogMessage (TestHelpers)
++ (DDLogMessage *)test_message {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithMessage:(NSString *)message {
+    return [[DDLogMessage alloc] initWithMessage:message
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithFunction:(NSString *)function
+                                   options:(DDLogMessageOptions)options {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:function
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:options
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithFile:(NSString *)file
+                               options:(DDLogMessageOptions)options {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:file
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:options
+                                       timestamp:nil];
+}
+
++ (DDLogMessage *)test_messageWithTimestamp:(NSDate *)timestamp {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:@(__func__)
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:timestamp];
+}
+
+@end
+
+
+@interface DDLogMessageTests : XCTestCase
+@property (nonatomic, strong, readwrite) DDLogMessage *message;
+@end
+
+@implementation DDLogMessageTests
+
+- (void)setUp {
+    [super setUp];
+    self.message = [DDLogMessage test_message];
+}
+
+- (void)tearDown {
+    [super tearDown];
+
+    self.message = nil;
+}
+
+#pragma mark - Message creation
+
+- (void)testInitSetsAllPassedParameters {
+    NSDate *referenceDate  = [NSDate dateWithTimeIntervalSince1970:0];
+    self.message =
+        [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                        level:DDLogLevelDebug
+                                         flag:DDLogFlagError
+                                      context:1
+                                         file:@"DDLogMessageTests.m"
+                                     function:@"testInitSetsAllPassedParameters"
+                                         line:50
+                                          tag:NULL
+                                         options:DDLogMessageCopyFile
+                                         timestamp:referenceDate];
+
+    expect(self.message.message).to.equal(@"Log message");
+    expect(self.message.level).to.equal(DDLogLevelDebug);
+    expect(self.message.flag).to.equal(DDLogFlagError);
+    expect(self.message.context).to.equal(1);
+    expect(self.message.file).to.equal(@"DDLogMessageTests.m");
+    expect(self.message.function).to.equal(@"testInitSetsAllPassedParameters");
+    expect(self.message.line).to.equal(50);
+    expect(self.message.tag).to.equal(NULL);
+    expect(self.message.options).to.equal(DDLogMessageCopyFile);
+    expect(self.message.timestamp).to.equal(referenceDate);
+}
+
+- (void)testInitCopyMessageParameter {
+    NSMutableString *message = [NSMutableString stringWithString:@"Log message"];
+    self.message = [DDLogMessage test_messageWithMessage:message];
+    [message appendString:@" changed"];
+    expect(self.message.message).to.equal(@"Log message");
+}
+
+- (void)testInitSetsCurrentDateToTimestampIfItIsNotProvided {
+    expect(fabs([self.message.timestamp timeIntervalSinceNow])).to.beLessThanOrEqualTo(5);
+}
+
+- (void)testInitSetsThreadIDToCurrentThreadID {
+    expect(self.message.threadID).notTo.beNil();
+}
+
+- (void)testInitSetsThreadNameToCurrentThreadName {
+    expect(self.message.threadName).to.equal(NSThread.currentThread.name);
+}
+
+- (void)testInitSetsFileNameToFilenameWithoutExtensionIfItHasExtension {
+    expect(self.message.fileName).to.equal(@"DDLogMessageTests");
+}
+
+- (void)testInitSetsFileNameToFilenameIfItHasNotExtension {
+    self.message = [DDLogMessage test_messageWithFile:@"no-extenstion" options:(DDLogMessageOptions)0];
+    expect(self.message.fileName).to.equal(@"no-extenstion");
+}
+
+//TODO: How to test this for different SDK versions? (pavel, Sat 18 Apr 15:35:46 2015)
+- (void)testInitSetsQueueLabelToQueueWeCurrentlyRun {
+    // We're running on main thread
+    expect(self.message.queueLabel).to.equal(@"com.apple.main-thread");
+}
+
+
+- (void)testInitAssignsFileParameterWithoutCopyFileOption {
+    NSMutableString *file = [NSMutableString stringWithString:@"file"];
+    self.message = [DDLogMessage test_messageWithFile:file options:(DDLogMessageOptions)0];
+    expect(self.message.file).to.equal(@"file");
+    [file appendString:@"file"];
+    expect(self.message.file).to.equal(@"filefile");
+}
+
+- (void)testInitCopyFileParameterWithCopyFileOption {
+    NSMutableString *file = [NSMutableString stringWithString:@"file"];
+    self.message = [DDLogMessage test_messageWithFile:file options:DDLogMessageCopyFile];
+    expect(self.message.file).to.equal(@"file");
+    [file appendString:@"file"];
+    expect(self.message.file).to.equal(@"file");
+}
+
+- (void)testInitAssignFunctionParameterWithoutCopyFunctionOption {
+    NSMutableString *function = [NSMutableString stringWithString:@"function"];
+    self.message = [DDLogMessage test_messageWithFunction:function options:(DDLogMessageOptions)0];
+    expect(self.message.function).to.equal(@"function");
+    [function appendString:@"function"];
+    expect(self.message.function).to.equal(@"functionfunction");
+}
+
+- (void)testInitCopyFunctionParameterWithCopyFunctionOption {
+    NSMutableString *function = [NSMutableString stringWithString:@"function"];
+    self.message = [DDLogMessage test_messageWithFunction:function options:DDLogMessageCopyFunction];
+    expect(self.message.function).to.equal(@"function");
+    [function appendString:@"function"];
+    expect(self.message.function).to.equal(@"function");
+}
+
+- (void)testCopyWithZoneCreatesValidCopy {
+    DDLogMessage *copy = [self.message copy];
+    expect(self.message.message).to.equal(copy.message);
+    expect(self.message.level).to.equal(copy.level);
+    expect(self.message.flag).to.equal(copy.flag);
+    expect(self.message.context).to.equal(copy.context);
+    expect(self.message.file).to.equal(copy.file);
+    expect(self.message.fileName).to.equal(copy.fileName);
+    expect(self.message.function).to.equal(copy.function);
+    expect(self.message.line).to.equal(copy.line);
+    expect(self.message.tag).to.equal(copy.tag);
+    expect(self.message.options).to.equal(copy.options);
+    expect(self.message.timestamp).to.equal(copy.timestamp);
+    expect(self.message.threadID).to.equal(copy.threadID);
+    expect(self.message.threadName).to.equal(copy.threadName);
+    expect(self.message.queueLabel).to.equal(copy.queueLabel);
+}
+
+@end

--- a/Tests/Tests/DDLogTests.m
+++ b/Tests/Tests/DDLogTests.m
@@ -1,0 +1,85 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2014-2015, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+//
+//  Created by Pavel Kunc on 18/04/2015.
+//
+
+@import XCTest;
+#import <Expecta.h>
+#import "DDLog.h"
+
+@interface DDTestLogger : NSObject <DDLogger>
+@end
+@implementation DDTestLogger
+@end
+
+@interface DDLogTests : XCTestCase
+@end
+
+
+// The fact thath the DDLog is initialized using +initialize makes it a bit
+// dificult to test as the state of the class might be hanging there when
+// test examples are run in parallel. Trying to reset the DDLog before & after
+// each test.
+@implementation DDLogTests
+
+- (void)setUp {
+    [DDLog removeAllLoggers];
+    [super setUp];
+}
+
+- (void)tearDown {
+    [DDLog removeAllLoggers];
+    [super tearDown];
+}
+
+
+#pragma mark - Logger management
+
+- (void)testAddLoggerAddsNewLoggerWithDDLogLevelAll {
+    DDTestLogger *logger = [DDTestLogger new];
+    [DDLog addLogger:logger];
+    expect([DDLog allLoggers]).haveACountOf(1);
+}
+
+- (void)testAddLoggerWithLevelAddLoggerWithSpecifiedLevelMask {
+    DDTestLogger *logger = [DDTestLogger new];
+    [DDLog addLogger:logger withLevel:DDLogLevelDebug | DDLogLevelError];
+    expect([DDLog allLoggers]).haveACountOf(1);
+}
+
+- (void)testRemoveLoggerRemovesExistingLogger {
+    DDTestLogger *logger = [DDTestLogger new];
+    [DDLog addLogger:logger];
+    [DDLog addLogger:[DDTestLogger new]];
+    [DDLog removeLogger:logger];
+    expect([DDLog allLoggers]).haveACountOf(1);
+    expect([[DDLog allLoggers] firstObject]).notTo.beIdenticalTo(logger);
+}
+
+- (void)testRemoveAllLoggersRemovesAllLoggers {
+    [DDLog addLogger:[DDTestLogger new]];
+    [DDLog addLogger:[DDTestLogger new]];
+    [DDLog removeAllLoggers];
+    expect([DDLog allLoggers]).to.beEmpty();
+}
+
+- (void)testAllLoggersReturnsAllLoggers {
+    [DDLog addLogger:[DDTestLogger new]];
+    [DDLog addLogger:[DDTestLogger new]];
+    expect([DDLog allLoggers]).haveACountOf(2);
+}
+
+@end


### PR DESCRIPTION
The following are fixes/enhancements to CocoaLumberjack for Swift 2.0/Xcode 7.

Notably, *DDLogMacros.h* can be set as a textual header, making defining custom macros for CocoaLumberjack, such as `ddLogLevel`, less troublesome.