### PR TITLE
Expose CLIColor header publicly in cross-platform framework target

### DIFF
--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -37,3 +37,6 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
+
+// CLI
+#import <CocoaLumberjack/CLIColor.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...


In #745, CLIColor.h was made public. However, there was not a corresponding addition to CocoaLumberjack.h to make this file publicly available. This should fix that issue.

This results in the following error when attempting to import CocoaLumberjack (when built via Carthage):
```
Umbrella header for module 'CocoaLumberjack' does not include header 'CLIColor.h'
```