### PR TITLE
Fixes pod lib lint warnings

### DIFF
--- a/Classes/DDAbstractDatabaseLogger.m
+++ b/Classes/DDAbstractDatabaseLogger.m
@@ -217,7 +217,7 @@
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _saveThreshold;
+            result = self->_saveThreshold;
         });
     });
 
@@ -227,15 +227,15 @@
 - (void)setSaveThreshold:(NSUInteger)threshold {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            if (_saveThreshold != threshold) {
-                _saveThreshold = threshold;
+            if (self->_saveThreshold != threshold) {
+                self->_saveThreshold = threshold;
 
                 // Since the saveThreshold has changed,
                 // we check to see if the current unsavedCount has surpassed the new threshold.
                 //
                 // If it has, we immediately save the log.
 
-                if ((_unsavedCount >= _saveThreshold) && (_saveThreshold > 0)) {
+                if ((self->_unsavedCount >= self->_saveThreshold) && (self->_saveThreshold > 0)) {
                     [self performSaveAndSuspendSaveTimer];
                 }
             }
@@ -277,7 +277,7 @@
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _saveInterval;
+            result = self->_saveInterval;
         });
     });
 
@@ -290,8 +290,8 @@
             // C99 recommended floating point comparison macro
             // Read: isLessThanOrGreaterThan(floatA, floatB)
 
-            if (/* saveInterval != interval */ islessgreater(_saveInterval, interval)) {
-                _saveInterval = interval;
+            if (/* saveInterval != interval */ islessgreater(self->_saveInterval, interval)) {
+                self->_saveInterval = interval;
 
                 // There are several cases we need to handle here.
                 //
@@ -306,8 +306,8 @@
                 // 4. If the saveInterval decreased, then we need to reset the timer so that it fires at an earlier date.
                 //    (Plus we might need to do an immediate save.)
 
-                if (_saveInterval > 0.0) {
-                    if (_saveTimer == NULL) {
+                if (self->_saveInterval > 0.0) {
+                    if (self->_saveTimer == NULL) {
                         // Handles #2
                         //
                         // Since the saveTimer uses the unsavedTime to calculate it's first fireDate,
@@ -324,7 +324,7 @@
 
                         [self updateAndResumeSaveTimer];
                     }
-                } else if (_saveTimer) {
+                } else if (self->_saveTimer) {
                     // Handles #1
 
                     [self destroySaveTimer];
@@ -368,7 +368,7 @@
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _maxAge;
+            result = self->_maxAge;
         });
     });
 
@@ -381,11 +381,11 @@
             // C99 recommended floating point comparison macro
             // Read: isLessThanOrGreaterThan(floatA, floatB)
 
-            if (/* maxAge != interval */ islessgreater(_maxAge, interval)) {
-                NSTimeInterval oldMaxAge = _maxAge;
+            if (/* maxAge != interval */ islessgreater(self->_maxAge, interval)) {
+                NSTimeInterval oldMaxAge = self->_maxAge;
                 NSTimeInterval newMaxAge = interval;
 
-                _maxAge = interval;
+                self->_maxAge = interval;
 
                 // There are several cases we need to handle here.
                 //
@@ -420,7 +420,7 @@
                 if (shouldDeleteNow) {
                     [self performDelete];
 
-                    if (_deleteTimer) {
+                    if (self->_deleteTimer) {
                         [self updateDeleteTimer];
                     } else {
                         [self createAndStartDeleteTimer];
@@ -465,7 +465,7 @@
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _deleteInterval;
+            result = self->_deleteInterval;
         });
     });
 
@@ -478,8 +478,8 @@
             // C99 recommended floating point comparison macro
             // Read: isLessThanOrGreaterThan(floatA, floatB)
 
-            if (/* deleteInterval != interval */ islessgreater(_deleteInterval, interval)) {
-                _deleteInterval = interval;
+            if (/* deleteInterval != interval */ islessgreater(self->_deleteInterval, interval)) {
+                self->_deleteInterval = interval;
 
                 // There are several cases we need to handle here.
                 //
@@ -494,8 +494,8 @@
                 // 4. If the deleteInterval decreased, then we need to reset the timer so that it fires at an earlier date.
                 //    (Plus we might need to do an immediate delete.)
 
-                if (_deleteInterval > 0.0) {
-                    if (_deleteTimer == NULL) {
+                if (self->_deleteInterval > 0.0) {
+                    if (self->_deleteTimer == NULL) {
                         // Handles #2
                         //
                         // Since the deleteTimer uses the lastDeleteTime to calculate it's first fireDate,
@@ -511,7 +511,7 @@
 
                         [self updateDeleteTimer];
                     }
-                } else if (_deleteTimer) {
+                } else if (self->_deleteTimer) {
                     // Handles #1
 
                     [self destroyDeleteTimer];
@@ -555,7 +555,7 @@
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _deleteOnEverySave;
+            result = self->_deleteOnEverySave;
         });
     });
 
@@ -564,7 +564,7 @@
 
 - (void)setDeleteOnEverySave:(BOOL)flag {
     dispatch_block_t block = ^{
-        _deleteOnEverySave = flag;
+        self->_deleteOnEverySave = flag;
     };
 
     // The design of the setter logic below is taken from the DDAbstractLogger implementation.

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -612,7 +612,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     __block unsigned long long result;
 
     dispatch_block_t block = ^{
-        result = _maximumFileSize;
+        result = self->_maximumFileSize;
     };
 
     // The design of this method is taken from the DDAbstractLogger implementation.
@@ -640,7 +640,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 - (void)setMaximumFileSize:(unsigned long long)newMaximumFileSize {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            _maximumFileSize = newMaximumFileSize;
+            self->_maximumFileSize = newMaximumFileSize;
             [self maybeRollLogFileDueToSize];
         }
     };
@@ -669,7 +669,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     __block NSTimeInterval result;
 
     dispatch_block_t block = ^{
-        result = _rollingFrequency;
+        result = self->_rollingFrequency;
     };
 
     // The design of this method is taken from the DDAbstractLogger implementation.
@@ -697,7 +697,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 - (void)setRollingFrequency:(NSTimeInterval)newRollingFrequency {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            _rollingFrequency = newRollingFrequency;
+            self->_rollingFrequency = newRollingFrequency;
             [self maybeRollLogFileDueToAge];
         }
     };

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -1312,8 +1312,8 @@ static __inline__ __attribute__((__always_inline__)) void _dispatch_queue_label_
     __block id <DDLogFormatter> result;
 
     dispatch_sync(globalLoggingQueue, ^{
-        dispatch_sync(_loggerQueue, ^{
-            result = _logFormatter;
+        dispatch_sync(self->_loggerQueue, ^{
+            result = self->_logFormatter;
         });
     });
 
@@ -1328,17 +1328,17 @@ static __inline__ __attribute__((__always_inline__)) void _dispatch_queue_label_
 
     dispatch_block_t block = ^{
         @autoreleasepool {
-            if (_logFormatter != logFormatter) {
-                if ([_logFormatter respondsToSelector:@selector(willRemoveFromLogger:)]) {
-                    [_logFormatter willRemoveFromLogger:self];
+            if (self->_logFormatter != logFormatter) {
+                if ([self->_logFormatter respondsToSelector:@selector(willRemoveFromLogger:)]) {
+                    [self->_logFormatter willRemoveFromLogger:self];
                 }
 
-                _logFormatter = logFormatter;
+                self->_logFormatter = logFormatter;
  
-                if ([_logFormatter respondsToSelector:@selector(didAddToLogger:inQueue:)]) {
-                    [_logFormatter didAddToLogger:self inQueue:_loggerQueue];
-                } else if ([_logFormatter respondsToSelector:@selector(didAddToLogger:)]) {
-                    [_logFormatter didAddToLogger:self];
+                if ([self->_logFormatter respondsToSelector:@selector(didAddToLogger:inQueue:)]) {
+                    [self->_logFormatter didAddToLogger:self inQueue:self->_loggerQueue];
+                } else if ([self->_logFormatter respondsToSelector:@selector(didAddToLogger:)]) {
+                    [self->_logFormatter didAddToLogger:self];
                 }
             }
         }
@@ -1347,7 +1347,7 @@ static __inline__ __attribute__((__always_inline__)) void _dispatch_queue_label_
     dispatch_queue_t globalLoggingQueue = [DDLog loggingQueue];
 
     dispatch_async(globalLoggingQueue, ^{
-        dispatch_async(_loggerQueue, block);
+        dispatch_async(self->_loggerQueue, block);
     });
 }
 

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -900,7 +900,7 @@ static DDTTYLogger *sharedInstance;
 
     dispatch_sync(globalLoggingQueue, ^{
         dispatch_sync(self.loggerQueue, ^{
-            result = _colorsEnabled;
+            result = self->_colorsEnabled;
         });
     });
 
@@ -910,9 +910,9 @@ static DDTTYLogger *sharedInstance;
 - (void)setColorsEnabled:(BOOL)newColorsEnabled {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            _colorsEnabled = newColorsEnabled;
+            self->_colorsEnabled = newColorsEnabled;
 
-            if ([_colorProfilesArray count] == 0) {
+            if ([self->_colorProfilesArray count] == 0) {
                 [self loadDefaultColorProfiles];
             }
         }
@@ -955,7 +955,7 @@ static DDTTYLogger *sharedInstance;
 
             NSUInteger i = 0;
 
-            for (DDTTYLoggerColorProfile *colorProfile in _colorProfilesArray) {
+            for (DDTTYLoggerColorProfile *colorProfile in self->_colorProfilesArray) {
                 if ((colorProfile->mask == mask) && (colorProfile->context == ctxt)) {
                     break;
                 }
@@ -963,10 +963,10 @@ static DDTTYLogger *sharedInstance;
                 i++;
             }
 
-            if (i < [_colorProfilesArray count]) {
-                _colorProfilesArray[i] = newColorProfile;
+            if (i < [self->_colorProfilesArray count]) {
+                self->_colorProfilesArray[i] = newColorProfile;
             } else {
-                [_colorProfilesArray addObject:newColorProfile];
+                [self->_colorProfilesArray addObject:newColorProfile];
             }
         }
     };
@@ -999,7 +999,7 @@ static DDTTYLogger *sharedInstance;
 
             NSLogInfo(@"DDTTYLogger: newColorProfile: %@", newColorProfile);
 
-            _colorProfilesDict[tag] = newColorProfile;
+            self->_colorProfilesDict[tag] = newColorProfile;
         }
     };
 
@@ -1027,7 +1027,7 @@ static DDTTYLogger *sharedInstance;
         @autoreleasepool {
             NSUInteger i = 0;
 
-            for (DDTTYLoggerColorProfile *colorProfile in _colorProfilesArray) {
+            for (DDTTYLoggerColorProfile *colorProfile in self->_colorProfilesArray) {
                 if ((colorProfile->mask == mask) && (colorProfile->context == context)) {
                     break;
                 }
@@ -1035,8 +1035,8 @@ static DDTTYLogger *sharedInstance;
                 i++;
             }
 
-            if (i < [_colorProfilesArray count]) {
-                [_colorProfilesArray removeObjectAtIndex:i];
+            if (i < [self->_colorProfilesArray count]) {
+                [self->_colorProfilesArray removeObjectAtIndex:i];
             }
         }
     };
@@ -1061,7 +1061,7 @@ static DDTTYLogger *sharedInstance;
 
     dispatch_block_t block = ^{
         @autoreleasepool {
-            [_colorProfilesDict removeObjectForKey:tag];
+            [self->_colorProfilesDict removeObjectForKey:tag];
         }
     };
 
@@ -1083,7 +1083,7 @@ static DDTTYLogger *sharedInstance;
 - (void)clearColorsForAllFlags {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            [_colorProfilesArray removeAllObjects];
+            [self->_colorProfilesArray removeAllObjects];
         }
     };
 
@@ -1105,7 +1105,7 @@ static DDTTYLogger *sharedInstance;
 - (void)clearColorsForAllTags {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            [_colorProfilesDict removeAllObjects];
+            [self->_colorProfilesDict removeAllObjects];
         }
     };
 
@@ -1127,8 +1127,8 @@ static DDTTYLogger *sharedInstance;
 - (void)clearAllColors {
     dispatch_block_t block = ^{
         @autoreleasepool {
-            [_colorProfilesArray removeAllObjects];
-            [_colorProfilesDict removeAllObjects];
+            [self->_colorProfilesArray removeAllObjects];
+            [self->_colorProfilesDict removeAllObjects];
         }
     };
 

--- a/Classes/Extensions/DDMultiFormatter.m
+++ b/Classes/Extensions/DDMultiFormatter.m
@@ -81,7 +81,7 @@
     __block NSString *line = logMessage->_message;
 
     dispatch_sync(_queue, ^{
-        for (id<DDLogFormatter> formatter in _formatters) {
+        for (id<DDLogFormatter> formatter in self->_formatters) {
             DDLogMessage *message = [self logMessageForLine:line originalMessage:logMessage];
             line = [formatter formatLogMessage:message];
 
@@ -107,7 +107,7 @@
     __block NSArray *formatters;
 
     dispatch_sync(_queue, ^{
-        formatters = [_formatters copy];
+        formatters = [self->_formatters copy];
     });
 
     return formatters;
@@ -115,19 +115,19 @@
 
 - (void)addFormatter:(id<DDLogFormatter>)formatter {
     dispatch_barrier_async(_queue, ^{
-        [_formatters addObject:formatter];
+        [self->_formatters addObject:formatter];
     });
 }
 
 - (void)removeFormatter:(id<DDLogFormatter>)formatter {
     dispatch_barrier_async(_queue, ^{
-        [_formatters removeObject:formatter];
+        [self->_formatters removeObject:formatter];
     });
 }
 
 - (void)removeAllFormatters {
     dispatch_barrier_async(_queue, ^{
-        [_formatters removeAllObjects];
+        [self->_formatters removeAllObjects];
     });
 }
 
@@ -135,7 +135,7 @@
     __block BOOL hasFormatter;
 
     dispatch_sync(_queue, ^{
-        hasFormatter = [_formatters containsObject:formatter];
+        hasFormatter = [self->_formatters containsObject:formatter];
     });
 
     return hasFormatter;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes `pod lib lint` warnings. As a result, this fixes also travis-ci failure.

[Details]
`pod lib lint` of CocoaPods 1.4.0 or later enables `-Wimplicit-retain-self` and this merge request fixes this warnings.
In addition, this warning setting seems to be set by default in next version Xcode(9.3)😄
