### PR TITLE
Conditionally include CLIColor in umbrella header

### DIFF
--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -39,4 +39,6 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 #import <CocoaLumberjack/DDFileLogger.h>
 
 // CLI
+#if defined(DD_CLI) || !__has_include(<AppKit/NSColor.h>)
 #import <CocoaLumberjack/CLIColor.h>
+#endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* n/a I have added the required tests to prove the fix/feature I am adding
* n/a I have updated the documentation (if necesarry)
* [ ] I have run the tests and they pass **:( see below**
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: <none>

I get linker errors if I try to run any of the tests, even on master, so I can't test this :(. The compiled framework with this change does work in my app the same as one without the change, at least.

### Pull Request Description

`CocoaLumberjack.h`, what seems to be the include-everything-public header for CocoaLumberjack, includes `CLIColor.h` for all platforms. But `CLIColor.h` is not added as a public header in the project settings for the iOS/watchOS/tvOS targets, e.g. `CocoaLumberjack-iOS`, and therefore is not included in the umbrella header of the resulting frameworks. Including one of those frameworks in an iOS project results in Xcode complaining with a warning like this:
```
/[snip]/<module-includes>:1:1: Umbrella header for module 'CocoaLumberjack' does not include header 'CLIColor.h'
```

I wasn't sure exactly what the fix for this is. I took a stab at it but wouldn't be surprised if this isn't the right approach.

This issue applies to CocoaLumberjack 3.0.0 and at least back to 2.4.0.