### PR TITLE
Make build work on tvOS

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -140,15 +140,20 @@ static NSUInteger _numProcessors;
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
 
+        NSUInteger one    = (NSUInteger)1;
+        NSUInteger result = one;
+#if TARGET_OS_TV
+        if ([NSProcessInfo class]) {
+            result = [[NSProcessInfo processInfo] activeProcessorCount];
+        }
+#else
         host_basic_info_data_t hostInfo;
         mach_msg_type_number_t infoCount;
 
         infoCount = HOST_BASIC_INFO_COUNT;
         host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t)&hostInfo, &infoCount);
-
-        NSUInteger result = (NSUInteger)hostInfo.max_cpus;
-        NSUInteger one    = (NSUInteger)1;
-
+        result = (NSUInteger)hostInfo.max_cpus;
+#endif
         _numProcessors = MAX(result, one);
 
         NSLogDebug(@"DDLog: numProcessors = %@", @(_numProcessors));

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -142,10 +142,8 @@ static NSUInteger _numProcessors;
 
         NSUInteger one    = (NSUInteger)1;
         NSUInteger result = one;
-#if TARGET_OS_TV
-        if ([NSProcessInfo class]) {
-            result = [[NSProcessInfo processInfo] activeProcessorCount];
-        }
+#if TARGET_OS_IPHONE || TARGET_OS_TV
+        result = [[NSProcessInfo processInfo] activeProcessorCount];
 #else
         host_basic_info_data_t hostInfo;
         mach_msg_type_number_t infoCount;

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -139,19 +139,14 @@ static NSUInteger _numProcessors;
 
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
-
+        
         NSUInteger one    = (NSUInteger)1;
         NSUInteger result = one;
-#if TARGET_OS_IPHONE || TARGET_OS_TV
-        result = [[NSProcessInfo processInfo] activeProcessorCount];
-#else
-        host_basic_info_data_t hostInfo;
-        mach_msg_type_number_t infoCount;
-
-        infoCount = HOST_BASIC_INFO_COUNT;
-        host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t)&hostInfo, &infoCount);
-        result = (NSUInteger)hostInfo.max_cpus;
-#endif
+        
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        if ([processInfo respondsToSelector:@selector(processorCount)]) {
+            result = processInfo.processorCount;
+        }
         _numProcessors = MAX(result, one);
 
         NSLogDebug(@"DDLog: numProcessors = %@", @(_numProcessors));


### PR DESCRIPTION
tvOS will not support `host_info()` anymore. At the same time it will support `[[NSProcessInfo processInfo] activeProcessorCount]` so this can be used instead.