### PR TITLE
Skip messages in ASL logger which are filtered out by the formatter

### DIFF
--- a/Classes/DDASLLogger.m
+++ b/Classes/DDASLLogger.m
@@ -68,7 +68,7 @@ static DDASLLogger *sharedInstance;
 
     NSString * message = _logFormatter ? [_logFormatter formatLogMessage:logMessage] : logMessage->_message;
 
-    if (logMessage) {
+    if (message) {
         const char *msg = [message UTF8String];
 
         size_t aslLogLevel;


### PR DESCRIPTION
See title, fixes #742 
