### PR TITLE
Retrieve the `DDLogLevel` of each logger associated to DDLog

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -492,6 +492,16 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 - (NSArray *)allLoggers;
 
 /**
+ *  Return all the current loggers with their level (aka DDLoggerInformation).
+ */
++ (NSArray *)allLoggersWithLevel;
+
+/**
+ *  Return all the current loggers with their level (aka DDLoggerInformation).
+ */
+- (NSArray *)allLoggersWithLevel;
+
+/**
  * Registered Dynamic Logging
  *
  * These methods allow you to obtain a list of classes that are using registered dynamic logging,
@@ -857,3 +867,16 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
 
 @end
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+@interface DDLoggerInformation : NSObject
+
+@property (nonatomic, readonly) id <DDLogger> logger;
+@property (nonatomic, readonly) DDLogLevel level;
+
++ (DDLoggerInformation *)informationWithLogger:(id <DDLogger>)logger
+                           andLevel:(DDLogLevel)level;
+
+@end

--- a/Documentation/PerLoggerLogLevels.md
+++ b/Documentation/PerLoggerLogLevels.md
@@ -8,3 +8,5 @@ If you need a different log level for every logger (i.e. if you have a custom lo
 ```
 
 You can still use the old method `+addLogger:`, this one uses the `DDLogLevelVerbose` as default, so no log is excluded.
+
+You can retrieve the list of every logger and level associated to DDLog via the `[DDLog allLoggersWithLevel]` method.

--- a/Tests/Tests/DDLogTests.m
+++ b/Tests/Tests/DDLogTests.m
@@ -82,4 +82,14 @@
     expect([DDLog allLoggers]).haveACountOf(2);
 }
 
+- (void)testAllLoggersWithLevelReturnsAllLoggersWithLevel {
+    [DDLog addLogger:[DDTestLogger new]];
+    [DDLog addLogger:[DDTestLogger new] withLevel:DDLogLevelDebug];
+    [DDLog addLogger:[DDTestLogger new] withLevel:DDLogLevelInfo];
+    expect([DDLog allLoggersWithLevel]).haveACountOf(3);
+    expect([[[DDLog allLoggersWithLevel] firstObject] level]).to.equal(DDLogLevelAll);
+    expect([[DDLog allLoggersWithLevel][1] level]).to.equal(DDLogLevelDebug);
+    expect([[DDLog allLoggersWithLevel][2] level]).to.equal(DDLogLevelInfo);
+}
+
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

In some case, it can be useful to know which are the `DDLogger` associated to `DDLog`. It is currently possible to get these information thank to `[DDLog allLoggers]` method.
However, it is not possible to know the `DDLogLevel` associated to these loggers. This piece of information is stored in the `DDLoggerNode` which is private.

This pull request allows to retrieve these information. It completes the #136.

#### Added:
- A new class `DDLoggerInformation` which contains a logger and its associated level.
- A new public method `[DDLog allLoggersWithLevel]` which returns an array of `DDLoggerInformation`.
- A new private method `lt_allLoggersWithLevel`.
- A unit test which verify `[DDLog allLoggersWithLevel]` method.

#### Updated:
- Documentation ([PerLoggerLogLevels.md](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/PerLoggerLogLevels.md))

#### To check:
An English native speaker should check what's the best method name between `allLoggersWithLevel ` and `allLoggersWithLevels`.
