### PR TITLE
DDAssert for Swift

### DIFF
--- a/Classes/DDAssert.swift
+++ b/Classes/DDAssert.swift
@@ -1,0 +1,43 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2014-2016, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+/**
+ * Replacement for Swift's `assert` function that will output a log message even when assertions
+ * are disabled.
+ *
+ * - Parameters:
+ *   - condition: The condition to test. Unlike `Swift.assert`, `condition` is always evaluated,
+ *     even when assertions are disabled.
+ *   - message: A string to log (using `DDLogError`) if `condition` evaluates to `false`.
+ *     The default is an empty string.
+ */
+public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+    if !condition() {
+        DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+        Swift.assertionFailure(message, file: file, line: line)
+    }
+}
+
+/**
+ * Replacement for Swift's `assertionFailure` function that will output a log message even
+ * when assertions are disabled.
+ *
+ * - Parameters:
+ *   - message: A string to log (using `DDLogError`). The default is an empty string.
+ */
+public func DDAssertionFailure(_ message: @autoclosure () -> String = "", level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+    DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+    Swift.assertionFailure(message, file: file, line: line)
+}

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
     ss.watchos.deployment_target  = '2.0'
     ss.tvos.deployment_target     = '9.0'
     ss.dependency 'CocoaLumberjack/Default'
-    ss.source_files               = 'Classes/CocoaLumberjack.swift'
+    ss.source_files               = 'Classes/CocoaLumberjack.swift', 'Classes/DDAssert.swift'
   end
   
 end

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -130,6 +130,10 @@
 		55CCBF0619BA679200957A39 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CCBF0519BA679200957A39 /* AppDelegate.swift */; };
 		55CCBF2019BA67CB00957A39 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
 		55F88BF81B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5D34A74720B00EB400233A79 /* DDAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D34A74620B00EB400233A79 /* DDAssert.swift */; };
+		5D34A74820B00EB400233A79 /* DDAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D34A74620B00EB400233A79 /* DDAssert.swift */; };
+		5D34A74920B00EB400233A79 /* DDAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D34A74620B00EB400233A79 /* DDAssert.swift */; };
+		5D34A74A20B00EB400233A79 /* DDAssert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D34A74620B00EB400233A79 /* DDAssert.swift */; };
 		620EEE741BFA65CE00D1B9CB /* CocoaLumberjack.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E5D89BA41994749300C180CF /* CocoaLumberjack.h */; };
 		620EEE751BFA65CE00D1B9CB /* DDLogMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; };
 		620EEE761BFA65CE00D1B9CB /* DDAssertMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; };
@@ -418,6 +422,7 @@
 		55CCBF0219BA679200957A39 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55CCBF0519BA679200957A39 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		55F88BF71B3CB15C00E31255 /* CocoaLumberjackSwift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjackSwift.h; sourceTree = "<group>"; };
+		5D34A74620B00EB400233A79 /* DDAssert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DDAssert.swift; sourceTree = "<group>"; };
 		93483CFA1D09E39000AD40D6 /* CLIColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CLIColor.h; path = CLI/CLIColor.h; sourceTree = "<group>"; };
 		93483CFB1D09E39000AD40D6 /* CLIColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = CLIColor.m; path = CLI/CLIColor.m; sourceTree = "<group>"; };
 		DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
@@ -756,6 +761,7 @@
 				55BCB5C619D4BB6E0096E784 /* CocoaLumberjack.swift */,
 				E5D89BA61994749300C180CF /* DDLogMacros.h */,
 				E5D89BA51994749300C180CF /* DDAssertMacros.h */,
+				5D34A74620B00EB400233A79 /* DDAssert.swift */,
 				E58079621A032F92008819CA /* DDLegacyMacros.h */,
 				DA9C20C7192A0E0000AB7171 /* DDLog+LOGV.h */,
 				DA9C20BD192A0E0000AB7171 /* DDAbstractDatabaseLogger.h */,
@@ -1467,6 +1473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				18F3BF081A81D8B700692297 /* CocoaLumberjack.swift in Sources */,
+				5D34A74820B00EB400233A79 /* DDAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1529,6 +1536,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				19190F0B1B84DB9F008D059E /* CocoaLumberjack.swift in Sources */,
+				5D34A74A20B00EB400233A79 /* DDAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1564,6 +1572,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				19D90B2E1BBFAA7500947169 /* CocoaLumberjack.swift in Sources */,
+				5D34A74920B00EB400233A79 /* DDAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1599,6 +1608,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				19FF46351B8B4F0700B43179 /* CocoaLumberjack.swift in Sources */,
+				5D34A74720B00EB400233A79 /* DDAssert.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding _(see discussion below)_
* [ ] I have updated the documentation (if necessary) _(not sure if these functions should be mentioned in the documentation)_
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This PR contains the implementation for #918: two new Swift functions, `DDAssert` and `DDAssertionFailure`. They mimic the stdlib's [`assert`](https://developer.apple.com/documentation/swift/1541112-assert) and [`assertionFailure`](https://developer.apple.com/documentation/swift/1539616-assertionfailure), but they also log a message (using `DDLogError`) if the assertions fails. (The consequence is that, unlike `assert`, the assertion condition for `DDAssert` is always evaluated, even when assertions are disabled.)

cc @bpoplauschi @diederich 

#### Implementation notes

* I chose to create a new file, `DDAssert.swift`, for these function. If you prefer, we could also include them in `CocoaLumberjack.swift`, of course. I found it clearer to separate the two because the new functions aren't plain Obj-C wrappers.

* I added the new file to the podspec, but I didn't change anything else (version number etc.) in the podspec because I'm not familiar with your release process. @bpoplauschi Please advise if I should change anything else.

#### Missing tests

This PR doesn't come with any new unit tests. The main reason is that testing these functions is inherently difficult (or impossible). The only "simple" test I can come up with is a test that `DDAssert` does _not_ log anything when the assertion passes.

Testing for positive logs when assertions fail would either (a) require us to build the test targets with assertions disabled, or (b) add another flag parameter to the functions that would only be used by the tests, e.g.

```swift
func DDAssert(_ condition: ..., ..., omitCallToAssert: Bool = false)
```

**In my opinion option (a) is problematic, but option (b) isn’t too bad. I think it would be a nice compromise. Option (c) would be to leave out any tests. What do you think?**

Less importantly, we'd have to set up the test targets for tests written in Swift. This would entail things like:

* Upping the deployment target of the test target to iOS 8/macOS 10.10 (the minimum version supported by Swift). Is that a problem?
* Implementing a mock `DDLogger` implementation in Swift (OCMock can't be used in test written in Swift).

I have a partial implementation of this on a branch: [ddassert-swift-tests](https://github.com/ole/CocoaLumberjack/tree/ddassert-swift-tests).

#### Decision Required

Should we:

* merge the PR as is (without tests)?
* add a `omitCallToAssert` flag to the functions and write tests using the flag?
* do something else?
