### PR TITLE
Explicitly name master branch in Travis icon url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CocoaLumberjack
 ===============
-[![Build Status](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack.svg)](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack)
+[![Build Status](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack.svg?branch=master)](https://travis-ci.org/CocoaLumberjack/CocoaLumberjack)
 [![Pod Version](http://img.shields.io/cocoapods/v/CocoaLumberjack.svg?style=flat)](http://cocoadocs.org/docsets/CocoaLumberjack/)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Pod Platform](http://img.shields.io/cocoapods/p/CocoaLumberjack.svg?style=flat)](http://cocoadocs.org/docsets/CocoaLumberjack/)


### PR DESCRIPTION
For some reason, when not giving a branch, Travis CI currently seems to return
the icon for the build status of the `tvOS_Xcode_7.1` branch.
This shows a "failing" icon on the masters Readme.

I think this is a bug in Travis CI, that can be worked around by adding
a branch=master parameter to the svg url