### PR TITLE
Fix import for when CL framework files are manually imported into project

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -20,7 +20,7 @@
     #define DD_LEGACY_MACROS 1
 #endif
 // DD_LEGACY_MACROS is checked in the file itself
-#import <CocoaLumberjack/DDLegacyMacros.h>
+#import "DDLegacyMacros.h"
 
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong


### PR DESCRIPTION
Referencing issue #558, this PR changes one import when manually importing CocoaLumberjack files into your Xcode project. The fix was suggested by @robotive.

For those that use them, it would be important to confirm it doesn't spoil integration with CocoaPods and Swift.  (I don't use either yet, so am not confident to verify this).