### PR TITLE
added a very basic os_log (unified logging) logger

### DIFF
--- a/Classes/CocoaLumberjack.h
+++ b/Classes/CocoaLumberjack.h
@@ -78,6 +78,7 @@
 #import "DDTTYLogger.h"
 #import "DDASLLogger.h"
 #import "DDFileLogger.h"
+#import "DDOSLogger.h"
 
 // CLI
 #if __has_include("CLIColor.h") && TARGET_OS_OSX

--- a/Classes/DDOSLogger.h
+++ b/Classes/DDOSLogger.h
@@ -1,0 +1,58 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2016, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <Foundation/Foundation.h>
+
+// Disable legacy macros
+#ifndef DD_LEGACY_MACROS
+    #define DD_LEGACY_MACROS 0
+#endif
+
+#import "DDLog.h"
+
+// Custom key set on messages sent to ASL
+extern const char* const kDDASLKeyDDLog;
+
+// Value set for kDDASLKeyDDLog
+extern const char* const kDDASLDDLogValue;
+
+/**
+ * This class provides a logger for the Apple System Log facility.
+ *
+ * As described in the "Getting Started" page,
+ * the traditional NSLog() function directs its output to two places:
+ *
+ * - Apple System Log
+ * - StdErr (if stderr is a TTY) so log statements show up in Xcode console
+ *
+ * To duplicate NSLog() functionality you can simply add this logger and a tty logger.
+ * However, if you instead choose to use file logging (for faster performance),
+ * you may choose to use a file logger and a tty logger.
+ **/
+@interface DDASLLogger : DDAbstractLogger <DDLogger>
+
+/**
+ *  Singleton method
+ *
+ *  @return the shared instance
+ */
+@property (class, readonly, strong) DDASLLogger *sharedInstance;
+
+// Inherited from DDAbstractLogger
+
+// - (id <DDLogFormatter>)logFormatter;
+// - (void)setLogFormatter:(id <DDLogFormatter>)formatter;
+
+@end

--- a/Classes/DDOSLogger.h
+++ b/Classes/DDOSLogger.h
@@ -22,37 +22,16 @@
 
 #import "DDLog.h"
 
-// Custom key set on messages sent to ASL
-extern const char* const kDDASLKeyDDLog;
-
-// Value set for kDDASLKeyDDLog
-extern const char* const kDDASLDDLogValue;
-
 /**
- * This class provides a logger for the Apple System Log facility.
- *
- * As described in the "Getting Started" page,
- * the traditional NSLog() function directs its output to two places:
- *
- * - Apple System Log
- * - StdErr (if stderr is a TTY) so log statements show up in Xcode console
- *
- * To duplicate NSLog() functionality you can simply add this logger and a tty logger.
- * However, if you instead choose to use file logging (for faster performance),
- * you may choose to use a file logger and a tty logger.
+ * This class provides a logger for the Apple os_log facility.
  **/
-@interface DDASLLogger : DDAbstractLogger <DDLogger>
+@interface DDOSLogger : DDAbstractLogger <DDLogger>
 
 /**
  *  Singleton method
  *
  *  @return the shared instance
  */
-@property (class, readonly, strong) DDASLLogger *sharedInstance;
-
-// Inherited from DDAbstractLogger
-
-// - (id <DDLogFormatter>)logFormatter;
-// - (void)setLogFormatter:(id <DDLogFormatter>)formatter;
+@property (class, readonly, strong) DDOSLogger *sharedInstance;
 
 @end

--- a/Classes/DDOSLogger.m
+++ b/Classes/DDOSLogger.m
@@ -1,0 +1,121 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2016, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import "DDASLLogger.h"
+#import <asl.h>
+
+#if !__has_feature(objc_arc)
+#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
+#endif
+
+const char* const kDDASLKeyDDLog = "DDLog";
+
+const char* const kDDASLDDLogValue = "1";
+
+static DDASLLogger *sharedInstance;
+
+@interface DDASLLogger () {
+    aslclient _client;
+}
+
+@end
+
+
+@implementation DDASLLogger
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t DDASLLoggerOnceToken;
+
+    dispatch_once(&DDASLLoggerOnceToken, ^{
+        sharedInstance = [[[self class] alloc] init];
+    });
+
+    return sharedInstance;
+}
+
+- (instancetype)init {
+    if (sharedInstance != nil) {
+        return nil;
+    }
+
+    if ((self = [super init])) {
+        // A default asl client is provided for the main thread,
+        // but background threads need to create their own client.
+
+        _client = asl_open(NULL, "com.apple.console", 0);
+    }
+
+    return self;
+}
+
+- (void)logMessage:(DDLogMessage *)logMessage {
+    // Skip captured log messages
+    if ([logMessage->_fileName isEqualToString:@"DDASLLogCapture"]) {
+        return;
+    }
+
+    NSString * message = _logFormatter ? [_logFormatter formatLogMessage:logMessage] : logMessage->_message;
+
+    if (message) {
+        const char *msg = [message UTF8String];
+
+        size_t aslLogLevel;
+        switch (logMessage->_flag) {
+            // Note: By default ASL will filter anything above level 5 (Notice).
+            // So our mappings shouldn't go above that level.
+            case DDLogFlagError     : aslLogLevel = ASL_LEVEL_CRIT;     break;
+            case DDLogFlagWarning   : aslLogLevel = ASL_LEVEL_ERR;      break;
+            case DDLogFlagInfo      : aslLogLevel = ASL_LEVEL_WARNING;  break; // Regular NSLog's level
+            case DDLogFlagDebug     :
+            case DDLogFlagVerbose   :
+            default                 : aslLogLevel = ASL_LEVEL_NOTICE;   break;
+        }
+
+        static char const *const level_strings[] = { "0", "1", "2", "3", "4", "5", "6", "7" };
+
+        // NSLog uses the current euid to set the ASL_KEY_READ_UID.
+        uid_t const readUID = geteuid();
+
+        char readUIDString[16];
+#ifndef NS_BLOCK_ASSERTIONS
+        size_t l = snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
+#else
+        snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
+#endif
+
+        NSAssert(l < sizeof(readUIDString),
+                 @"Formatted euid is too long.");
+        NSAssert(aslLogLevel < (sizeof(level_strings) / sizeof(level_strings[0])),
+                 @"Unhandled ASL log level.");
+
+        aslmsg m = asl_new(ASL_TYPE_MSG);
+        if (m != NULL) {
+            if (asl_set(m, ASL_KEY_LEVEL, level_strings[aslLogLevel]) == 0 &&
+                asl_set(m, ASL_KEY_MSG, msg) == 0 &&
+                asl_set(m, ASL_KEY_READ_UID, readUIDString) == 0 &&
+                asl_set(m, kDDASLKeyDDLog, kDDASLDDLogValue) == 0) {
+                asl_send(_client, m);
+            }
+            asl_free(m);
+        }
+        //TODO handle asl_* failures non-silently?
+    }
+}
+
+- (NSString *)loggerName {
+    return @"cocoa.lumberjack.aslLogger";
+}
+
+@end

--- a/Classes/DDOSLogger.m
+++ b/Classes/DDOSLogger.m
@@ -13,32 +13,17 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import "DDASLLogger.h"
-#import <asl.h>
+#import "DDOSLogger.h"
+@import os.log;
 
-#if !__has_feature(objc_arc)
-#error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
-#endif
+static DDOSLogger *sharedInstance;
 
-const char* const kDDASLKeyDDLog = "DDLog";
-
-const char* const kDDASLDDLogValue = "1";
-
-static DDASLLogger *sharedInstance;
-
-@interface DDASLLogger () {
-    aslclient _client;
-}
-
-@end
-
-
-@implementation DDASLLogger
+@implementation DDOSLogger
 
 + (instancetype)sharedInstance {
-    static dispatch_once_t DDASLLoggerOnceToken;
+    static dispatch_once_t DDOSLoggerOnceToken;
 
-    dispatch_once(&DDASLLoggerOnceToken, ^{
+    dispatch_once(&DDOSLoggerOnceToken, ^{
         sharedInstance = [[[self class] alloc] init];
     });
 
@@ -50,14 +35,11 @@ static DDASLLogger *sharedInstance;
         return nil;
     }
 
-    if ((self = [super init])) {
-        // A default asl client is provided for the main thread,
-        // but background threads need to create their own client.
-
-        _client = asl_open(NULL, "com.apple.console", 0);
+    if (self = [super init]) {
+        return self;
     }
 
-    return self;
+    return nil;
 }
 
 - (void)logMessage:(DDLogMessage *)logMessage {
@@ -65,57 +47,31 @@ static DDASLLogger *sharedInstance;
     if ([logMessage->_fileName isEqualToString:@"DDASLLogCapture"]) {
         return;
     }
-
+    
     NSString * message = _logFormatter ? [_logFormatter formatLogMessage:logMessage] : logMessage->_message;
-
+    
     if (message) {
         const char *msg = [message UTF8String];
-
-        size_t aslLogLevel;
+        
         switch (logMessage->_flag) {
-            // Note: By default ASL will filter anything above level 5 (Notice).
-            // So our mappings shouldn't go above that level.
-            case DDLogFlagError     : aslLogLevel = ASL_LEVEL_CRIT;     break;
-            case DDLogFlagWarning   : aslLogLevel = ASL_LEVEL_ERR;      break;
-            case DDLogFlagInfo      : aslLogLevel = ASL_LEVEL_WARNING;  break; // Regular NSLog's level
+            case DDLogFlagError     :
+                os_log_error(OS_LOG_DEFAULT, msg);
+                break;
+            case DDLogFlagWarning   :
+            case DDLogFlagInfo      :
+                os_log_info(OS_LOG_DEFAULT, msg);
+                break;
             case DDLogFlagDebug     :
             case DDLogFlagVerbose   :
-            default                 : aslLogLevel = ASL_LEVEL_NOTICE;   break;
+            default                 :
+                os_log_debug(OS_LOG_DEFAULT, msg);
+                break;
         }
-
-        static char const *const level_strings[] = { "0", "1", "2", "3", "4", "5", "6", "7" };
-
-        // NSLog uses the current euid to set the ASL_KEY_READ_UID.
-        uid_t const readUID = geteuid();
-
-        char readUIDString[16];
-#ifndef NS_BLOCK_ASSERTIONS
-        size_t l = snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
-#else
-        snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
-#endif
-
-        NSAssert(l < sizeof(readUIDString),
-                 @"Formatted euid is too long.");
-        NSAssert(aslLogLevel < (sizeof(level_strings) / sizeof(level_strings[0])),
-                 @"Unhandled ASL log level.");
-
-        aslmsg m = asl_new(ASL_TYPE_MSG);
-        if (m != NULL) {
-            if (asl_set(m, ASL_KEY_LEVEL, level_strings[aslLogLevel]) == 0 &&
-                asl_set(m, ASL_KEY_MSG, msg) == 0 &&
-                asl_set(m, ASL_KEY_READ_UID, readUIDString) == 0 &&
-                asl_set(m, kDDASLKeyDDLog, kDDASLDDLogValue) == 0) {
-                asl_send(_client, m);
-            }
-            asl_free(m);
-        }
-        //TODO handle asl_* failures non-silently?
     }
 }
 
 - (NSString *)loggerName {
-    return @"cocoa.lumberjack.aslLogger";
+    return @"cocoa.lumberjack.osLogger";
 }
 
 @end

--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -37,6 +37,7 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
+#import <CocoaLumberjack/DDOSLogger.h>
 
 // CLI
 #if __has_include(<CocoaLumberjack/CLIColor.h>) && TARGET_OS_OSX

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -176,6 +176,10 @@
 		DCB318DE14ED6C3B001CFBEE /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCB318DC14ED6C3B001CFBEE /* MainMenu.xib */; };
 		DD4738841E7168A400F1A4F5 /* DDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4738831E7168A400F1A4F5 /* DDOSLogger.m */; };
 		DD4738851E71A14400F1A4F5 /* DDOSLogger.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; };
+		DDBE6E861E73ED10003F093F /* DDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DDBE6E871E73ED11003F093F /* DDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DDBE6E881E73ED12003F093F /* DDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DDBE6E891E73ED12003F093F /* DDOSLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E58079631A032F92008819CA /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA81994749300C180CF /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA91994749300C180CF /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -847,6 +851,7 @@
 				19190EFC1B84DB21008D059E /* DDLog.h in Headers */,
 				19190EFD1B84DB26008D059E /* DDASLLogger.h in Headers */,
 				19190EFE1B84DB2C008D059E /* DDMultiFormatter.h in Headers */,
+				DDBE6E891E73ED12003F093F /* DDOSLogger.h in Headers */,
 				19190EFF1B84DB31008D059E /* CocoaLumberjack.h in Headers */,
 				19190F001B84DB36008D059E /* DDFileLogger.h in Headers */,
 			);
@@ -876,6 +881,7 @@
 				19D90B121BBFA9DB00947169 /* DDLog.h in Headers */,
 				19D90B131BBFA9DB00947169 /* DDASLLogger.h in Headers */,
 				19D90B141BBFA9DB00947169 /* DDMultiFormatter.h in Headers */,
+				DDBE6E881E73ED12003F093F /* DDOSLogger.h in Headers */,
 				19D90B151BBFA9DB00947169 /* CocoaLumberjack.h in Headers */,
 				19D90B161BBFA9DB00947169 /* DDFileLogger.h in Headers */,
 			);
@@ -905,6 +911,7 @@
 				19FF46211B8B4E9200B43179 /* DDLog.h in Headers */,
 				19FF46201B8B4E8D00B43179 /* DDASLLogger.h in Headers */,
 				19FF461F1B8B4E8800B43179 /* DDMultiFormatter.h in Headers */,
+				DDBE6E861E73ED10003F093F /* DDOSLogger.h in Headers */,
 				19FF461E1B8B4E8400B43179 /* CocoaLumberjack.h in Headers */,
 				19FF461D1B8B4E8200B43179 /* DDFileLogger.h in Headers */,
 			);
@@ -934,6 +941,7 @@
 				DA9C20D9192A0E0000AB7171 /* DDLog.h in Headers */,
 				DA9C20D5192A0E0000AB7171 /* DDASLLogger.h in Headers */,
 				DA9C20E2192A0E0000AB7171 /* DDMultiFormatter.h in Headers */,
+				DDBE6E871E73ED11003F093F /* DDOSLogger.h in Headers */,
 				C7D056731E1A58EA000E6591 /* CocoaLumberjack.h in Headers */,
 				93483CFC1D09E39000AD40D6 /* CLIColor.h in Headers */,
 				DA9C20D7192A0E0000AB7171 /* DDFileLogger.h in Headers */,

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -174,6 +174,8 @@
 		DCB318D814ED6C3B001CFBEE /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = DCB318D614ED6C3B001CFBEE /* Credits.rtf */; };
 		DCB318DB14ED6C3B001CFBEE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = DCB318DA14ED6C3B001CFBEE /* AppDelegate.m */; };
 		DCB318DE14ED6C3B001CFBEE /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = DCB318DC14ED6C3B001CFBEE /* MainMenu.xib */; };
+		DD4738841E7168A400F1A4F5 /* DDOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DD4738831E7168A400F1A4F5 /* DDOSLogger.m */; };
+		DD4738851E71A14400F1A4F5 /* DDOSLogger.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DD4738821E7168A400F1A4F5 /* DDOSLogger.h */; };
 		E58079631A032F92008819CA /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E58079621A032F92008819CA /* DDLegacyMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA81994749300C180CF /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA91994749300C180CF /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -286,6 +288,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				DD4738851E71A14400F1A4F5 /* DDOSLogger.h in CopyFiles */,
 				620EEE741BFA65CE00D1B9CB /* CocoaLumberjack.h in CopyFiles */,
 				620EEE751BFA65CE00D1B9CB /* DDLogMacros.h in CopyFiles */,
 				620EEE761BFA65CE00D1B9CB /* DDAssertMacros.h in CopyFiles */,
@@ -449,6 +452,8 @@
 		DCB318D914ED6C3B001CFBEE /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		DCB318DA14ED6C3B001CFBEE /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		DCB318DD14ED6C3B001CFBEE /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/MainMenu.xib; sourceTree = "<group>"; };
+		DD4738821E7168A400F1A4F5 /* DDOSLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDOSLogger.h; sourceTree = "<group>"; };
+		DD4738831E7168A400F1A4F5 /* DDOSLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDOSLogger.m; sourceTree = "<group>"; };
 		E58078F91A01C92F008819CA /* CocoaLumberjackSwift-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "CocoaLumberjackSwift-Info.plist"; sourceTree = "<group>"; };
 		E58079621A032F92008819CA /* DDLegacyMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLegacyMacros.h; sourceTree = "<group>"; };
 		E5D89BA41994749300C180CF /* CocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjack.h; sourceTree = "<group>"; };
@@ -765,6 +770,8 @@
 				DA9C20C4192A0E0000AB7171 /* DDFileLogger.m */,
 				DA9C20C5192A0E0000AB7171 /* DDLog.h */,
 				DA9C20C6192A0E0000AB7171 /* DDLog.m */,
+				DD4738821E7168A400F1A4F5 /* DDOSLogger.h */,
+				DD4738831E7168A400F1A4F5 /* DDOSLogger.m */,
 				DA9C20C8192A0E0000AB7171 /* DDTTYLogger.h */,
 				DA9C20C9192A0E0000AB7171 /* DDTTYLogger.m */,
 				93483CFA1D09E39000AD40D6 /* CLIColor.h */,
@@ -1488,6 +1495,7 @@
 				18F3C01E1A81E14E00692297 /* DDFileLogger.m in Sources */,
 				18F3C01F1A81E14E00692297 /* DDLog.m in Sources */,
 				18F3C01B1A81E14E00692297 /* DDAbstractDatabaseLogger.m in Sources */,
+				DD4738841E7168A400F1A4F5 /* DDOSLogger.m in Sources */,
 				18F3C0191A81E14000692297 /* DDDispatchQueueLogFormatter.m in Sources */,
 				18F3C01C1A81E14E00692297 /* DDASLLogCapture.m in Sources */,
 			);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: 
https://github.com/CocoaLumberjack/CocoaLumberjack/issues/765

### Pull Request Description

I added a first draft of a logger which uses the new os_log API (https://developer.apple.com/reference/os/logging).

The aim is to be future proof and most of all to be able to log more than 1024chars in the device logs (see: https://github.com/CocoaLumberjack/CocoaLumberjack/issues/765)

