### PR TITLE
use custom modulemap

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -24,22 +24,16 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target    = '9.0'
 
-  s.default_subspecs = 'Default', 'Extensions'
+  s.module_map = 'Framework/Lumberjack/CocoaLumberjack.modulemap'
+  s.default_subspecs = 'Default'
 
   s.subspec 'Default' do |ss|
-    ss.source_files         = 'Classes/CocoaLumberjack.h', 'Classes/DD*.{h,m}'
-    ss.public_header_files  = 'Classes/CocoaLumberjack.h', 'Classes/DD*.h'
-  end
-
-  s.subspec 'Core' do |ss|
-    ss.source_files         = 'Classes/DD*.{h,m}'
-    ss.public_header_files  = 'Classes/DD*.h'
-  end
-
-  s.subspec 'Extensions' do |ss|
-    ss.dependency 'CocoaLumberjack/Default'
-    ss.source_files         = 'Classes/Extensions/*.{h,m}'
-    ss.public_header_files  = 'Classes/Extensions/*.h'
+    ss.source_files         = 'Classes/CocoaLumberjack.h',
+                              'Classes/DD*.{h,m}',
+                              'Classes/Extensions/*.{h,m}'
+    ss.public_header_files  = 'Classes/CocoaLumberjack.h',
+                              'Classes/DD*.h',
+                              'Classes/Extensions/*.h'
   end
   
   s.subspec 'CLI' do |ss|


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request reffers to the following issue: #815 
This merge request reffers to the following commit: https://github.com/CocoaLumberjack/CocoaLumberjack/commit/0f5a793843c748c06511e5c3d1e20967798b50d1

### Pull Request Description

Custom module map was removed by this commit(https://github.com/CocoaLumberjack/CocoaLumberjack/commit/0f5a793843c748c06511e5c3d1e20967798b50d1) and it should be a temporizing workaround. This PR enables custom modulemap again as CocoaLumberjack used it before(e.g. CocoaLumberjack 2.3.0 used it.).

However, keep in mind. 
In order to do this, podspec will be summarized to 3 subspecs for the reason why latest CocoaPods (probably from version 1.0.0) requires the strict podspec. 

For example,` DDDispatchQueueLogFormatter` is declared explicitly in the CocoaLumberjack.modulemap file, on the other hand, the original several subspecs(`Core` or `Extensions`) does not include this header. In this case `pod lib lint` fails. In other words, it is a root cause.
Moreover, as a podspec syntax, you can not specify `module_map` attribute in subspec level.
So I needed to change podspec.

Thanks.


