### PR TITLE
Remove redundant check for processorCount availability

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -141,12 +141,7 @@ static NSUInteger _numProcessors;
         // This may be used later for an optimization on uniprocessor machines.
         
         NSUInteger one    = (NSUInteger)1;
-        NSUInteger result = one;
-        
-        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
-        if ([processInfo respondsToSelector:@selector(processorCount)]) {
-            result = processInfo.processorCount;
-        }
+        NSUInteger result = [NSProcessInfo processInfo].processorCount;
         _numProcessors = MAX(result, one);
 
         NSLogDebug(@"DDLog: numProcessors = %@", @(_numProcessors));

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -139,10 +139,7 @@ static NSUInteger _numProcessors;
 
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
-        
-        NSUInteger one    = (NSUInteger)1;
-        NSUInteger result = [NSProcessInfo processInfo].processorCount;
-        _numProcessors = MAX(result, one);
+        _numProcessors = MAX([NSProcessInfo processInfo].processorCount, 1);
 
         NSLogDebug(@"DDLog: numProcessors = %@", @(_numProcessors));
 


### PR DESCRIPTION
As pointed out in #597 the check whether `processorCount` is available is not necessary anymore since min version for OS X is 10.7 and all other platforms supported it from the start.