### PR TITLE
modified 'Default' subspec to import CocoaLumberjack.h before DD*.h.

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -26,8 +26,7 @@ Pod::Spec.new do |s|
   s.default_subspecs = 'Default', 'Extensions'
 
   s.subspec 'Default' do |ss|
-    ss.source_files = 'Classes/CocoaLumberjack.{h,m}'
-    ss.dependency 'CocoaLumberjack/Core'
+    ss.source_files = 'Classes/CocoaLumberjack.{h,m}', 'Classes/DD*.{h,m}'
   end
 
   s.subspec 'Core' do |ss|


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)

~~* [x] I have added the required tests to prove the fix/feature I am adding~~

  --> **but I tested at local machine to execute 'pod install' with the modified CocoaLumberjack.podspec file.**

* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: #778

### Pull Request Description

This Pull Request should fix the issue 'Use of undeclared identifier 'LOG_ASYNC_ENABLED'.
See #778.

From CocoaLumberjack 2.4.0 and 3.0.0, modulemap has been automatically created by CocoaPods. As a result, CocoaLumberjack.h has been imported after DD*.h by the umbrella header file(this file is also created by CocoaPods). This is the root cause of above issue.

So I modified 'Default' subspec to import CocoaLumberjack.h before DD*.h. I think this should be the expected action for 'Default' subspec. 

In addition, this PR is to master branch but should be adopted not only to CocoaLumberjack 3.0.x but also to CocoaLumberjack 2.4.x.
Do I need to bump the version to 2.3 and 3.0 branch by myself(e.g. 2.3.1 and 3.0.1)?

Thanks in advance.



