### PR TITLE
Fix NSDateFormatter issues

### DIFF
--- a/Classes/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.h
@@ -24,6 +24,11 @@
 #import "DDLog.h"
 
 
+typedef NS_OPTIONS(NSUInteger, DDDispatchQueueLogFormatterOptions) {
+    DDDispatchQueueLogFormatterShareable = 1 << 0,
+};
+
+
 /**
  * This class provides a log formatter that prints the dispatch_queue label instead of the mach_thread_id.
  *
@@ -68,6 +73,8 @@
  * Configure using properties as desired.
  **/
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithOptions:(DDDispatchQueueLogFormatterOptions)options;
 
 /**
  * The minQueueLength restricts the minimum size of the [detail box].

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.h
@@ -135,6 +135,7 @@ typedef NS_OPTIONS(NSUInteger, DDDispatchQueueLogFormatterOptions) {
  **/
 @interface DDDispatchQueueLogFormatter (OverridableMethods)
 
+- (void)configureDateFormatter:(NSDateFormatter *)dateFormatter;
 - (NSString *)stringFromDate:(NSDate *)date;
 - (NSString *)queueThreadLabelForLogMessage:(DDLogMessage *)logMessage;
 - (NSString *)formatLogMessage:(DDLogMessage *)logMessage;

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.h
@@ -24,8 +24,9 @@
 #import "DDLog.h"
 
 
-typedef NS_OPTIONS(NSUInteger, DDDispatchQueueLogFormatterOptions) {
-    DDDispatchQueueLogFormatterShareable = 1 << 0,
+typedef NS_ENUM(NSUInteger, DDDispatchQueueLogFormatterMode) {
+    DDDispatchQueueLogFormatterModeShareble = 0,
+    DDDispatchQueueLogFormatterModeNonShareble,
 };
 
 
@@ -74,7 +75,7 @@ typedef NS_OPTIONS(NSUInteger, DDDispatchQueueLogFormatterOptions) {
  **/
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithOptions:(DDDispatchQueueLogFormatterOptions)options;
+- (instancetype)initWithMode:(DDDispatchQueueLogFormatterMode)mode;
 
 /**
  * The minQueueLength restricts the minimum size of the [detail box].

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -48,14 +48,12 @@
         // We need to carefully pick the name for storing in thread dictionary to not
         // use a formatter configured by subclass and avoid surprises.
         Class cls = [self class];
+        Class superClass = class_getSuperclass(cls);
         SEL configMethodName = @selector(configureDateFormatter:);
         Method configMethod = class_getInstanceMethod(cls, configMethodName);
-        for (;;) {
-            Class superCls = class_getSuperclass(cls);
-            Method m = class_getInstanceMethod(superCls, configMethodName);
-            if (configMethod != m)
-                break;
-            cls = superCls;
+        while (class_getInstanceMethod(superClass, configMethodName) == configMethod) {
+            cls = superClass;
+            superClass = class_getSuperclass(cls);
         }
         // now `cls` is the class that provides implementation for `configureDateFormatter:`
         _dateFormatterKey = [NSString stringWithFormat:@"%s_NSDateFormatter", class_getName(cls)];

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -126,6 +126,7 @@
 - (void)configureDateFormatter:(NSDateFormatter *)dateFormatter {
     [dateFormatter setFormatterBehavior:NSDateFormatterBehavior10_4];
     [dateFormatter setDateFormat:@"yyyy-MM-dd HH:mm:ss:SSS"];
+    [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
 
     NSString *calendarIdentifier = nil;
 #if defined(__IPHONE_8_0) || defined(__MAC_10_10)

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -265,7 +265,8 @@
 }
 
 - (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
-    int32_t count = OSAtomicIncrement32(&_atomicLoggerCount);
+    int32_t count = 0;
+    count = OSAtomicIncrement32(&_atomicLoggerCount);
     NSAssert(count <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
 }
 

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -23,7 +23,7 @@
 #endif
 
 @interface DDDispatchQueueLogFormatter () {
-    DDDispatchQueueLogFormatterOptions _options;
+    DDDispatchQueueLogFormatterMode _mode;
     NSString *_dateFormatterKey;
     
     int32_t _atomicLoggerCount;
@@ -43,7 +43,7 @@
 
 - (instancetype)init {
     if ((self = [super init])) {
-        _options = DDDispatchQueueLogFormatterShareable;
+        _mode = DDDispatchQueueLogFormatterModeShareble;
 
         // We need to carefully pick the name for storing in thread dictionary to not
         // use a formatter configured by subclass and avoid surprises.
@@ -75,9 +75,9 @@
     return self;
 }
 
-- (instancetype)initWithOptions:(DDDispatchQueueLogFormatterOptions)options {
+- (instancetype)initWithMode:(DDDispatchQueueLogFormatterMode)mode {
     if ((self = [self init])) {
-        _options = options;
+        _mode = mode;
     }
     return self;
 }
@@ -141,7 +141,7 @@
 - (NSString *)stringFromDate:(NSDate *)date {
 
     NSDateFormatter *dateFormatter = nil;
-    if ((_options & DDDispatchQueueLogFormatterShareable) == 0) {
+    if (_mode == DDDispatchQueueLogFormatterModeNonShareble) {
         // Single-threaded mode.
 
         dateFormatter = _threadUnsafeDateFormatter;
@@ -268,7 +268,7 @@
 
 - (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
     int32_t count = OSAtomicIncrement32(&_atomicLoggerCount);
-    NSAssert(count <= 1 || (_options & DDDispatchQueueLogFormatterShareable) != 0, @"Can't reuse formatter with multiple loggers in single-threaded mode.");
+    NSAssert(count <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
 }
 
 - (void)willRemoveFromLogger:(id <DDLogger> __attribute__((unused)))logger {


### PR DESCRIPTION
Attempt to solve crashes in NSDateFormatter still observed in the wild.
Stop using so-called "hybrid approach" when implementation tries to determine in runtime what NSDateFormatter instance to use: the shared one or retrieved from thread dictionary. Now a library user must decide if thread-safe but more expensive behaviour is desired (default) or simple storing date formatter in ivar is sufficient (suitable for using formatter with a single logger).

A few more minor tweaks:
- make simple customisations (like changing date format) easy by exposing a method to configure used NSDateFormatter instance
- set date formatter's calendar once instead of doing that each time a log message is formatted
- use POSIX locale to have consistent timestamp. For example, currently on devices with Arabian regional settings you'll see digits that you've probably never seen before.