### PR TITLE
Fix for the warning "Method override for the designated initializer of the superclass '-init' not found"

### DIFF
--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -341,6 +341,7 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 + (instancetype)logFileWithPath:(NSString *)filePath;
 
+- (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithFilePath:(NSString *)filePath NS_DESIGNATED_INITIALIZER;
 
 - (void)reset;

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1122,6 +1122,10 @@ static int exception_count = 0;
     return [[self alloc] initWithFilePath:aFilePath];
 }
 
+- (instancetype)init {
+    @throw nil;
+}
+
 - (instancetype)initWithFilePath:(NSString *)aFilePath {
     if ((self = [super init])) {
         filePath = [aFilePath copy];

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -459,6 +459,8 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
     NSString *_queueLabel;
 }
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  * Standard init method for a log message object.
  * Used by the logging primitives. (And the macros use the logging primitives.)

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -910,6 +910,10 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy) {
 
 #endif /* if TARGET_OS_IPHONE */
 
+- (instancetype)init {
+    @throw nil;
+}
+
 - (instancetype)initWithMessage:(NSString *)message
                           level:(DDLogLevel)level
                            flag:(DDLogFlag)flag


### PR DESCRIPTION
Fixes a new warning on Xcode 7 about designated initializers.