### PR TITLE
DDLog usable via instances

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -54,33 +54,33 @@ public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Verbose
 }
 
-public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String) {
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String, ddlog: DDLog = DDLog.sharedInstance()) {
     if level.rawValue & flg.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
         // Using string interpolation to prevent integer overflow warning when using StaticString.stringValue
         let logMessage = DDLogMessage(message: string(), level: level, flag: flg, context: context, file: "\(file)", function: "\(function)", line: line, tag: tag, options: [.CopyFile, .CopyFunction], timestamp: nil)
-        DDLog.log(isAsynchronous, message: logMessage)
+        ddlog.log(isAsynchronous, message: logMessage)
     }
 }
 
-public func DDLogDebug(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Debug, context: context, file: file, function: function, line: line, tag: tag, string: logText)
+public func DDLogDebug(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    SwiftLogMacro(async, level: level, flag: .Debug, context: context, file: file, function: function, line: line, tag: tag, string: logText, ddlog: ddlog)
 }
 
-public func DDLogInfo(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Info, context: context, file: file, function: function, line: line, tag: tag, string: logText)
+public func DDLogInfo(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    SwiftLogMacro(async, level: level, flag: .Info, context: context, file: file, function: function, line: line, tag: tag, string: logText, ddlog: ddlog)
 }
 
-public func DDLogWarn(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Warning, context: context, file: file, function: function, line: line, tag: tag, string: logText)
+public func DDLogWarn(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    SwiftLogMacro(async, level: level, flag: .Warning, context: context, file: file, function: function, line: line, tag: tag, string: logText, ddlog: ddlog)
 }
 
-public func DDLogVerbose(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true) {
-    SwiftLogMacro(async, level: level, flag: .Verbose, context: context, file: file, function: function, line: line, tag: tag, string: logText)
+public func DDLogVerbose(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    SwiftLogMacro(async, level: level, flag: .Verbose, context: context, file: file, function: function, line: line, tag: tag, string: logText, ddlog: ddlog)
 }
 
-public func DDLogError(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = false) {
-    SwiftLogMacro(async, level: level, flag: .Error, context: context, file: file, function: function, line: line, tag: tag, string: logText)
+public func DDLogError(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance()) {
+    SwiftLogMacro(async, level: level, flag: .Error, context: context, file: file, function: function, line: line, tag: tag, string: logText, ddlog: ddlog)
 }
 
 /// Analogous to the C preprocessor macro `THIS_FILE`.

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -206,6 +206,14 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 @interface DDLog : NSObject
 
 /**
+ *  Returns the singleton `DDLog`.
+ *  The instance is used by `DDLog` class methods.
+ *
+ *  @return The singleton `DDLog`.
+ */
++ (instancetype)sharedInstance;
+
+/**
  * Provides access to the underlying logging queue.
  * This may be helpful to Logger classes for things like thread synchronization.
  **/
@@ -228,6 +236,32 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  *  @param format       the log format
  */
 + (void)log:(BOOL)asynchronous
+      level:(DDLogLevel)level
+       flag:(DDLogFlag)flag
+    context:(NSInteger)context
+       file:(const char *)file
+   function:(const char *)function
+       line:(NSUInteger)line
+        tag:(id)tag
+     format:(NSString *)format, ... NS_FORMAT_FUNCTION(9,10);
+
+/**
+ * Logging Primitive.
+ *
+ * This method is used by the macros or logging functions.
+ * It is suggested you stick with the macros as they're easier to use.
+ *
+ *  @param asynchronous YES if the logging is done async, NO if you want to force sync
+ *  @param level        the log level
+ *  @param flag         the log flag
+ *  @param context      the context (if any is defined)
+ *  @param file         the current file
+ *  @param function     the current function
+ *  @param line         the current code line
+ *  @param tag          potential tag
+ *  @param format       the log format
+ */
+- (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
     context:(NSInteger)context
@@ -266,10 +300,12 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
        args:(va_list)argList;
 
 /**
- *  Logging Primitive.
+ * Logging Primitive.
+ *
+ * This method can be used if you have a prepared va_list.
+ * Similar to `log:level:flag:context:file:function:line:tag:format:...`
  *
  *  @param asynchronous YES if the logging is done async, NO if you want to force sync
- *  @param message      the message
  *  @param level        the log level
  *  @param flag         the log flag
  *  @param context      the context (if any is defined)
@@ -277,16 +313,19 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  *  @param function     the current function
  *  @param line         the current code line
  *  @param tag          potential tag
+ *  @param format       the log format
+ *  @param argList      the arguments list as a va_list
  */
-+ (void)log:(BOOL)asynchronous
-    message:(NSString *)message
+- (void)log:(BOOL)asynchronous
       level:(DDLogLevel)level
        flag:(DDLogFlag)flag
     context:(NSInteger)context
        file:(const char *)file
    function:(const char *)function
        line:(NSUInteger)line
-        tag:(id)tag;
+        tag:(id)tag
+     format:(NSString *)format
+       args:(va_list)argList;
 
 /**
  * Logging Primitive.
@@ -300,10 +339,27 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
     message:(DDLogMessage *)logMessage;
 
 /**
+ * Logging Primitive.
+ *
+ * This method can be used if you manualy prepared DDLogMessage.
+ *
+ *  @param asynchronous YES if the logging is done async, NO if you want to force sync
+ *  @param logMessage   the log message stored in a `DDLogMessage` model object
+ */
+- (void)log:(BOOL)asynchronous
+    message:(DDLogMessage *)logMessage;
+
+/**
  * Since logging can be asynchronous, there may be times when you want to flush the logs.
  * The framework invokes this automatically when the application quits.
  **/
 + (void)flushLog;
+
+/**
+ * Since logging can be asynchronous, there may be times when you want to flush the logs.
+ * The framework invokes this automatically when the application quits.
+ **/
+- (void)flushLog;
 
 /**
  * Loggers
@@ -321,6 +377,13 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * This is equivalent to invoking `[DDLog addLogger:logger withLogLevel:DDLogLevelAll]`.
  **/
 + (void)addLogger:(id <DDLogger>)logger;
+
+/**
+ * Adds the logger to the system.
+ *
+ * This is equivalent to invoking `[DDLog addLogger:logger withLogLevel:DDLogLevelAll]`.
+ **/
+- (void)addLogger:(id <DDLogger>)logger;
 
 /**
  * Adds the logger to the system.
@@ -361,9 +424,52 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 + (void)addLogger:(id <DDLogger>)logger withLevel:(DDLogLevel)level;
 
 /**
+ * Adds the logger to the system.
+ *
+ * The level that you provide here is a preemptive filter (for performance).
+ * That is, the level specified here will be used to filter out logMessages so that
+ * the logger is never even invoked for the messages.
+ *
+ * More information:
+ * When you issue a log statement, the logging framework iterates over each logger,
+ * and checks to see if it should forward the logMessage to the logger.
+ * This check is done using the level parameter passed to this method.
+ *
+ * For example:
+ *
+ * `[DDLog addLogger:consoleLogger withLogLevel:DDLogLevelVerbose];`
+ * `[DDLog addLogger:fileLogger    withLogLevel:DDLogLevelWarning];`
+ *
+ * `DDLogError(@"oh no");` => gets forwarded to consoleLogger & fileLogger
+ * `DDLogInfo(@"hi");`     => gets forwarded to consoleLogger only
+ *
+ * It is important to remember that Lumberjack uses a BITMASK.
+ * Many developers & third party frameworks may define extra log levels & flags.
+ * For example:
+ *
+ * `#define SOME_FRAMEWORK_LOG_FLAG_TRACE (1 << 6) // 0...1000000`
+ *
+ * So if you specify `DDLogLevelVerbose` to this method, you won't see the framework's trace messages.
+ *
+ * `(SOME_FRAMEWORK_LOG_FLAG_TRACE & DDLogLevelVerbose) => (01000000 & 00011111) => NO`
+ *
+ * Consider passing `DDLogLevelAll` to this method, which has all bits set.
+ * You can also use the exclusive-or bitwise operator to get a bitmask that has all flags set,
+ * except the ones you explicitly don't want. For example, if you wanted everything except verbose & debug:
+ *
+ * `((DDLogLevelAll ^ DDLogLevelVerbose) | DDLogLevelInfo)`
+ **/
+- (void)addLogger:(id <DDLogger>)logger withLevel:(DDLogLevel)level;
+
+/**
  *  Remove the logger from the system
  */
 + (void)removeLogger:(id <DDLogger>)logger;
+
+/**
+ *  Remove the logger from the system
+ */
+- (void)removeLogger:(id <DDLogger>)logger;
 
 /**
  *  Remove all the current loggers
@@ -371,9 +477,19 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 + (void)removeAllLoggers;
 
 /**
+ *  Remove all the current loggers
+ */
+- (void)removeAllLoggers;
+
+/**
  *  Return all the current loggers
  */
 + (NSArray *)allLoggers;
+
+/**
+ *  Return all the current loggers
+ */
+- (NSArray *)allLoggers;
 
 /**
  * Registered Dynamic Logging

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -93,11 +93,15 @@ static void *const GlobalLoggingQueueIdentityKey = (void *)&GlobalLoggingQueueId
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@implementation DDLog
+@interface DDLog ()
 
 // An array used to manage all the individual loggers.
 // The array is only modified on the loggingQueue/loggingThread.
-static NSMutableArray *_loggers;
+@property (nonatomic, strong) NSMutableArray *_loggers;
+
+@end
+
+@implementation DDLog
 
 // All logging statements are added to the same queue to ensure FIFO operation.
 static dispatch_queue_t _loggingQueue;
@@ -114,6 +118,23 @@ static dispatch_semaphore_t _queueSemaphore;
 static NSUInteger _numProcessors;
 
 /**
+ *  Returns the singleton `DDLog`.
+ *  The instance is used by `DDLog` class methods.
+ *
+ *  @return The singleton `DDLog`.
+ */
++ (instancetype)sharedInstance {
+    static id sharedInstance = nil;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+    });
+    
+    return sharedInstance;
+}
+
+/**
  * The runtime sends initialize to each class in a program exactly one time just before the class,
  * or any class that inherits from it, is sent its first message from within the program. (Thus the
  * method may never be invoked if the class is not used.) The runtime sends the initialize message to
@@ -123,42 +144,53 @@ static NSUInteger _numProcessors;
  **/
 + (void)initialize {
     static dispatch_once_t DDLogOnceToken;
-
+    
     dispatch_once(&DDLogOnceToken, ^{
-        _loggers = [[NSMutableArray alloc] initWithCapacity:4];
-
         NSLogDebug(@"DDLog: Using grand central dispatch");
-
+        
         _loggingQueue = dispatch_queue_create("cocoa.lumberjack", NULL);
         _loggingGroup = dispatch_group_create();
-
+        
         void *nonNullValue = GlobalLoggingQueueIdentityKey; // Whatever, just not null
         dispatch_queue_set_specific(_loggingQueue, GlobalLoggingQueueIdentityKey, nonNullValue, NULL);
-
+        
         _queueSemaphore = dispatch_semaphore_create(LOG_MAX_QUEUE_SIZE);
-
+        
         // Figure out how many processors are available.
         // This may be used later for an optimization on uniprocessor machines.
         
         _numProcessors = MAX([NSProcessInfo processInfo].processorCount, 1);
-
+        
         NSLogDebug(@"DDLog: numProcessors = %@", @(_numProcessors));
+    });
+}
 
-
+/**
+ *  The `DDLog` initializer.
+ *  Static variables are set only once.
+ *
+ *  @return An initialized `DDLog` instance.
+ */
+- (id)init {
+    self = [super init];
+    
+    if (self) {
+        self._loggers = [[NSMutableArray alloc] initWithCapacity:4];
+        
 #if TARGET_OS_IOS
         NSString *notificationName = @"UIApplicationWillTerminateNotification";
 #else
         NSString *notificationName = nil;
-
+        
         // On Command Line Tool apps AppKit may not be avaliable
 #ifdef NSAppKitVersionNumber10_0
-
+        
         if (NSApp) {
             notificationName = @"NSApplicationWillTerminateNotification";
         }
-
+        
 #endif
-
+        
         if (!notificationName) {
             // If there is no NSApp -> we are running Command Line Tool app.
             // In this case terminate notification wouldn't be fired, so we use workaround.
@@ -166,16 +198,18 @@ static NSUInteger _numProcessors;
                 [self applicationWillTerminate:nil];
             });
         }
-
+        
 #endif /* if TARGET_OS_IOS */
-
+        
         if (notificationName) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(applicationWillTerminate:)
                                                          name:notificationName
                                                        object:nil];
         }
-    });
+    }
+    
+    return self;
 }
 
 /**
@@ -189,7 +223,7 @@ static NSUInteger _numProcessors;
 #pragma mark Notifications
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (void)applicationWillTerminate:(NSNotification * __attribute__((unused)))notification {
+- (void)applicationWillTerminate:(NSNotification * __attribute__((unused)))notification {
     [self flushLog];
 }
 
@@ -198,42 +232,62 @@ static NSUInteger _numProcessors;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 + (void)addLogger:(id <DDLogger>)logger {
+    [self.sharedInstance addLogger:logger];
+}
+
+- (void)addLogger:(id <DDLogger>)logger {
     [self addLogger:logger withLevel:DDLogLevelAll]; // DDLogLevelAll has all bits set
 }
 
 + (void)addLogger:(id <DDLogger>)logger withLevel:(DDLogLevel)level {
+    [self.sharedInstance addLogger:logger withLevel:level];
+}
+
+- (void)addLogger:(id <DDLogger>)logger withLevel:(DDLogLevel)level {
     if (!logger) {
         return;
     }
-
+    
     dispatch_async(_loggingQueue, ^{ @autoreleasepool {
-                                        [self lt_addLogger:logger level:level];
-                                    } });
+        [self lt_addLogger:logger level:level];
+    } });
 }
 
 + (void)removeLogger:(id <DDLogger>)logger {
+    [self.sharedInstance removeLogger:logger];
+}
+
+- (void)removeLogger:(id <DDLogger>)logger {
     if (!logger) {
         return;
     }
-
+    
     dispatch_async(_loggingQueue, ^{ @autoreleasepool {
-                                        [self lt_removeLogger:logger];
-                                    } });
+        [self lt_removeLogger:logger];
+    } });
 }
 
 + (void)removeAllLoggers {
+    [self.sharedInstance removeAllLoggers];
+}
+
+- (void)removeAllLoggers {
     dispatch_async(_loggingQueue, ^{ @autoreleasepool {
-                                        [self lt_removeAllLoggers];
-                                    } });
+        [self lt_removeAllLoggers];
+    } });
 }
 
 + (NSArray *)allLoggers {
+    return [self.sharedInstance allLoggers];
+}
+
+- (NSArray *)allLoggers {
     __block NSArray *theLoggers;
-
+    
     dispatch_sync(_loggingQueue, ^{ @autoreleasepool {
-                                       theLoggers = [self lt_allLoggers];
-                                   } });
-
+        theLoggers = [self lt_allLoggers];
+    } });
+    
     return theLoggers;
 }
 
@@ -241,7 +295,7 @@ static NSUInteger _numProcessors;
 #pragma mark - Master Logging
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (void)queueLogMessage:(DDLogMessage *)logMessage asynchronously:(BOOL)asyncFlag {
+- (void)queueLogMessage:(DDLogMessage *)logMessage asynchronously:(BOOL)asyncFlag {
     // We have a tricky situation here...
     //
     // In the common case, when the queueSize is below the maximumQueueSize,
@@ -322,7 +376,36 @@ static NSUInteger _numProcessors;
          function:function
              line:line
               tag:tag];
+        
+        va_end(args);
+    }
+}
 
+- (void)log:(BOOL)asynchronous
+      level:(DDLogLevel)level
+       flag:(DDLogFlag)flag
+    context:(NSInteger)context
+       file:(const char *)file
+   function:(const char *)function
+       line:(NSUInteger)line
+        tag:(id)tag
+     format:(NSString *)format, ... {
+    va_list args;
+    
+    if (format) {
+        va_start(args, format);
+        
+        NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+        [self log:asynchronous
+          message:message
+            level:level
+             flag:flag
+          context:context
+             file:file
+         function:function
+             line:line
+              tag:tag];
+        
         va_end(args);
     }
 }
@@ -337,7 +420,19 @@ static NSUInteger _numProcessors;
         tag:(id)tag
      format:(NSString *)format
        args:(va_list)args {
-    
+    [self.sharedInstance log:asynchronous level:level flag:flag context:context file:file function:function line:line tag:tag format:format args:args];
+}
+
+- (void)log:(BOOL)asynchronous
+      level:(DDLogLevel)level
+       flag:(DDLogFlag)flag
+    context:(NSInteger)context
+       file:(const char *)file
+   function:(const char *)function
+       line:(NSUInteger)line
+        tag:(id)tag
+     format:(NSString *)format
+       args:(va_list)args {
     if (format) {
         NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
         [self log:asynchronous
@@ -361,7 +456,18 @@ static NSUInteger _numProcessors;
    function:(const char *)function
        line:(NSUInteger)line
         tag:(id)tag {
-    
+    [self.sharedInstance log:asynchronous message:message level:level flag:flag context:context file:file function:function line:line tag:tag];
+}
+
+- (void)log:(BOOL)asynchronous
+    message:(NSString *)message
+      level:(DDLogLevel)level
+       flag:(DDLogFlag)flag
+    context:(NSInteger)context
+       file:(const char *)file
+   function:(const char *)function
+       line:(NSUInteger)line
+        tag:(id)tag {
     DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message
                                                                level:level
                                                                 flag:flag
@@ -378,13 +484,22 @@ static NSUInteger _numProcessors;
 
 + (void)log:(BOOL)asynchronous
     message:(DDLogMessage *)logMessage {
+    [self.sharedInstance log:asynchronous message:logMessage];
+}
+
+- (void)log:(BOOL)asynchronous
+    message:(DDLogMessage *)logMessage {
     [self queueLogMessage:logMessage asynchronously:asynchronous];
 }
 
 + (void)flushLog {
+    [self.sharedInstance flushLog];
+}
+
+- (void)flushLog {
     dispatch_sync(_loggingQueue, ^{ @autoreleasepool {
-                                       [self lt_flush];
-                                   } });
+        [self lt_flush];
+    } });
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -547,7 +662,7 @@ static NSUInteger _numProcessors;
 #pragma mark Logging Thread
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-+ (void)lt_addLogger:(id <DDLogger>)logger level:(DDLogLevel)level {
+- (void)lt_addLogger:(id <DDLogger>)logger level:(DDLogLevel)level {
     // Add to loggers array.
     // Need to create loggerQueue if loggerNode doesn't provide one.
 
@@ -576,7 +691,7 @@ static NSUInteger _numProcessors;
     }
 
     DDLoggerNode *loggerNode = [DDLoggerNode nodeWithLogger:logger loggerQueue:loggerQueue level:level];
-    [_loggers addObject:loggerNode];
+    [self._loggers addObject:loggerNode];
 
     if ([logger respondsToSelector:@selector(didAddLogger)]) {
         dispatch_async(loggerNode->_loggerQueue, ^{ @autoreleasepool {
@@ -585,7 +700,7 @@ static NSUInteger _numProcessors;
     }
 }
 
-+ (void)lt_removeLogger:(id <DDLogger>)logger {
+- (void)lt_removeLogger:(id <DDLogger>)logger {
     // Find associated loggerNode in list of added loggers
 
     NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
@@ -593,7 +708,7 @@ static NSUInteger _numProcessors;
 
     DDLoggerNode *loggerNode = nil;
 
-    for (DDLoggerNode *node in _loggers) {
+    for (DDLoggerNode *node in self._loggers) {
         if (node->_logger == logger) {
             loggerNode = node;
             break;
@@ -613,15 +728,15 @@ static NSUInteger _numProcessors;
     }
     
     // Remove from loggers array
-    [_loggers removeObject:loggerNode];
+    [self._loggers removeObject:loggerNode];
 }
 
-+ (void)lt_removeAllLoggers {
+- (void)lt_removeAllLoggers {
     NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
              @"This method should only be run on the logging thread/queue");
     
     // Notify all loggers
-    for (DDLoggerNode *loggerNode in _loggers) {
+    for (DDLoggerNode *loggerNode in self._loggers) {
         if ([loggerNode->_logger respondsToSelector:@selector(willRemoveLogger)]) {
             dispatch_async(loggerNode->_loggerQueue, ^{ @autoreleasepool {
                 [loggerNode->_logger willRemoveLogger];
@@ -631,23 +746,23 @@ static NSUInteger _numProcessors;
     
     // Remove all loggers from array
 
-    [_loggers removeAllObjects];
+    [self._loggers removeAllObjects];
 }
 
-+ (NSArray *)lt_allLoggers {
+- (NSArray *)lt_allLoggers {
     NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
              @"This method should only be run on the logging thread/queue");
 
     NSMutableArray *theLoggers = [NSMutableArray new];
 
-    for (DDLoggerNode *loggerNode in _loggers) {
+    for (DDLoggerNode *loggerNode in self._loggers) {
         [theLoggers addObject:loggerNode->_logger];
     }
 
     return [theLoggers copy];
 }
 
-+ (void)lt_log:(DDLogMessage *)logMessage {
+- (void)lt_log:(DDLogMessage *)logMessage {
     // Execute the given log message on each of our loggers.
 
     NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
@@ -661,7 +776,7 @@ static NSUInteger _numProcessors;
         // The waiting ensures that a slow logger doesn't end up with a large queue of pending log messages.
         // This would defeat the purpose of the efforts we made earlier to restrict the max queue size.
 
-        for (DDLoggerNode *loggerNode in _loggers) {
+        for (DDLoggerNode *loggerNode in self._loggers) {
             // skip the loggers that shouldn't write this message based on the log level
 
             if (!(logMessage->_flag & loggerNode->_level)) {
@@ -677,7 +792,7 @@ static NSUInteger _numProcessors;
     } else {
         // Execute each logger serialy, each within its own queue.
         
-        for (DDLoggerNode *loggerNode in _loggers) {
+        for (DDLoggerNode *loggerNode in self._loggers) {
             // skip the loggers that shouldn't write this message based on the log level
 
             if (!(logMessage->_flag & loggerNode->_level)) {
@@ -707,7 +822,7 @@ static NSUInteger _numProcessors;
     dispatch_semaphore_signal(_queueSemaphore);
 }
 
-+ (void)lt_flush {
+- (void)lt_flush {
     // All log statements issued before the flush method was invoked have now been executed.
     //
     // Now we need to propogate the flush request to any loggers that implement the flush method.
@@ -716,7 +831,7 @@ static NSUInteger _numProcessors;
     NSAssert(dispatch_get_specific(GlobalLoggingQueueIdentityKey),
              @"This method should only be run on the logging thread/queue");
     
-    for (DDLoggerNode *loggerNode in _loggers) {
+    for (DDLoggerNode *loggerNode in self._loggers) {
         if ([loggerNode->_logger respondsToSelector:@selector(flush)]) {
             dispatch_group_async(_loggingGroup, loggerNode->_loggerQueue, ^{ @autoreleasepool {
                 [loggerNode->_logger flush];

--- a/Classes/DDLogMacros.h
+++ b/Classes/DDLogMacros.h
@@ -35,11 +35,22 @@
 #endif
 
 /**
- * This is the single macro that all other macros below compile into.
- * This big multiline macro makes all the other macros easier to read.
+ * These are the two macros that all other macros below compile into.
+ * These big multiline macros makes all the other macros easier to read.
  **/
 #define LOG_MACRO(isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, ...) \
         [DDLog log : isAsynchronous                                     \
+             level : lvl                                                \
+              flag : flg                                                \
+           context : ctx                                                \
+              file : __FILE__                                           \
+          function : fnct                                               \
+              line : __LINE__                                           \
+               tag : atag                                               \
+            format : (frmt), ## __VA_ARGS__]
+
+#define LOG_MACRO_TO_DDLOG(ddlog, isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, ...) \
+        [ddlog log : isAsynchronous                                     \
              level : lvl                                                \
               flag : flg                                                \
            context : ctx                                                \
@@ -71,6 +82,9 @@
 #define LOG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) \
         do { if(lvl & flg) LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
+#define LOG_MAYBE_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ...) \
+        do { if(lvl & flg) LOG_MACRO_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+
 /**
  * Ready to use log macros with no context or tag.
  **/
@@ -80,3 +94,8 @@
 #define DDLogDebug(frmt, ...)   LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 #define DDLogVerbose(frmt, ...) LOG_MAYBE(LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
 
+#define DDLogErrorToDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_DDLOG(ddlog, NO,                LOG_LEVEL_DEF, DDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define DDLogWarnToDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define DDLogInfoToDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define DDLogDebugToDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
+#define DDLogVerboseToDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)

--- a/Framework/FmwkTest/AppDelegate.m
+++ b/Framework/FmwkTest/AppDelegate.m
@@ -18,6 +18,14 @@ static const DDLogLevel ddLogLevel = DDLogLevelVerbose;
     DDLogInfo(@"Info");
     DDLogWarn(@"Warn");
     DDLogError(@"Error");
+    
+    DDLog *aDDLogInstance = [DDLog new];
+    [aDDLogInstance addLogger:[DDTTYLogger sharedInstance]];
+    
+    DDLogVerboseToDDLog(aDDLogInstance, @"Verbose from aDDLogInstance");
+    DDLogInfoToDDLog(aDDLogInstance, @"Info from aDDLogInstance");
+    DDLogWarnToDDLog(aDDLogInstance, @"Warn from aDDLogInstance");
+    DDLogErrorToDDLog(aDDLogInstance, @"Error from aDDLogInstance");
 }
 
 @end

--- a/Framework/SwiftTest/AppDelegate.swift
+++ b/Framework/SwiftTest/AppDelegate.swift
@@ -41,6 +41,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DDLogError("Error", level: ourLogLevel);
         
         DDLogError("Error \(5)", level: ourLogLevel);
+        
+        defaultDebugLevel = .Verbose
+        
+        let aDDLogInstance = DDLog()
+        aDDLogInstance.addLogger(DDTTYLogger.sharedInstance())
+        
+        DDLogVerbose("Verbose from aDDLogInstance", ddlog: aDDLogInstance)
+        DDLogInfo("Info from aDDLogInstance", ddlog: aDDLogInstance)
+        DDLogWarn("Warn from aDDLogInstance", ddlog: aDDLogInstance)
+        DDLogError("Error from aDDLogInstance", ddlog: aDDLogInstance)
     }
 
 	func applicationWillTerminate(aNotification: NSNotification) {


### PR DESCRIPTION
**TL;DR:** This modification in the implementation of `CocoaLumberjack` allows to create instances of `DDLog` which can manage their own loggers.

## Problem

In the current implementation, `DDLog` can only be used through class methods.

It means the following configuration is not possible:

- Network `DDLog`
  - `DDTTYLogger` (verbose level)
  - `DDFileLogger` (info level)
- Default `DDLog`
  - `DDTTYLogger` (debug level)
  - `DDFileLogger` (error level)

## Solution

Make `DDLog` usable via instances.
Each `DDLog` instance manages its own list of loggers.

## Compatibility

By using the singleton instance, `DDLog` class methods continue to work smoothly.

In `Objective-C`, a new brunch of macros are created to get a `DDLog` instance as parameter:

```Objective-C
#define LOG_MACRO_TO_DDLOG(ddlog, isAsynchronous, lvl, flg, ctx, atag, fnct, frmt, ...) \
        [ddlog log : isAsynchronous                                     \
             level : lvl                                                \
              flag : flg                                                \
           context : ctx                                                \
              file : __FILE__                                           \
          function : fnct                                               \
              line : __LINE__                                           \
               tag : atag                                               \
            format : (frmt), ## __VA_ARGS__]

#define LOG_MAYBE_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ...) \
        do { if(lvl & flg) LOG_MACRO_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)

#define DDLogErrorToDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_DDLOG(ddlog, NO,                LOG_LEVEL_DEF, DDLogFlagError,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
#define DDLogWarnToDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagWarning, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
#define DDLogInfoToDDLog(ddlog, frmt, ...)    LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagInfo,    0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
#define DDLogDebugToDDLog(ddlog, frmt, ...)   LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagDebug,   0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
#define DDLogVerboseToDDLog(ddlog, frmt, ...) LOG_MAYBE_TO_DDLOG(ddlog, LOG_ASYNC_ENABLED, LOG_LEVEL_DEF, DDLogFlagVerbose, 0, nil, __PRETTY_FUNCTION__, frmt, ##__VA_ARGS__)
```

In `Swift`, a last parameter has been added to the current methods. The default value of this parameter is the `DDLog` singleton:

```Swift
public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String, ddlog: DDLog = DDLog.sharedInstance())
public func DDLogDebug(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance())
public func DDLogInfo(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance())
public func DDLogWarn(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance())
public func DDLogVerbose(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance())
public func DDLogError(@autoclosure logText: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance())
```
## Tests

- `FmwkTest`: ✅
- `iOS Test`: ✅
- `iOSLibStaticTest`: ✅
- `iOSSwiftTest`: ✅
- `OS X Tests`: ✅
- `SwiftTest`: ✅
- `tvOSSwiftTest`: ✅
- `watchOSSwiftTest`: ✅ (`iOSSwiftTest` added in the build section of the scheme)

## Examples

```Objective-C
DDLog *aDDLogInstance = [DDLog new];
[aDDLogInstance addLogger:[DDTTYLogger sharedInstance]];

DDLogVerboseToDDLog(aDDLogInstance, @"Verbose from aDDLogInstance");
DDLogInfoToDDLog(aDDLogInstance, @"Info from aDDLogInstance");
DDLogWarnToDDLog(aDDLogInstance, @"Warn from aDDLogInstance");
DDLogErrorToDDLog(aDDLogInstance, @"Error from aDDLogInstance");
```

```Swift
let aDDLogInstance = DDLog()
aDDLogInstance.addLogger(DDTTYLogger.sharedInstance())

DDLogVerbose("Verbose from aDDLogInstance", ddlog: aDDLogInstance)
DDLogInfo("Info from aDDLogInstance", ddlog: aDDLogInstance)
DDLogWarn("Warn from aDDLogInstance", ddlog: aDDLogInstance)
DDLogError("Error from aDDLogInstance", ddlog: aDDLogInstance)
```

## Benchmark

Benchmarking has been done by using `measureBlock` of `XCTestCase`.

### Original DDLog (commit [f57de5cb54c9334e0685c7de2f33f1da5658d2f8](https://github.com/CocoaLumberjack/CocoaLumberjack/commit/f57de5cb54c9334e0685c7de2f33f1da5658d2f8))

```Objective-C
- (void)testDDLogPerformance {
    [DDLog addLogger:[DDTTYLogger sharedInstance]];

    [self measureBlock:^{
        int iterationNumber = 10;

        for (int i = 0; i < iterationNumber; i++) {
            DDLogVerbose(@"Verbose");
            DDLogDebug(@"Debug");
            DDLogInfo(@"Info");
            DDLogWarn(@"Warn");
            DDLogError(@"Error");
        }
    }];
}
```

Iterations | 10 | 100 | 1,000 | 10,000
---|---|---|---|---
Test 01	| 0.006358 | 0.050466 | 0.449133 | 4.681051
Test 02	| 0.004214 | 0.047361 | 0.4497 | 5.020725
Test 03	| 0.004208 | 0.057457 | 0.450455 | 5.364892
Test 04	| 0.003599 | 0.032899 | 0.480746 | 5.711939
Test 05	| 0.003484 | 0.055528 | 0.456196 | 6.085689
Test 06	| 0.003533 | 0.054706 | 0.460553 | 6.418635
Test 07	| 0.003227 | 0.032037 | 0.477891 | 6.72061
Test 08	| 0.003113 | 0.053676 | 0.466962 | 7.016381
Test 09	| 0.003195 | 0.049097 | 0.497723 | 7.322585
Test 10	| 0.003093 | 0.033128 | 0.476314 | 7.677249
Average	| 0.0038024 | 0.0466355 | 0.4665673 | 6.2019756

### New DDLog - Class methods

```Objective-C
- (void)testDDLogPerformance {
    [DDLog addLogger:[DDTTYLogger sharedInstance]];

    [self measureBlock:^{
        int iterationNumber = 10;

        for (int i = 0; i < iterationNumber; i++) {
            DDLogVerbose(@"Verbose");
            DDLogDebug(@"Debug");
            DDLogInfo(@"Info");
            DDLogWarn(@"Warn");
            DDLogError(@"Error");
        }
    }];
}
```

Iterations | 10 | 100 | 1,000 | 10,000
---|---|---|---|---
Test 01 | 0.008415 | 0.048922 | 0.450412 | 4.723066
Test 02 | 0.004199 | 0.048806 | 0.442287 | 5.087969
Test 03 | 0.004288 | 0.054765 | 0.445504 | 5.343012
Test 04 | 0.003322 | 0.031189 | 0.471846 | 5.594273
Test 05 | 0.003043 | 0.054596 | 0.460314 | 6.16756
Test 06 | 0.003144 | 0.055294 | 0.45318 | 6.379006
Test 07 | 0.003135 | 0.031816 | 0.484594 | 6.857466
Test 08 | 0.00336 | 0.053838 | 0.459076 | 7.213925
Test 09 | 0.003042 | 0.031708 | 0.465455 | 7.46398
Test 10 | 0.002971 | 0.05395 | 0.479195 | 7.749783
Average | 0.0038919 | 0.0464884 | 0.4611863 | 6.258004

### New DDLog - Instance methods

```Objective-C
- (void)testDDLogPerformance {
  DDLog *aDDLogInstance = [DDLog new];
  [log addLogger:[DDTTYLogger sharedInstance]];

    [self measureBlock:^{
        int iterationNumber = 10;

        for (int i = 0; i < iterationNumber; i++) {
            DDLogVerboseToDDLog(log, @"Verbose");
            DDLogDebugToDDLog(log, @"Debug");
            DDLogInfoToDDLog(log, @"Info");
            DDLogWarnToDDLog(log, @"Warn");
            DDLogErrorToDDLog(log, @"Error");
        }
    }];
}
```

Iterations | 10 | 100 | 1,000 | 10,000
---|---|---|---|---
Test 01 | 0.020452 | 0.053247 | 0.465182 | 4.661897
Test 02 | 0.00547 | 0.050217 | 0.469592 | 5.035122
Test 03 | 0.003185 | 0.052808 | 0.450275 | 5.302781
Test 04 | 0.003148 | 0.031154 | 0.453416 | 5.800895
Test 05 | 0.003128 | 0.053521 | 0.487779 | 6.377715
Test 06 | 0.00338 | 0.054477 | 0.458461 | 6.549329
Test 07 | 0.003116 | 0.030609 | 0.490032 | 6.479876
Test 08 | 0.003192 | 0.053939 | 0.458052 | 6.858836
Test 09 | 0.003087 | 0.05343 | 0.500307 | 7.105818
Test 10 | 0.003092 | 0.030952 | 0.469353 | 7.44152
Average | 0.005125 | 0.0464354 | 0.4702449 | 6.1613789

### Summary

Iterations | 10 | 100 | 1,000 | 10,000
---|---|---|---|---
Original DDLog | 0.0038024 | 0.0466355 | 0.4665673 | 6.2019756
New DDLog - Class methods	| 0.0038919 | 0.0464884 | 0.4611863 | 6.258004
New DDLog - Instance methods | 0.005125 | 0.0464354 | 0.4702449 | 6.1613789

`DDLog`'s performances doesn't seem to be affected by the modifications.
