### PR TITLE
Silence the Xcode 7 upgrade check.

### DIFF
--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -740,6 +740,7 @@
 		DCB3184714EB418D001CFBEE /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0630;
 				TargetAttributes = {
 					18F3BF5E1A81DD2E00692297 = {


### PR DESCRIPTION
Let Xcode 7 run its Swift upgrade check so it doesn't keep modifying the project.