### PR TITLE
Typo in import statement

### DIFF
--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -36,4 +36,4 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 // Loggers
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
-#import <CocoaLUmberjack/DDFileLogger.h>
+#import <CocoaLumberjack/DDFileLogger.h>


### PR DESCRIPTION
Replace LUmberjack with Lumberjack. Otherwise DDFileLogger.h is not found on case-sensitive file systems.