### PR TITLE
Add new queue label which will be hold by a manual created thread.

### DIFF
--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -192,7 +192,8 @@
             @"com.apple.root.high-priority",
             @"com.apple.root.low-overcommit-priority",
             @"com.apple.root.default-overcommit-priority",
-            @"com.apple.root.high-overcommit-priority"
+            @"com.apple.root.high-overcommit-priority",
+            @"com.apple.root.default-qos.overcommit"
         ];
 
         for (NSString * name in names) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

```objective-c
// If you manually create a thread, it's dispatch_queue will have one of the thread names below.
// Since all such threads have the same name, we'd prefer to use the threadName or the machThreadID.
```
I craeted a Thread (on iOS 11.3), and found that it holds a dispatch queue label which is not in the name list. So I added it to the list.
