### PR TITLE
Fix Xcode 7 beta3 "Cannot import module that is being compiled" error

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -14,7 +14,6 @@
 //   prior written permission of Deusty, LLC.
 
 import Foundation
-import CocoaLumberjack
 
 extension DDLogFlag {
     public static func fromLogLevel(logLevel: DDLogLevel) -> DDLogFlag {


### PR DESCRIPTION
# Xcode7-beta3
 * Error when using current head of swift_2.0 branch
 * "Cannot import module that is being compiled" ... which actually makes sense compared to most swift xcode errors
 * Simply remove the import line