### PR TITLE
Fix common warnings emitted by -Wall -Wconversion -Wextra, etc

### DIFF
--- a/Classes/DDAbstractDatabaseLogger.m
+++ b/Classes/DDAbstractDatabaseLogger.m
@@ -126,8 +126,8 @@
 
 - (void)updateAndResumeSaveTimer {
     if ((_saveTimer != NULL) && (_saveInterval > 0.0) && (_unsavedTime > 0.0)) {
-        uint64_t interval = (uint64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
-        dispatch_time_t startTime = dispatch_time(_unsavedTime, (int64_t)interval);
+        int64_t interval = (int64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
+        dispatch_time_t startTime = dispatch_time(_unsavedTime, interval);
 
         dispatch_source_set_timer(_saveTimer, startTime, interval, 1ull * NSEC_PER_SEC);
 
@@ -162,13 +162,13 @@
 
 - (void)updateDeleteTimer {
     if ((_deleteTimer != NULL) && (_deleteInterval > 0.0) && (_maxAge > 0.0)) {
-        uint64_t interval = (uint64_t)(_deleteInterval * (NSTimeInterval) NSEC_PER_SEC);
+        int64_t interval = (int64_t)(_deleteInterval * (NSTimeInterval) NSEC_PER_SEC);
         dispatch_time_t startTime;
 
         if (_lastDeleteTime > 0) {
-            startTime = (dispatch_time_t)dispatch_time(_lastDeleteTime, (int64_t)interval);
+            startTime = dispatch_time(_lastDeleteTime, interval);
         } else {
-            startTime = (dispatch_time_t)dispatch_time(DISPATCH_TIME_NOW, (int64_t)interval);
+            startTime = dispatch_time(DISPATCH_TIME_NOW, interval);
         }
 
         dispatch_source_set_timer(_deleteTimer, startTime, interval, 1ull * NSEC_PER_SEC);

--- a/Classes/DDAbstractDatabaseLogger.m
+++ b/Classes/DDAbstractDatabaseLogger.m
@@ -52,7 +52,7 @@
 #pragma mark Override Me
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)db_log:(DDLogMessage *)logMessage {
+- (BOOL)db_log:(__unused DDLogMessage *)logMessage {
     // Override me and add your implementation.
     //
     // Return YES if an item was added to the buffer.
@@ -126,8 +126,8 @@
 
 - (void)updateAndResumeSaveTimer {
     if ((_saveTimer != NULL) && (_saveInterval > 0.0) && (_unsavedTime > 0.0)) {
-        int64_t interval = (int64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
-        dispatch_time_t startTime = dispatch_time(_unsavedTime, interval);
+        uint64_t interval = (uint64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
+        dispatch_time_t startTime = dispatch_time(_unsavedTime, (int64_t)interval);
 
         dispatch_source_set_timer(_saveTimer, startTime, interval, 1ull * NSEC_PER_SEC);
 
@@ -171,7 +171,7 @@
             startTime = dispatch_time(DISPATCH_TIME_NOW, interval);
         }
 
-        dispatch_source_set_timer(_deleteTimer, startTime, interval, 1ull * NSEC_PER_SEC);
+        dispatch_source_set_timer(_deleteTimer, startTime, (uint64_t)interval, 1ull * NSEC_PER_SEC);
     }
 }
 

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -144,9 +144,9 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
+                      ofObject:(__unused id)object
                         change:(NSDictionary *)change
-                       context:(void *)context {
+                       context:(__unused void *)context {
     NSNumber *old = change[NSKeyValueChangeOldKey];
     NSNumber *new = change[NSKeyValueChangeNewKey];
 

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -761,8 +761,8 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     });
     #endif
 
-    uint64_t delay = (uint64_t)([logFileRollingDate timeIntervalSinceNow] * (NSTimeInterval) NSEC_PER_SEC);
-    dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)delay);
+    int64_t delay = (int64_t)([logFileRollingDate timeIntervalSinceNow] * (NSTimeInterval) NSEC_PER_SEC);
+    dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, delay);
 
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, 1ull * NSEC_PER_SEC);
     dispatch_resume(_rollingTimer);
@@ -1026,7 +1026,7 @@ static int exception_count = 0;
     [self maybeRollLogFileDueToSize];
 }
 
-- (BOOL)shouldArchiveRecentLogFileInfo:(DDLogFileInfo *)recentLogFileInfo {
+- (BOOL)shouldArchiveRecentLogFileInfo:(__unused DDLogFileInfo *)recentLogFileInfo {
     return NO;
 }
 

--- a/Classes/Extensions/DDContextFilterLogFormatter.h
+++ b/Classes/Extensions/DDContextFilterLogFormatter.h
@@ -53,14 +53,14 @@
  *
  *  @param loggingContext the context
  */
-- (void)addToWhitelist:(NSUInteger)loggingContext;
+- (void)addToWhitelist:(NSInteger)loggingContext;
 
 /**
  *  Remove context from whitelist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromWhitelist:(NSUInteger)loggingContext;
+- (void)removeFromWhitelist:(NSInteger)loggingContext;
 
 /**
  *  Return the whitelist
@@ -72,7 +72,7 @@
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnWhitelist:(NSUInteger)loggingContext;
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext;
 
 @end
 
@@ -92,14 +92,14 @@
  *
  *  @param loggingContext the context
  */
-- (void)addToBlacklist:(NSUInteger)loggingContext;
+- (void)addToBlacklist:(NSInteger)loggingContext;
 
 /**
  *  Remove context from blacklist
  *
  *  @param loggingContext the context
  */
-- (void)removeFromBlacklist:(NSUInteger)loggingContext;
+- (void)removeFromBlacklist:(NSInteger)loggingContext;
 
 /**
  *  Return the blacklist
@@ -112,6 +112,6 @@
  *
  *  @param loggingContext the context
  */
-- (BOOL)isOnBlacklist:(NSUInteger)loggingContext;
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext;
 
 @end

--- a/Classes/Extensions/DDContextFilterLogFormatter.m
+++ b/Classes/Extensions/DDContextFilterLogFormatter.m
@@ -22,12 +22,12 @@
 
 @interface DDLoggingContextSet : NSObject
 
-- (void)addToSet:(NSUInteger)loggingContext;
-- (void)removeFromSet:(NSUInteger)loggingContext;
+- (void)addToSet:(NSInteger)loggingContext;
+- (void)removeFromSet:(NSInteger)loggingContext;
 
 @property (readonly, copy) NSArray *currentSet;
 
-- (BOOL)isInSet:(NSUInteger)loggingContext;
+- (BOOL)isInSet:(NSInteger)loggingContext;
 
 @end
 
@@ -52,11 +52,11 @@
     return self;
 }
 
-- (void)addToWhitelist:(NSUInteger)loggingContext {
+- (void)addToWhitelist:(NSInteger)loggingContext {
     [_contextSet addToSet:loggingContext];
 }
 
-- (void)removeFromWhitelist:(NSUInteger)loggingContext {
+- (void)removeFromWhitelist:(NSInteger)loggingContext {
     [_contextSet removeFromSet:loggingContext];
 }
 
@@ -64,7 +64,7 @@
     return [_contextSet currentSet];
 }
 
-- (BOOL)isOnWhitelist:(NSUInteger)loggingContext {
+- (BOOL)isOnWhitelist:(NSInteger)loggingContext {
     return [_contextSet isInSet:loggingContext];
 }
 
@@ -99,11 +99,11 @@
     return self;
 }
 
-- (void)addToBlacklist:(NSUInteger)loggingContext {
+- (void)addToBlacklist:(NSInteger)loggingContext {
     [_contextSet addToSet:loggingContext];
 }
 
-- (void)removeFromBlacklist:(NSUInteger)loggingContext {
+- (void)removeFromBlacklist:(NSInteger)loggingContext {
     [_contextSet removeFromSet:loggingContext];
 }
 
@@ -111,7 +111,7 @@
     return [_contextSet currentSet];
 }
 
-- (BOOL)isOnBlacklist:(NSUInteger)loggingContext {
+- (BOOL)isOnBlacklist:(NSInteger)loggingContext {
     return [_contextSet isInSet:loggingContext];
 }
 
@@ -153,7 +153,7 @@
     pthread_mutex_destroy(&_mutex);
 }
 
-- (void)addToSet:(NSUInteger)loggingContext {
+- (void)addToSet:(NSInteger)loggingContext {
     pthread_mutex_lock(&_mutex);
     {
         [_set addObject:@(loggingContext)];
@@ -161,7 +161,7 @@
     pthread_mutex_unlock(&_mutex);
 }
 
-- (void)removeFromSet:(NSUInteger)loggingContext {
+- (void)removeFromSet:(NSInteger)loggingContext {
     pthread_mutex_lock(&_mutex);
     {
         [_set removeObject:@(loggingContext)];
@@ -181,7 +181,7 @@
     return result;
 }
 
-- (BOOL)isInSet:(NSUInteger)loggingContext {
+- (BOOL)isInSet:(NSInteger)loggingContext {
     BOOL result = NO;
 
     pthread_mutex_lock(&_mutex);


### PR DESCRIPTION
* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)



### Fix common warnings emitted by -Wall -Wconversion -Wextra, etc

Change from NSUInteger to NSInteger in context filter formatter, since the majority of the library uses NSInteger _context.

Mark unused variables as such.
Remove unneeded casts.
