### PR TITLE
Add Carthage/Build to .gitignore to avoid dirty submodules when insta…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ DerivedData
 *.ipa
 *.xcuserstate
 
+# Carthage
+Carthage/Build
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
…lling with Carthage

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

...

This pull request fixes the fact that after installing this with Carthage using submodules you'll see a message like this when running `git status`:
```modified:   Carthage/Checkouts/CocoaLumberjack (untracked content)```

And this happens because `.gitignore` is not ignoring `Carthage/Build` directory.
