### PR TITLE
Using Xcode 6.4 image on Travis-CI for Swift 1.2 environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 
+osx_image: beta-xcode6.3
 language: objective-c
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 
-osx_image: beta-xcode6.3
+osx_image: xcode6.4
 language: objective-c
 
 before_install:


### PR DESCRIPTION
This will help to test Swift 1.2 codes.