### PR TITLE
Crash  [DDLog log:level:flag:context:file:function:line:tag:format:]

### DIFF
--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -381,6 +381,11 @@ static NSUInteger _numProcessors;
         va_start(args, format);
         
         NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+        
+        va_end(args);
+        
+        va_start(args, format);
+        
         [self log:asynchronous
           message:message
             level:level
@@ -410,6 +415,11 @@ static NSUInteger _numProcessors;
         va_start(args, format);
         
         NSString *message = [[NSString alloc] initWithFormat:format arguments:args];
+        
+        va_end(args);
+        
+        va_start(args, format);
+        
         [self log:asynchronous
           message:message
             level:level


### PR DESCRIPTION
Fix crash for ios 9 and 10 

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

We need the nil or some other way to know how many arguments to grab. `va_list` has no magic way to know when to stop.

Things like `stringWithFormat:` don't need a nil because it determines the number of arguments based on the number of format specifiers (which is why they need to match or your code goes boom). 
What you could do is make use of the following NSString method:
```
va_start(args, format);
    NSString *msg = [[NSString alloc] initWithFormat:format arguments:args];
    // do whatever
va_end(args);
```
Please help me to review. 
