### PR TITLE
update 'Use Log Level per Logger' doc

### DIFF
--- a/Documentation/PerLoggerLogLevels.md
+++ b/Documentation/PerLoggerLogLevels.md
@@ -1,11 +1,19 @@
 ### Use Log Level per Logger
 
-If you need a different log level for every logger (i.e. if you have a custom logger like Crashlytics logger that should not log Info or Debug info), you can easily achieve this using the `[DDLog addLogger:withLevel:]` method.
+If you need a different log level for every logger (i.e. if you have a custom logger like Crashlytics logger that should not log Info or Debug info), you can easily achieve this using the `DDLog.add(_, with:)` method in Swift, or `[DDLog addLogger:withLevel:]` method in Objective C.
 
+#### Swift
+```swift
+DDLog.add(DDASLLogger.sharedInstance, with: DDLogLevel.info)
+DDLog.add(DDTTYLogger.sharedInstance, with: DDLogLevel.debug)
+```
+
+#### Objective C
 ```objective-c
 [DDLog addLogger:[DDASLLogger sharedInstance] withLevel:DDLogLevelInfo];
 [DDLog addLogger:[DDTTYLogger sharedInstance] withLevel:DDLogLevelDebug];
 ```
+
 
 You can still use the old method `+addLogger:`, this one uses the `DDLogLevelVerbose` as default, so no log is excluded.
 


### PR DESCRIPTION
Added a Swift example

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none
* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necesarry)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: none

### Pull Request Description

Just a tiny documentation update. The 'Use Log Level per Logger' page lacked a Swift example. Took me long enough to figure it out that I wanted to share it.

Best regards
Guillaume
