### PR TITLE
Fixed new log files being deleted immediately when there are logs with the old date format

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -388,23 +388,23 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 
 - (NSArray *)sortedLogFileInfos {
     return  [[self unsortedLogFileInfos] sortedArrayUsingComparator:^NSComparisonResult(DDLogFileInfo   * _Nonnull obj1, DDLogFileInfo   * _Nonnull obj2) {
-        
         NSDate *date1 = [NSDate new];
         NSDate *date2 = [NSDate new];
-        NSArray *arryComponant = [[obj1 fileName] componentsSeparatedByString:@" "];
-        if(arryComponant.count>0){
-            NSString *stringDate = arryComponant.lastObject;
+
+        NSArray<NSString *> *arrayComponent = [[obj1 fileName] componentsSeparatedByString:@" "];
+        if (arrayComponent.count > 0) {
+            NSString *stringDate = arrayComponent.lastObject;
             stringDate = [stringDate stringByReplacingOccurrencesOfString:@".log" withString:@""];
             stringDate = [stringDate stringByReplacingOccurrencesOfString:@".archived" withString:@""];
-            date1 = [[self logFileDateFormatter] dateFromString:stringDate];
+            date1 = [[self logFileDateFormatter] dateFromString:stringDate] ?: [obj1 creationDate];
         }
         
-        arryComponant = [[obj2 fileName] componentsSeparatedByString:@" "];
-        if(arryComponant.count>0){
-            NSString *stringDate = arryComponant.lastObject;
+        arrayComponent = [[obj2 fileName] componentsSeparatedByString:@" "];
+        if (arrayComponent.count > 0) {
+            NSString *stringDate = arrayComponent.lastObject;
             stringDate = [stringDate stringByReplacingOccurrencesOfString:@".log" withString:@""];
             stringDate = [stringDate stringByReplacingOccurrencesOfString:@".archived" withString:@""];
-            date2 = [[self logFileDateFormatter] dateFromString:stringDate];
+            date2 = [[self logFileDateFormatter] dateFromString:stringDate] ?: [obj2 creationDate];
         }
         
         return [date2 compare:date1];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / reffers to the following issues: ...

### Pull Request Description

This is an additional fix on top of #868.

`-[DDFileLogger sortedLogFileInfos]` was assuming that all files are using the new date format introduced in 44ec1fafc3acab53513e4c0474ee58ee17b044af.
This was resulting in old log files ending up with a nil date when being parsed by `logFileDateFormatter`, which would result in a bad compare: result.
If the date formatter fails to parse a date then we fall back to the file's creation date.
Fixed typo in variable name (`arryComponant` -> `arrayComponent`).