### PR TITLE
Fix warnings in Swift 2.2

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -54,17 +54,66 @@ public func resetDefaultDebugLevel() {
     defaultDebugLevel = DDLogLevel.Verbose
 }
 
-@available(*, deprecated, message="Use one of the DDLog*() functions if appropriate or call _DDLogMessage()")
-public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String, ddlog: DDLog = DDLog.sharedInstance()) {
-    _DDLogMessage(string, level: level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, asynchronous: isAsynchronous, ddlog: ddlog)
-}
-
 public func _DDLogMessage(@autoclosure message: () -> String, level: DDLogLevel, flag: DDLogFlag, context: Int, file: StaticString, function: StaticString, line: UInt, tag: AnyObject?, asynchronous: Bool, ddlog: DDLog) {
     if level.rawValue & flag.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
         let logMessage = DDLogMessage(message: message(), level: level, flag: flag, context: context, file: file.stringValue, function: function.stringValue, line: line, tag: tag, options: [.CopyFile, .CopyFunction], timestamp: nil)
         ddlog.log(asynchronous, message: logMessage)
     }
+}
+
+// MARK: - Swift version dependent code
+
+#if swift(>=2.2)
+  
+// MARK: >= 2.2
+
+@available(*, deprecated, message="Use one of the DDLog*() functions if appropriate or call _DDLogMessage()")
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, @autoclosure string: () -> String, ddlog: DDLog = DDLog.sharedInstance()) {
+  _DDLogMessage(string, level: level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, asynchronous: isAsynchronous, ddlog: ddlog)
+}
+
+public func DDLogDebug(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    _DDLogMessage(message, level: level, flag: .Debug, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+}
+
+public func DDLogInfo(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    _DDLogMessage(message, level: level, flag: .Info, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+}
+
+public func DDLogWarn(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    _DDLogMessage(message, level: level, flag: .Warning, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+}
+
+public func DDLogVerbose(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
+    _DDLogMessage(message, level: level, flag: .Verbose, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+}
+
+public func DDLogError(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: AnyObject? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance()) {
+    _DDLogMessage(message, level: level, flag: .Error, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+}
+
+/// Returns a String of the current filename, without full path or extension.
+///
+/// Analogous to the C preprocessor macro `THIS_FILE`.
+public func CurrentFileName(fileName: StaticString = #file) -> String {
+    var str = fileName.stringValue
+    if let idx = str.rangeOfString("/", options: .BackwardsSearch)?.endIndex {
+        str = str.substringFromIndex(idx)
+    }
+    if let idx = str.rangeOfString(".", options: .BackwardsSearch)?.startIndex {
+        str = str.substringToIndex(idx)
+    }
+    return str
+}
+
+#else
+  
+// MARK: < 2.2
+  
+@available(*, deprecated, message="Use one of the DDLog*() functions if appropriate or call _DDLogMessage()")
+public func SwiftLogMacro(isAsynchronous: Bool, level: DDLogLevel, flag flg: DDLogFlag, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, @autoclosure string: () -> String, ddlog: DDLog = DDLog.sharedInstance()) {
+  _DDLogMessage(string, level: level, flag: flg, context: context, file: file, function: function, line: line, tag: tag, asynchronous: isAsynchronous, ddlog: ddlog)
 }
 
 public func DDLogDebug(@autoclosure message: () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = __FILE__, function: StaticString = __FUNCTION__, line: UInt = __LINE__, tag: AnyObject? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance()) {
@@ -100,3 +149,5 @@ public func CurrentFileName(fileName: StaticString = __FILE__) -> String {
     }
     return str
 }
+  
+#endif


### PR DESCRIPTION
`__FILE__`, `__FUNCTION__` and `__LINE__` have been deprecated and replaced by `#file`, `#function` and `#line` respectively.

Unfortunately I didn't find any better option than duplicating all methods using these debug identifiers.
It is not possible to do #if checks within the parameter list in Swift.
Using different func declarations and sharing the same implementation is also not possible.
I have tried wrapping this functionality into a method which doesn't work either.