### PR TITLE
Merge master back into swift_2.0

### DIFF
--- a/Classes/DDASLLogger.h
+++ b/Classes/DDASLLogger.h
@@ -32,7 +32,7 @@ extern const char* const kDDASLDDLogValue;
  * This class provides a logger for the Apple System Log facility.
  *
  * As described in the "Getting Started" page,
- * the traditional NSLog() function directs it's output to two places:
+ * the traditional NSLog() function directs its output to two places:
  *
  * - Apple System Log
  * - StdErr (if stderr is a TTY) so log statements show up in Xcode console

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -31,13 +31,15 @@
 // So we use primitive logging macros around NSLog.
 // We maintain the NS prefix on the macros to be explicit about the fact that we're using NSLog.
 
-#define LOG_LEVEL 2
+#ifndef DD_NSLOG_LEVEL
+    #define DD_NSLOG_LEVEL 2
+#endif
 
-#define NSLogError(frmt, ...)    do{ if(LOG_LEVEL >= 1) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogWarn(frmt, ...)     do{ if(LOG_LEVEL >= 2) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogInfo(frmt, ...)     do{ if(LOG_LEVEL >= 3) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogDebug(frmt, ...)    do{ if(LOG_LEVEL >= 4) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogVerbose(frmt, ...)  do{ if(LOG_LEVEL >= 5) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogError(frmt, ...)    do{ if(DD_NSLOG_LEVEL >= 1) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogWarn(frmt, ...)     do{ if(DD_NSLOG_LEVEL >= 2) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogInfo(frmt, ...)     do{ if(DD_NSLOG_LEVEL >= 3) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogDebug(frmt, ...)    do{ if(DD_NSLOG_LEVEL >= 4) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogVerbose(frmt, ...)  do{ if(DD_NSLOG_LEVEL >= 5) NSLog((frmt), ##__VA_ARGS__); } while(0)
 
 
 #if TARGET_OS_IPHONE
@@ -830,7 +832,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
             [self rollLogFileNow];
 
             if (completionBlock) {
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                     completionBlock();
                 });
             }
@@ -1428,7 +1430,7 @@ static int exception_count = 0;
     if (result < 0) {
         NSLogError(@"DDLogFileInfo: setxattr(%@, %@): error = %s",
                    attrName,
-                   self.fileName,
+                   filePath,
                    strerror(errno));
     }
 }

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -20,7 +20,7 @@
     #define DD_LEGACY_MACROS 1
 #endif
 // DD_LEGACY_MACROS is checked in the file itself
-#import <CocoaLumberjack/DDLegacyMacros.h>
+#import "DDLegacyMacros.h"
 
 #if OS_OBJECT_USE_OBJC
     #define DISPATCH_QUEUE_REFERENCE_TYPE strong
@@ -157,7 +157,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * It is suggested you stick with the macros as they're easier to use.
  **/
 
-+ (void)log:(BOOL)synchronous
++ (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
     context:(NSInteger)context
@@ -484,7 +484,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions) {
                            line:(NSUInteger)line
                             tag:(id)tag
                         options:(DDLogMessageOptions)options
-                      timestamp:(NSDate *)timestamp NS_DESIGNATED_INITIALIZER;
+                      timestamp:(NSDate *)timestamp;
 
 /**
  * Read-only properties

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -42,7 +42,9 @@
 // So we use a primitive logging macro around NSLog.
 // We maintain the NS prefix on the macros to be explicit about the fact that we're using NSLog.
 
-#define DD_DEBUG NO
+#ifndef DD_DEBUG
+    #define DD_DEBUG NO
+#endif
 
 #define NSLogDebug(frmt, ...) do{ if(DD_DEBUG) NSLog((frmt), ##__VA_ARGS__); } while(0)
 
@@ -143,16 +145,14 @@ static NSUInteger _numProcessors;
 #else
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
-
-        host_basic_info_data_t hostInfo;
-        mach_msg_type_number_t infoCount;
-
-        infoCount = HOST_BASIC_INFO_COUNT;
-        host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t)&hostInfo, &infoCount);
-
-        NSUInteger result = (NSUInteger)hostInfo.max_cpus;
+        
         NSUInteger one    = (NSUInteger)1;
-
+        NSUInteger result = one;
+        
+        NSProcessInfo *processInfo = [NSProcessInfo processInfo];
+        if ([processInfo respondsToSelector:@selector(processorCount)]) {
+            result = processInfo.processorCount;
+        }
         _numProcessors = MAX(result, one);
 #endif
 
@@ -203,7 +203,7 @@ static NSUInteger _numProcessors;
 #pragma mark Notifications
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (void)applicationWillTerminate:(NSNotification *)notification {
++ (void)applicationWillTerminate:(NSNotification * __attribute__((unused)))notification {
     [self flushLog];
 }
 
@@ -988,7 +988,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy) {
     return self;
 }
 
-- (id)copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone * __attribute__((unused)))zone {
     DDLogMessage *newMessage = [DDLogMessage new];
     
     newMessage->_message = _message;
@@ -1061,7 +1061,7 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy) {
     #endif
 }
 
-- (void)logMessage:(DDLogMessage *)logMessage {
+- (void)logMessage:(DDLogMessage * __attribute__((unused)))logMessage {
     // Override me
 }
 

--- a/Classes/DDTTYLogger.h
+++ b/Classes/DDTTYLogger.h
@@ -37,6 +37,8 @@
 
 #define LOG_CONTEXT_ALL INT_MAX
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 #if TARGET_OS_IPHONE
     // iOS
     #import <UIKit/UIColor.h>
@@ -53,6 +55,7 @@
     typedef CLIColor DDColor;
     static  DDColor* DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
 #endif
+#pragma clang diagnostic pop
 
 @interface DDTTYLogger : DDAbstractLogger <DDLogger>
 

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -29,13 +29,15 @@
 // So we use primitive logging macros around NSLog.
 // We maintain the NS prefix on the macros to be explicit about the fact that we're using NSLog.
 
-#define LOG_LEVEL 2
+#ifndef DD_NSLOG_LEVEL
+    #define DD_NSLOG_LEVEL 2
+#endif
 
-#define NSLogError(frmt, ...)    do{ if(LOG_LEVEL >= 1) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogWarn(frmt, ...)     do{ if(LOG_LEVEL >= 2) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogInfo(frmt, ...)     do{ if(LOG_LEVEL >= 3) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogDebug(frmt, ...)    do{ if(LOG_LEVEL >= 4) NSLog((frmt), ##__VA_ARGS__); } while(0)
-#define NSLogVerbose(frmt, ...)  do{ if(LOG_LEVEL >= 5) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogError(frmt, ...)    do{ if(DD_NSLOG_LEVEL >= 1) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogWarn(frmt, ...)     do{ if(DD_NSLOG_LEVEL >= 2) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogInfo(frmt, ...)     do{ if(DD_NSLOG_LEVEL >= 3) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogDebug(frmt, ...)    do{ if(DD_NSLOG_LEVEL >= 4) NSLog((frmt), ##__VA_ARGS__); } while(0)
+#define NSLogVerbose(frmt, ...)  do{ if(DD_NSLOG_LEVEL >= 5) NSLog((frmt), ##__VA_ARGS__); } while(0)
 
 // Xcode does NOT natively support colors in the Xcode debugging console.
 // You'll need to install the XcodeColors plugin to see colors in the Xcode console.

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -94,7 +94,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (NSString *)stringFromDate:(NSDate *)date {
-    int32_t loggerCount = OSAtomicAdd32(0, &_atomicLoggerCount);
+    int32_t loggerCount = OSAtomicAdd32(1, &_atomicLoggerCount);
 
     NSString *calendarIdentifier = nil;
 
@@ -236,11 +236,11 @@
     return [NSString stringWithFormat:@"%@ [%@] %@", timestamp, queueThreadLabel, logMessage->_message];
 }
 
-- (void)didAddToLogger:(id <DDLogger>)logger {
+- (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
     OSAtomicIncrement32(&_atomicLoggerCount);
 }
 
-- (void)willRemoveFromLogger:(id <DDLogger>)logger {
+- (void)willRemoveFromLogger:(id <DDLogger> __attribute__((unused)))logger {
     OSAtomicDecrement32(&_atomicLoggerCount);
 }
 

--- a/Documentation/CustomFormatters.md
+++ b/Documentation/CustomFormatters.md
@@ -92,7 +92,7 @@ MyCustomFormatter.m
 
 # Thread-safety (simple)
 
-Let's update our example formatter to also include the timestamp. To do this we'll use `NSDateFormatter`. But... `NSDateFormatter` is NOT thread-safe. Does this pose any problems for us?
+Let's update our example formatter to also include the timestamp. To do this we'll use `NSDateFormatter`. But... `NSDateFormatter` is NOT thread-safe (unless you're targeting iOS 7+, or OSX 10.9+ with modern behavior on 64-bit architecture, see [NSDateFormatter](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSDateFormatter_Class/])). Does this pose any problems for us?
 
 Log formatters are applied individually to loggers. If you instantiate a log formatter instance, **and apply it to a single logger**, then you don't have to worry about thread-safety. All log messages are sent to the logger (and thus to its log formatter) via the serial dispatch queue of the logger. Thus, in this scenario, the formatLogMessage method is guaranteed to run on only a single thread at a time.
 

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -59,6 +59,16 @@ fileLogger.logFileManager.maximumNumberOfLogFiles = 7;
 
 The above code tells the application to keep a week's worth of log files on the system.
 
+You will also need to set a global log level for your application. This can be modified in different manners later (see the bottom of this document for more information).
+
+To do this, simply define the `ddLogLevel` constant. One example of this may be in your .pch file like so:
+
+```objective-c
+static const int ddLogLevel = DDLogLevelDebug;
+```
+
+This global log level will be used as a default unless stated otherwise. See below for possible levels you can set this to.
+
 ### Convert your NSLog statements to DDLog
 
 The DDLog header file defines the macros that you will use to replace your NSLog statements. Essentially they look like this:

--- a/Documentation/XcodeTricks.md
+++ b/Documentation/XcodeTricks.md
@@ -52,7 +52,7 @@ Your project settings should look like this:
 
 <a href="http://www.flickr.com/photos/100714763@N06/9575920131/" title="CocoaLumberjack_xcode2 by robbiehanson, on Flickr"><img src="http://farm4.staticflickr.com/3808/9575920131_52625d8f01_o.png" width="653" height="673" alt="CocoaLumberjack_xcode2"></a>
 
-And that's all there is to it. You're done!\
+And that's all there is to it. You're done!
 
 And this isn't limited to just logging.
 You can use the `#ifdef CONFIGURATION_DEBUG` anywhere you want in your project if you feel the need to differentiate something between your debug and release builds.

--- a/Framework/Mobile/Lumberjack.xcodeproj/project.pbxproj
+++ b/Framework/Mobile/Lumberjack.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		2A37F9E618E37536009FAAA7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F9E518E37536009FAAA7 /* main.m */; };
 		2A37F9EA18E37536009FAAA7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F9E918E37536009FAAA7 /* AppDelegate.m */; };
 		2A37F9F318E37536009FAAA7 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A37F9F218E37536009FAAA7 /* ViewController.m */; };
-		2A37F9F518E37536009FAAA7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2A37F9F418E37536009FAAA7 /* Images.xcassets */; };
 		2A37FA0F18E375D8009FAAA7 /* libCocoaLumberjack.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2A37F97718E37270009FAAA7 /* libCocoaLumberjack.a */; };
 		DA9C209B192A04E100AB7171 /* Formatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C209A192A04E100AB7171 /* Formatter.m */; };
 		DA9C20B0192A0CB500AB7171 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C209D192A0CB500AB7171 /* DDAbstractDatabaseLogger.m */; };
@@ -26,6 +25,7 @@
 		DA9C20B6192A0CB500AB7171 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20AB192A0CB500AB7171 /* DDContextFilterLogFormatter.m */; };
 		DA9C20B7192A0CB500AB7171 /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20AD192A0CB500AB7171 /* DDDispatchQueueLogFormatter.m */; };
 		DA9C20B8192A0CB500AB7171 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = DA9C20AF192A0CB500AB7171 /* DDMultiFormatter.m */; };
+		DF2CD19D1B4C336D00D7F66B /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = DF2CD19C1B4C336D00D7F66B /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5CEB3721994971500EDC36E /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BAA199474A900C180CF /* CocoaLumberjack.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5CEB3731994971500EDC36E /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BAC199474A900C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5CEB3741994971500EDC36E /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BAB199474A900C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -66,7 +66,6 @@
 		2A37F9E918E37536009FAAA7 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		2A37F9F118E37536009FAAA7 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		2A37F9F218E37536009FAAA7 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
-		2A37F9F418E37536009FAAA7 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		2A37F9FB18E37536009FAAA7 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		55CCBEF719BA64B200957A39 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = InfoPlist.strings; sourceTree = "<group>"; };
 		55CCBEF819BA64B200957A39 /* Lumberjack-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Lumberjack-Info.plist"; path = "../../Desktop/Lumberjack/Lumberjack-Info.plist"; sourceTree = "<group>"; };
@@ -91,6 +90,7 @@
 		DA9C20AD192A0CB500AB7171 /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
 		DA9C20AE192A0CB500AB7171 /* DDMultiFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDMultiFormatter.h; sourceTree = "<group>"; };
 		DA9C20AF192A0CB500AB7171 /* DDMultiFormatter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDMultiFormatter.m; sourceTree = "<group>"; };
+		DF2CD19C1B4C336D00D7F66B /* DDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLegacyMacros.h; sourceTree = "<group>"; };
 		E5D89BAA199474A900C180CF /* CocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjack.h; sourceTree = "<group>"; };
 		E5D89BAB199474A900C180CF /* DDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAssertMacros.h; sourceTree = "<group>"; };
 		E5D89BAC199474A900C180CF /* DDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLogMacros.h; sourceTree = "<group>"; };
@@ -146,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				E5D89BAA199474A900C180CF /* CocoaLumberjack.h */,
+				DF2CD19C1B4C336D00D7F66B /* DDLegacyMacros.h */,
 				E5D89BAC199474A900C180CF /* DDLogMacros.h */,
 				E5D89BAB199474A900C180CF /* DDAssertMacros.h */,
 				DA9C20A6192A0CB500AB7171 /* DDLog+LOGV.h */,
@@ -188,7 +189,6 @@
 				2A37F9E918E37536009FAAA7 /* AppDelegate.m */,
 				2A37F9F118E37536009FAAA7 /* ViewController.h */,
 				2A37F9F218E37536009FAAA7 /* ViewController.m */,
-				2A37F9F418E37536009FAAA7 /* Images.xcassets */,
 				2A37F9E018E37536009FAAA7 /* Supporting Files */,
 			);
 			path = LibTest;
@@ -240,8 +240,9 @@
 				E5CEB3771994971500EDC36E /* DDASLLogCapture.h in Headers */,
 				E5CEB3781994971500EDC36E /* DDASLLogger.h in Headers */,
 				E5CEB3791994971500EDC36E /* DDFileLogger.h in Headers */,
-				E5CEB37A1994971500EDC36E /* DDLog.h in Headers */,
 				E5CEB37B1994971500EDC36E /* DDTTYLogger.h in Headers */,
+				E5CEB37A1994971500EDC36E /* DDLog.h in Headers */,
+				DF2CD19D1B4C336D00D7F66B /* DDLegacyMacros.h in Headers */,
 				E5CEB37C1994971500EDC36E /* DDContextFilterLogFormatter.h in Headers */,
 				E5CEB37D1994971500EDC36E /* DDDispatchQueueLogFormatter.h in Headers */,
 				E5CEB37E1994971500EDC36E /* DDMultiFormatter.h in Headers */,
@@ -316,7 +317,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2A37F9F518E37536009FAAA7 /* Images.xcassets in Resources */,
 				2A37F9E418E37536009FAAA7 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -1414,6 +1414,7 @@
 		18F3BF0D1A81D8B700692297 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -1440,6 +1441,7 @@
 		18F3BF0E1A81D8B700692297 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -1753,6 +1755,7 @@
 		19FF46071B8B4CF400B43179 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1776,6 +1779,7 @@
 		19FF46081B8B4CF400B43179 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1799,6 +1803,7 @@
 		19FF46191B8B4D1400B43179 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1821,6 +1826,7 @@
 		19FF461A1B8B4D1400B43179 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1969,6 +1975,7 @@
 		DCB3186714EB418E001CFBEE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -1995,6 +2002,7 @@
 		DCB3186814EB418E001CFBEE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -2123,6 +2131,7 @@
 				19FF46081B8B4CF400B43179 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		19FF46181B8B4D1400B43179 /* Build configuration list for PBXNativeTarget "CocoaLumberjackSwift-iOS" */ = {
 			isa = XCConfigurationList;
@@ -2131,6 +2140,7 @@
 				19FF461A1B8B4D1400B43179 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		55CCBF1C19BA679200957A39 /* Build configuration list for PBXNativeTarget "SwiftTest" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Conflicts:
- .travis.yml
  Resolved by choosing the version from the swift_2.0 branch that requires the
  xcode7 build environment.

- Classes/DDFileLogger.h
  Resolved by choosing the changes from 58ae948 by sinoru over changes from
  b765caf by stephencelis.
  See discussion on issue #592

- Lumberjack.xcodeproj/project.pbxproj
  Resolved by choosing the version from the swift_2.0 branch and manually
  redoing what was done in 9f41918.

  Since it was branched off master, there have been three new commits modifying
  the project file:

  - f1cd4b8 Make CocoaLumberjackSwift-iOS Target depend on CocoaLumberjack-iOS

    Similar change was done when re-adding CocoaLumberjackSwift-iOS
    target again (after it had been removed) in fa57e49

  - 9f41918 Mark CocoaLumberjack dynamic libraries as Require Only App-Extension-Safe API

    Manually applied changes again in GUI after choosing project file from
    swift_2.0 branch. Switched the 'Require Only App-Extension-Safe API' to
    'Yes' on CocoaLumberjack, CocoaLumberjackSwift, CocoaLumberjack-iOS and
    CocoaLumberjackSwift-iOS targets.
    CocoaLumberjack(Swift)-watchOS targets already had this option set.

  - 96b1dfd Silence the Xcode 7 upgrade check.

    Similar change was done in aee07079