### PR TITLE
Added new hooks when adding loggers and formatters.

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -593,6 +593,19 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
 - (void)didAddLogger;
 
 /**
+ * Since logging is asynchronous, adding and removing loggers is also asynchronous.
+ * In other words, the loggers are added and removed at appropriate times with regards to log messages.
+ *
+ * - Loggers will not receive log messages that were executed prior to when they were added.
+ * - Loggers will not receive log messages that were executed after they were removed.
+ *
+ * These methods are executed in the logging thread/queue given in parameter.
+ * This is the same thread/queue that will execute every logMessage: invocation.
+ * Loggers may use the queue parameter to set specific values on the queue with dispatch_set_specific() function.
+ **/
+- (void)didAddLoggerInQueue:(dispatch_queue_t)queue;
+
+/**
  *  See the above description for `didAddLoger`
  */
 - (void)willRemoveLogger;
@@ -661,6 +674,18 @@ NSString * DDExtractFileNameWithoutExtension(const char *filePath, BOOL copy);
  * it could possibly use these hooks to switch to thread-safe versions of the code.
  **/
 - (void)didAddToLogger:(id <DDLogger>)logger;
+
+/**
+ * A single formatter instance can be added to multiple loggers.
+ * These methods provides hooks to notify the formatter of when it's added/removed.
+ *
+ * This is primarily for thread-safety.
+ * If a formatter is explicitly not thread-safe, it may wish to throw an exception if added to multiple loggers.
+ * Or if a formatter has potentially thread-unsafe code (e.g. NSDateFormatter),
+ * it could possibly use these hooks to switch to thread-safe versions of the code or use dispatch_set_specific()
+.* to add its own specific values.
+ **/
+- (void)didAddToLogger:(id <DDLogger>)logger inQueue:(dispatch_queue_t)queue;
 
 /**
  *  See the above description for `didAddToLogger:`

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -716,7 +716,11 @@ static NSUInteger _numProcessors;
     DDLoggerNode *loggerNode = [DDLoggerNode nodeWithLogger:logger loggerQueue:loggerQueue level:level];
     [self._loggers addObject:loggerNode];
 
-    if ([logger respondsToSelector:@selector(didAddLogger)]) {
+    if ([logger respondsToSelector:@selector(didAddLoggerInQueue:)]) {
+        dispatch_async(loggerNode->_loggerQueue, ^{ @autoreleasepool {
+            [logger didAddLoggerInQueue:loggerNode->_loggerQueue];
+        } });
+    } else if ([logger respondsToSelector:@selector(didAddLogger)]) {
         dispatch_async(loggerNode->_loggerQueue, ^{ @autoreleasepool {
             [logger didAddLogger];
         } });
@@ -1314,8 +1318,10 @@ static __inline__ __attribute__((__always_inline__)) void _dispatch_queue_label_
                 }
 
                 _logFormatter = logFormatter;
-
-                if ([_logFormatter respondsToSelector:@selector(didAddToLogger:)]) {
+ 
+                if ([_logFormatter respondsToSelector:@selector(didAddToLogger:inQueue:)]) {
+                    [_logFormatter didAddToLogger:self inQueue:_loggerQueue];
+                } else if ([_logFormatter respondsToSelector:@selector(didAddToLogger:)]) {
                     [_logFormatter didAddToLogger:self];
                 }
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

Problem: if a logger doesn't inherit from DDAbstractLogger and doesn't provide a queue (i.e..-loggerQueue returns nil), DDLog will create a queue for it. However it doesn't know anything about this queue and cannot create an environment in it. For formatters, the problem is the same: they don't know on which logger queue they are being added.
I propose this new API to compensate this problem. Maybe we should mark the old notifiers as obsolete… 
