### PR TITLE
Optimized timestamp calculation.

### DIFF
--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -79,8 +79,6 @@
 
 #define MAP_TO_TERMINAL_APP_COLORS 1
 
-static void *const CalendarSpecificKey = (void *)&CalendarSpecificKey;
-
 
 @interface DDTTYLoggerColorProfile : NSObject {
     @public
@@ -120,8 +118,6 @@ static void *const CalendarSpecificKey = (void *)&CalendarSpecificKey;
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 @interface DDTTYLogger () {
-    NSUInteger _calendarUnitFlags;
-    
     NSString *_appName;
     char *_app;
     size_t _appLen;
@@ -823,16 +819,6 @@ static DDTTYLogger *sharedInstance;
     }
 
     if ((self = [super init])) {
-        _calendarUnitFlags = (NSCalendarUnitYear     |
-                              NSCalendarUnitMonth    |
-                              NSCalendarUnitDay      |
-                              NSCalendarUnitHour     |
-                              NSCalendarUnitMinute   |
-                              NSCalendarUnitSecond);
-
-        NSCalendar* calendar = [NSCalendar autoupdatingCurrentCalendar];
-        dispatch_queue_set_specific(self.loggerQueue, CalendarSpecificKey, (__bridge_retained void*) calendar, (dispatch_function_t) CFRelease);
-
         // Initialze 'app' variable (char *)
 
         _appName = [[NSProcessInfo processInfo] processName];
@@ -1273,20 +1259,19 @@ static DDTTYLogger *sharedInstance;
             // Calculate timestamp.
             // The technique below is faster than using NSDateFormatter.
             if (logMessage->_timestamp) {
-                NSCalendar* calendar = (__bridge NSCalendar*) dispatch_get_specific(CalendarSpecificKey);
-                NSAssert(calendar != nil, @"Core architecture requirement failure");
-                NSDateComponents *components = [calendar components:_calendarUnitFlags fromDate:logMessage->_timestamp];
+                NSTimeInterval epoch = [logMessage->_timestamp timeIntervalSince1970];
+                struct tm tm;
+                time_t time = (time_t)epoch;
+                (void)localtime_r(&time, &tm);
+                int milliseconds = (int)((epoch - floor(epoch)) * 1000.0);
 
-                NSTimeInterval epoch = [logMessage->_timestamp timeIntervalSinceReferenceDate];
-                int milliseconds = (int)((epoch - floor(epoch)) * 1000);
-
-                len = snprintf(ts, 24, "%04ld-%02ld-%02ld %02ld:%02ld:%02ld:%03d", // yyyy-MM-dd HH:mm:ss:SSS
-                               (long)components.year,
-                               (long)components.month,
-                               (long)components.day,
-                               (long)components.hour,
-                               (long)components.minute,
-                               (long)components.second, milliseconds);
+                len = snprintf(ts, 24, "%04d-%02d-%02d %02d:%02d:%02d:%03d", // yyyy-MM-dd HH:mm:ss:SSS
+                               tm.tm_year + 1900,
+                               tm.tm_mon + 1,
+                               tm.tm_mday,
+                               tm.tm_hour,
+                               tm.tm_min,
+                               tm.tm_sec, milliseconds);
 
                 tsLen = (NSUInteger)MAX(MIN(24 - 1, len), 0);
             }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

By using POSIX API, we can further optimize timestamp calculation. On my Mac, I ran a test in a loop count of 10000000 that shows the difference:
calendar: 9.024821s
localtime: 7.373581s

