### PR TITLE
Fix CI failures

### DIFF
--- a/Tests/Tests/DDBasicLoggingTests.m
+++ b/Tests/Tests/DDBasicLoggingTests.m
@@ -52,8 +52,7 @@ DDLogLevel ddLogLevel = DDLogLevelVerbose;
             
             strongSelf.noOfMessagesLogged++;
             
-            // NOTE: this method is called twice for every log (the second time if for getting the obj param)
-            if (strongSelf.noOfMessagesLogged == 2 * [strongSelf.logs count]) {
+            if (strongSelf.noOfMessagesLogged == [strongSelf.logs count]) {
                 [self.expectation fulfill];
             }
             


### PR DESCRIPTION
### Force CocoaPods 0.39 or higher `[REVERTED]`
This cocoapods version is currently only available as a pre-release (in the release-candidate stadium).
It fixes CocoaPods/CocoaPods#4103 and is needed to successfully lint pods with watchOS support.

### Fix test failure in DDBasicLoggingTests
There was a comment, in line 55 indicating that the block would be called twice
for every log. Appearantly this isn't the case anymore.

Note: I do not fully understand what is going on there and why the behavior seems to have changed.
I only observed the current behavior to be that the block is called exactly once for every log.

@bpoplauschi please double check this commit