### PR TITLE
Fix static-analyzer error: +[DDLog registeredClasses] returning nil

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -609,7 +609,7 @@ static NSUInteger _numProcessors;
 
         classes = numClasses ? (Class *)malloc(sizeof(Class) * bufferSize) : NULL;
         if (classes == NULL) {
-            return nil; //no memory or classes?
+            return @[]; //no memory or classes?
         }
 
         numClasses = (NSUInteger)MAX(objc_getClassList(classes, (int)bufferSize),0);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necesarry)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Running the static analyzer Under Xcode 8.2 results in **Null is returned from a method that is expected to return a non-null value** in +[DDLog registeredClasses].  This due to a possible nil return.  This PR changes that return to an empty array ( @[] ), silencing the warning.

+[DDLog registeredClasses] is used by +[DDLog registeredClassNames, which expects an array object, rather than nil.
