### PR TITLE
Extend ignore unused warning pragma to cover all platforms

### DIFF
--- a/Classes/DDTTYLogger.h
+++ b/Classes/DDTTYLogger.h
@@ -37,14 +37,13 @@
 
 #define LOG_CONTEXT_ALL INT_MAX
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 #if TARGET_OS_IPHONE
     // iOS
     #import <UIKit/UIColor.h>
     typedef UIColor DDColor;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
     static  DDColor* DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
-#pragma clang diagnostic pop
 #elif __has_include(<AppKit/NSColor.h>)
     // OS X with AppKit
     #import <AppKit/NSColor.h>
@@ -56,6 +55,7 @@
     typedef CLIColor DDColor;
     static  DDColor* DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
 #endif
+#pragma clang diagnostic pop
 
 @interface DDTTYLogger : DDAbstractLogger <DDLogger>
 


### PR DESCRIPTION
This PR adds to the recently merged #553 to include OS X as well as iOS.  It silences an unnecessary warning for those who build with additional warnings enabled.