### PR TITLE
Fixed compiler warnings

### DIFF
--- a/Classes/DDASLLogCapture.m
+++ b/Classes/DDASLLogCapture.m
@@ -45,7 +45,7 @@ static void (*dd_asl_release)(aslresponse obj);
 + (void)initialize
 {
     #if (defined(DDASL_IOS_PIVOT_VERSION) && __IPHONE_OS_VERSION_MAX_ALLOWED >= DDASL_IOS_PIVOT_VERSION) || (defined(DDASL_OSX_PIVOT_VERSION) && __MAC_OS_X_VERSION_MAX_ALLOWED >= DDASL_OSX_PIVOT_VERSION)
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED < DDASL_IOS_PIVOT_VERSION || __MAC_OS_X_VERSION_MIN_REQUIRED < DDASL_OSX_PIVOT_VERSION
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED < DDASL_IOS_PIVOT_VERSION || (defined(__MAC_OS_X_VERSION_MIN_REQUIRED) && __MAC_OS_X_VERSION_MIN_REQUIRED < DDASL_OSX_PIVOT_VERSION)
             #pragma GCC diagnostic push
             #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
                 // Building on falsely advertised SDK, targeting deprecated API
@@ -99,7 +99,7 @@ static void (*dd_asl_release)(aslresponse obj);
     // Don't retrieve logs from our own DDASLLogger
     asl_set_query(query, kDDASLKeyDDLog, kDDASLDDLogValue, ASL_QUERY_OP_NOT_EQUAL);
     
-#if !TARGET_OS_IPHONE || TARGET_SIMULATOR
+#if !TARGET_OS_IPHONE || (defined(TARGET_SIMULATOR) && TARGET_SIMULATOR)
     int processId = [[NSProcessInfo processInfo] processIdentifier];
     char pid[16];
     sprintf(pid, "%d", processId);
@@ -112,7 +112,7 @@ static void (*dd_asl_release)(aslresponse obj);
     if ( messageCString == NULL )
         return;
 
-    int flag;
+    DDLogFlag flag;
     BOOL async;
 
     const char* levelCString = asl_get(msg, ASL_KEY_LEVEL);
@@ -171,7 +171,7 @@ static void (*dd_asl_release)(aslresponse obj);
             .tv_sec = 0
         };
         gettimeofday(&timeval, NULL);
-        unsigned long long startTime = timeval.tv_sec;
+        unsigned long long startTime = (unsigned long long)timeval.tv_sec;
         __block unsigned long long lastSeenID = 0;
 
         /*
@@ -212,7 +212,7 @@ static void (*dd_asl_release)(aslresponse obj);
                     [self aslMessageReceived:msg];
 
                     // Keep track of which messages we've seen.
-                    lastSeenID = atoll(asl_get(msg, ASL_KEY_MSG_ID));
+                    lastSeenID = (unsigned long long)atoll(asl_get(msg, ASL_KEY_MSG_ID));
                 }
                 dd_asl_release(response);
                 asl_free(query);

--- a/Classes/DDASLLogger.m
+++ b/Classes/DDASLLogger.m
@@ -90,7 +90,7 @@ static DDASLLogger *sharedInstance;
 
         char readUIDString[16];
 #ifndef NS_BLOCK_ASSERTIONS
-        size_t l = snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
+        size_t l = (size_t)snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
 #else
         snprintf(readUIDString, sizeof(readUIDString), "%d", readUID);
 #endif

--- a/Classes/DDAbstractDatabaseLogger.m
+++ b/Classes/DDAbstractDatabaseLogger.m
@@ -127,7 +127,7 @@
 - (void)updateAndResumeSaveTimer {
     if ((_saveTimer != NULL) && (_saveInterval > 0.0) && (_unsavedTime > 0.0)) {
         uint64_t interval = (uint64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
-        dispatch_time_t startTime = dispatch_time(_unsavedTime, interval);
+        dispatch_time_t startTime = dispatch_time(_unsavedTime, (int64_t)interval);
 
         dispatch_source_set_timer(_saveTimer, startTime, interval, 1ull * NSEC_PER_SEC);
 
@@ -166,9 +166,9 @@
         dispatch_time_t startTime;
 
         if (_lastDeleteTime > 0) {
-            startTime = dispatch_time(_lastDeleteTime, interval);
+            startTime = (dispatch_time_t)dispatch_time(_lastDeleteTime, (int64_t)interval);
         } else {
-            startTime = dispatch_time(DISPATCH_TIME_NOW, interval);
+            startTime = (dispatch_time_t)dispatch_time(DISPATCH_TIME_NOW, (int64_t)interval);
         }
 
         dispatch_source_set_timer(_deleteTimer, startTime, interval, 1ull * NSEC_PER_SEC);

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -762,7 +762,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     #endif
 
     uint64_t delay = (uint64_t)([logFileRollingDate timeIntervalSinceNow] * (NSTimeInterval) NSEC_PER_SEC);
-    dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, delay);
+    dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)delay);
 
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, 1ull * NSEC_PER_SEC);
     dispatch_resume(_rollingTimer);
@@ -952,7 +952,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
             // somewhere we want to roll it and use a new one.
             _currentLogFileVnode = dispatch_source_create(
                     DISPATCH_SOURCE_TYPE_VNODE,
-                    [_currentLogFileHandle fileDescriptor],
+                    (uintptr_t)[_currentLogFileHandle fileDescriptor],
                     DISPATCH_VNODE_DELETE | DISPATCH_VNODE_RENAME,
                     self.loggerQueue
                     );


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes compiler errors in Xcode when additional pragma checks are enabled:
```
DDASLLogger.m:93:20: Implicit conversion changes signedness: 'int' to 'size_t' (aka 'unsigned long')
DDASLLogCapture.m:132:27: Implicit conversion changes signedness: 'int' to 'unsigned long'
DDASLLogCapture.m:149:69: Implicit conversion changes signedness: 'int' to 'DDLogFlag' (aka 'enum DDLogFlag')
DDASLLogCapture.m:174:48: Implicit conversion changes signedness: '__darwin_time_t' (aka 'long') to 'unsigned long long'
DDASLLogCapture.m:215:34: Implicit conversion changes signedness: 'long long' to 'unsigned long long'
DDFileLogger.m:765:65: Implicit conversion changes signedness: 'uint64_t' (aka 'unsigned long long') to 'int64_t' (aka 'long long')
DDFileLogger.m:955:21: Implicit conversion changes signedness: 'int' to 'uintptr_t' (aka 'unsigned long')
DDASLLogCapture.m:48:75: '__MAC_OS_X_VERSION_MIN_REQUIRED' is not defined, evaluates to 0
DDASLLogCapture.m:102:26: 'TARGET_SIMULATOR' is not defined, evaluates to 0
```