### PR TITLE
fix bug: When log file rolling so fast (set maximumFileSize 100), fil…

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -59,6 +59,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     NSUInteger _maximumNumberOfLogFiles;
     unsigned long long _logFilesDiskQuota;
     NSString *_logsDirectory;
+    NSDate* _lastLogFileCreateDate;
 #if TARGET_OS_IPHONE
     NSString *_defaultFileProtectionLevel;
 #endif
@@ -433,6 +434,28 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     return [NSString stringWithFormat:@"%@ %@.log", appName, formattedDate];
 }
 
+- (void)modifyLogFileCreateDateIfNeed:(NSString *)filePath
+{
+    NSDate* fileCreateDate = [NSDate date];
+    if (_lastLogFileCreateDate == nil) {
+        DDLogFileInfo *logFileInfo = [self sortedLogFileInfos].firstObject;
+        if (logFileInfo) {
+            _lastLogFileCreateDate = logFileInfo.creationDate;
+        }
+    }
+    if (_lastLogFileCreateDate && (int)_lastLogFileCreateDate.timeIntervalSince1970 >= (int)fileCreateDate.timeIntervalSince1970) {
+        fileCreateDate = [_lastLogFileCreateDate dateByAddingTimeInterval:1];
+    }
+    NSDictionary* attr = [NSDictionary dictionaryWithObjectsAndKeys:fileCreateDate, NSFileModificationDate, fileCreateDate, NSFileCreationDate, NULL];
+    NSError* error = nil;
+    [[NSFileManager defaultManager] setAttributes:attr ofItemAtPath:filePath error:&error];
+    if (error) {
+        NSLogError(@"DDLogFileInfo: Error modify log file create date %@", error);
+    } else {
+        _lastLogFileCreateDate = fileCreateDate;
+    }
+}
+
 - (NSString *)createNewLogFile {
     NSString *fileName = [self newLogFileName];
     NSString *logsDirectory = [self logsDirectory];
@@ -477,6 +500,11 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 
             [[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:attributes];
 
+            // When log file rolling so fast, log file's create date may be same, so sorting log files is not reliable
+            // Eventually leading to the newly created file out, immediately deleted (by deleteOldLogFiles function below)
+            // The workaround is to control file creation time interval of 1 second, because ios file system is not accurate to the millisecond
+            [self modifyLogFileCreateDateIfNeed:filePath];
+            
             // Since we just created a new log file, we may need to delete some old log files
             [self deleteOldLogFiles];
 


### PR DESCRIPTION
…e create date may be same, may be leading to the newly created log file will be deleted

case:
fileLogger.maximumFileSize = 100;  // very small
fileLogger.rollingFrequency = 0;
fileLogger.logFileManager.maximumNumberOfLogFiles = 1;

you can add assert like following:
![image](https://cloud.githubusercontent.com/assets/15702091/11993224/8890d282-aa69-11e5-9354-ba79432805a1.png)

file log rolled very fast, lead to the same file creation time, sorting is not reliable.
may be leading to the newly created log file will be deleted
