### PR TITLE
Reenable default -init method for DDLogMessage class.

### DIFF
--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -786,9 +786,9 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
 }
 
 /**
- *  Default `init` is not available
+ *  Default `init` for empty messages.
  */
-- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
  * Standard init method for a log message object.

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -1100,6 +1100,11 @@ static __inline__ __attribute__((__always_inline__)) void _dispatch_queue_label_
 
 #endif /* if TARGET_OS_IOS */
 
+- (instancetype)init {
+    self = [super init];
+    return self;
+}
+
 - (instancetype)initWithMessage:(NSString *)message
                           level:(DDLogLevel)level
                            flag:(DDLogFlag)flag


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

By enabling -init method, you can write optimized loops like these since all DDLogMessage ivars are public:

`NSMutableArray* lines = [NSMutableArray arrayWithCapacity:array.count];`
`DDLogMessage* logMessage = [[DDLogMessage alloc] init];`
`for (NSDictionary* dict in array) {`
`    logMessage->_message    = …`
`    logMessage->_flag       = …`
`    logMessage->_context    = …`
`    logMessage->_file       = …`
`    logMessage->_function   = …`
`    logMessage->_line       = …`
`    logMessage->_tag        = …`
`    logMessage->_timestamp  = …`
`    logMessage->_threadID   = …`
`    logMessage->_threadName = …`
`    logMessage->_queueLabel = …`
`    [lines addObject:[self formatLogMessage:logMessage withTimestamp:YES]];`
`});`

It avoid DDLogMessage instance allocation for each loop.