### PR TITLE
Use static const for default log level so Swift can strip strings

### DIFF
--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -46,12 +46,7 @@ extension DDLogFlag {
     }
 }
 
-public var defaultDebugLevel = DDLogLevel.verbose
-
-public func resetDefaultDebugLevel() {
-    defaultDebugLevel = DDLogLevel.verbose
-}
-
+@inlinable
 public func _DDLogMessage(_ message: @autoclosure () -> String, level: DDLogLevel, flag: DDLogFlag, context: Int, file: StaticString, function: StaticString, line: UInt, tag: Any?, asynchronous: Bool, ddlog: DDLog) {
     if level.rawValue & flag.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
@@ -60,23 +55,28 @@ public func _DDLogMessage(_ message: @autoclosure () -> String, level: DDLogLeve
     }
 }
 
-public func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     _DDLogMessage(message, level: level, flag: .debug, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-public func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     _DDLogMessage(message, level: level, flag: .info, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-public func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     _DDLogMessage(message, level: level, flag: .warning, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-public func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
     _DDLogMessage(message, level: level, flag: .verbose, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
-public func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     _DDLogMessage(message, level: level, flag: .error, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -19,12 +19,12 @@ extension DDLogFlag {
     public static func from(_ logLevel: DDLogLevel) -> DDLogFlag {
         return DDLogFlag(rawValue: logLevel.rawValue)
     }
-	
+
 	public init(_ logLevel: DDLogLevel) {
         self = DDLogFlag(rawValue: logLevel.rawValue)
 	}
     
-    ///returns the log level, or the lowest equivalant.
+    /// Returns the log level, or the lowest equivalant.
     public func toLogLevel() -> DDLogLevel {
         if let ourValid = DDLogLevel(rawValue: rawValue) {
             return ourValid

--- a/Classes/DDAssert.swift
+++ b/Classes/DDAssert.swift
@@ -23,7 +23,8 @@
  *   - message: A string to log (using `DDLogError`) if `condition` evaluates to `false`.
  *     The default is an empty string.
  */
-public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     if !condition() {
         DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
         Swift.assertionFailure(message, file: file, line: line)
@@ -37,7 +38,8 @@ public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosu
  * - Parameters:
  *   - message: A string to log (using `DDLogError`). The default is an empty string.
  */
-public func DDAssertionFailure(_ message: @autoclosure () -> String = "", level: DDLogLevel = defaultDebugLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+@inlinable
+public func DDAssertionFailure(_ message: @autoclosure () -> String = "", level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     DDLogError(message, level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
     Swift.assertionFailure(message, file: file, line: line)
 }

--- a/Classes/SwiftLogLevel.h
+++ b/Classes/SwiftLogLevel.h
@@ -1,0 +1,18 @@
+//
+//  SwiftLogLevel.h
+//  Lumberjack
+//
+//  Created by Florian Friedrich on 05.10.18.
+//
+
+#ifndef SwiftLogLevel_h
+#define SwiftLogLevel_h
+
+#ifndef DD_LOG_LEVEL
+// #warning 'DD_LOG_LEVEL' is not defined. Using 'DDLogLevelAll' as default. Consider defining it yourself.
+#define DD_LOG_LEVEL DDLogLevelAll
+#endif
+
+static const DDLogLevel DDDefaultLogLevel = DD_LOG_LEVEL;
+
+#endif /* SwiftLogLevel_h */

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.requires_arc   = true
 
   s.preserve_paths = 'README.md', 'Classes/CocoaLumberjack.swift', 'Framework/Lumberjack/CocoaLumberjack.modulemap'
-  
+
   s.ios.deployment_target     = '6.0'
   s.osx.deployment_target     = '10.8'
   s.watchos.deployment_target = '2.0'
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     ss.source_files         = 'Classes/Extensions/*.{h,m}'
     ss.public_header_files  = 'Classes/Extensions/*.h'
   end
-  
+
   s.subspec 'CLI' do |ss|
     ss.osx.deployment_target    = '10.8'
     ss.osx.dependency 'CocoaLumberjack/Default'
@@ -55,7 +55,8 @@ Pod::Spec.new do |s|
     ss.watchos.deployment_target  = '2.0'
     ss.tvos.deployment_target     = '9.0'
     ss.dependency 'CocoaLumberjack/Default'
-    ss.source_files               = 'Classes/CocoaLumberjack.swift', 'Classes/DDAssert.swift'
+    ss.source_files               = 'Classes/CocoaLumberjack.swift', 'Classes/DDAssert.swift', 'Classes/SwiftLogLevel.h'
+    ss.public_header_files        = 'Classes/SwiftLogLevel.h'
   end
-  
+
 end

--- a/Framework/Lumberjack/CocoaLumberjackSwift.h
+++ b/Framework/Lumberjack/CocoaLumberjackSwift.h
@@ -10,3 +10,9 @@
 //Still, this header may still be needed so Swift doesn't complain when importing CocoaLumberjackSwift.
 
 @import CocoaLumberjack;
+
+#ifndef DD_LOG_LEVEL
+#define DD_LOG_LEVEL DDLogLevelAll
+#endif
+
+static const DDLogLevel DDDefaultLogLevel = DD_LOG_LEVEL;

--- a/Framework/Lumberjack/CocoaLumberjackSwift.h
+++ b/Framework/Lumberjack/CocoaLumberjackSwift.h
@@ -11,8 +11,4 @@
 
 @import CocoaLumberjack;
 
-#ifndef DD_LOG_LEVEL
-#define DD_LOG_LEVEL DDLogLevelAll
-#endif
-
-static const DDLogLevel DDDefaultLogLevel = DD_LOG_LEVEL;
+#import <CocoaLumberjackSwift/SwiftLogLevel.h>

--- a/Framework/SwiftTest/AppDelegate.swift
+++ b/Framework/SwiftTest/AppDelegate.swift
@@ -18,31 +18,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
         DDLog.add(DDTTYLogger.sharedInstance)
-		
-        defaultDebugLevel = .warning
 
         DDLogVerbose("Verbose");
         DDLogInfo("Info");
         DDLogWarn("Warn");
         DDLogError("Error");
-        
-        defaultDebugLevel = ourLogLevel
-        
-        DDLogVerbose("Verbose");
-        DDLogInfo("Info");
-        DDLogWarn("Warn");
-        DDLogError("Error");
-        
-        defaultDebugLevel = .off
-        
+
         DDLogVerbose("Verbose", level: ourLogLevel);
         DDLogInfo("Info", level: ourLogLevel);
         DDLogWarn("Warn", level: ourLogLevel);
         DDLogError("Error", level: ourLogLevel);
         
         DDLogError("Error \(5)", level: ourLogLevel);
-        
-        defaultDebugLevel = .verbose
         
         let aDDLogInstance = DDLog()
         aDDLogInstance.add(DDTTYLogger.sharedInstance)

--- a/Framework/SwiftTest/AppDelegate.swift
+++ b/Framework/SwiftTest/AppDelegate.swift
@@ -19,17 +19,30 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 	func applicationDidFinishLaunching(_ aNotification: Notification) {
         DDLog.add(DDTTYLogger.sharedInstance)
 
-        DDLogVerbose("Verbose");
-        DDLogInfo("Info");
-        DDLogWarn("Warn");
-        DDLogError("Error");
+        dynamicLogLevel = .warning
 
-        DDLogVerbose("Verbose", level: ourLogLevel);
-        DDLogInfo("Info", level: ourLogLevel);
-        DDLogWarn("Warn", level: ourLogLevel);
-        DDLogError("Error", level: ourLogLevel);
+        DDLogVerbose("Verbose")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
+        dynamicLogLevel = ourLogLevel
+
+        DDLogVerbose("Verbose")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
+        resetDynamicLogLevel()
+
+        DDLogVerbose("Verbose", level: ourLogLevel)
+        DDLogInfo("Info", level: ourLogLevel)
+        DDLogWarn("Warn", level: ourLogLevel)
+        DDLogError("Error", level: ourLogLevel)
         
-        DDLogError("Error \(5)", level: ourLogLevel);
+        DDLogError("Error \(5)", level: ourLogLevel)
+
+        dynamicLogLevel = .verbose
         
         let aDDLogInstance = DDLog()
         aDDLogInstance.add(DDTTYLogger.sharedInstance)

--- a/Framework/iOSSwift/AppDelegate.swift
+++ b/Framework/iOSSwift/AppDelegate.swift
@@ -36,6 +36,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DDLogWarn("Warn")
         DDLogError("Error")
 
+        printSomething()
+
+        dynamicLogLevel = ddloglevel
+
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
         DDLogVerbose("Verbose", level: ddloglevel)
         DDLogDebug("Debug", level: ddloglevel)
         DDLogInfo("Info", level: ddloglevel)

--- a/Framework/iOSSwift/AppDelegate.swift
+++ b/Framework/iOSSwift/AppDelegate.swift
@@ -13,11 +13,11 @@ import CocoaLumberjackSwift
 let ddloglevel = DDLogLevel.verbose
 
 private func printSomething() {
-    DDLogVerbose("Verbose");
-    DDLogDebug("Debug");
-    DDLogInfo("Info");
-    DDLogWarn("Warn");
-    DDLogError("Error");
+    DDLogVerbose("Verbose")
+    DDLogDebug("Debug")
+    DDLogInfo("Info")
+    DDLogWarn("Warn")
+    DDLogError("Error")
 }
 
 @UIApplicationMain
@@ -30,16 +30,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DDTTYLogger.sharedInstance.logFormatter = formatter
         DDLog.add(DDTTYLogger.sharedInstance)
         
-        DDLogVerbose("Verbose");
-        DDLogDebug("Debug");
-        DDLogInfo("Info");
-        DDLogWarn("Warn");
-        DDLogError("Error");
-        
-        printSomething()
-        
-        defaultDebugLevel = ddloglevel
-        
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
+        DDLogVerbose("Verbose", level: ddloglevel)
+        DDLogDebug("Debug", level: ddloglevel)
+        DDLogInfo("Info", level: ddloglevel)
+        DDLogWarn("Warn", level: ddloglevel)
+        DDLogError("Error", level: ddloglevel)
+
         printSomething()
         
 		return true

--- a/Framework/tvOSSwiftTest/AppDelegate.swift
+++ b/Framework/tvOSSwiftTest/AppDelegate.swift
@@ -36,6 +36,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DDLogWarn("Warn")
         DDLogError("Error")
 
+        printSomething()
+
+        dynamicLogLevel = ddloglevel
+
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
         DDLogVerbose("Verbose", level: ddloglevel)
         DDLogDebug("Debug", level: ddloglevel)
         DDLogInfo("Info", level: ddloglevel)

--- a/Framework/tvOSSwiftTest/AppDelegate.swift
+++ b/Framework/tvOSSwiftTest/AppDelegate.swift
@@ -13,11 +13,11 @@ import CocoaLumberjackSwift
 let ddloglevel = DDLogLevel.verbose
 
 private func printSomething() {
-    DDLogVerbose("Verbose");
-    DDLogDebug("Debug");
-    DDLogInfo("Info");
-    DDLogWarn("Warn");
-    DDLogError("Error");
+    DDLogVerbose("Verbose")
+    DDLogDebug("Debug")
+    DDLogInfo("Info")
+    DDLogWarn("Warn")
+    DDLogError("Error")
 }
 
 @UIApplicationMain
@@ -30,16 +30,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         DDTTYLogger.sharedInstance.logFormatter = formatter
         DDLog.add(DDTTYLogger.sharedInstance)
         
-        DDLogVerbose("Verbose");
-        DDLogDebug("Debug");
-        DDLogInfo("Info");
-        DDLogWarn("Warn");
-        DDLogError("Error");
-        
-        printSomething()
-        
-        defaultDebugLevel = ddloglevel
-        
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
+        DDLogVerbose("Verbose", level: ddloglevel)
+        DDLogDebug("Debug", level: ddloglevel)
+        DDLogInfo("Info", level: ddloglevel)
+        DDLogWarn("Warn", level: ddloglevel)
+        DDLogError("Error", level: ddloglevel)
+
         printSomething()
         
         return true

--- a/Framework/watchOSSwiftTest Extension/ExtensionDelegate.swift
+++ b/Framework/watchOSSwiftTest Extension/ExtensionDelegate.swift
@@ -35,6 +35,16 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         DDLogWarn("Warn")
         DDLogError("Error")
 
+        printSomething()
+
+        dynamicLogLevel = ddloglevel
+
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
         DDLogVerbose("Verbose", level: ddloglevel)
         DDLogDebug("Debug", level: ddloglevel)
         DDLogInfo("Info", level: ddloglevel)

--- a/Framework/watchOSSwiftTest Extension/ExtensionDelegate.swift
+++ b/Framework/watchOSSwiftTest Extension/ExtensionDelegate.swift
@@ -13,11 +13,11 @@ import CocoaLumberjackSwift
 let ddloglevel = DDLogLevel.verbose
 
 private func printSomething() {
-    DDLogVerbose("Verbose");
-    DDLogDebug("Debug");
-    DDLogInfo("Info");
-    DDLogWarn("Warn");
-    DDLogError("Error");
+    DDLogVerbose("Verbose")
+    DDLogDebug("Debug")
+    DDLogInfo("Info")
+    DDLogWarn("Warn")
+    DDLogError("Error")
 }
 
 class ExtensionDelegate: NSObject, WKExtensionDelegate {
@@ -29,16 +29,18 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         DDTTYLogger.sharedInstance.logFormatter = formatter
         DDLog.add(DDTTYLogger.sharedInstance)
         
-        DDLogVerbose("Verbose");
-        DDLogDebug("Debug");
-        DDLogInfo("Info");
-        DDLogWarn("Warn");
-        DDLogError("Error");
-        
-        printSomething()
-        
-        defaultDebugLevel = ddloglevel
-        
+        DDLogVerbose("Verbose")
+        DDLogDebug("Debug")
+        DDLogInfo("Info")
+        DDLogWarn("Warn")
+        DDLogError("Error")
+
+        DDLogVerbose("Verbose", level: ddloglevel)
+        DDLogDebug("Debug", level: ddloglevel)
+        DDLogInfo("Info", level: ddloglevel)
+        DDLogWarn("Warn", level: ddloglevel)
+        DDLogError("Error", level: ddloglevel)
+
         printSomething()
     }
 

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -1876,7 +1876,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
+					"DD_LOG_LEVEL=DDLogLevelWarning",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Framework/iOSSwift/Info.plist";
@@ -1895,6 +1895,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/Framework/iOSSwift/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.deusty.$(PRODUCT_NAME:rfc1034identifier)";
@@ -1909,10 +1913,6 @@
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRIVATE_HEADERS_FOLDER_PATH = "$(BUILT_PRODUCTS_DIR)/private";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.cocoalumberjack.ios;
@@ -1946,10 +1946,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = Framework/iOSLibStaticTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.deusty.$(PRODUCT_NAME:rfc1034identifier)";
@@ -2075,6 +2071,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = Framework/tvOSSwiftTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.tvOSSwiftTest;
@@ -2093,6 +2093,10 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				COPY_PHASE_STRIP = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = Framework/tvOSSwiftTest/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.tvOSSwiftTest;
@@ -2195,6 +2199,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				IBSC_MODULE = watchOSSwiftTest_Extension;
 				INFOPLIST_FILE = Framework/watchOSSwiftTest/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.iOSSwiftTest.watchkitapp;
@@ -2214,6 +2222,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				IBSC_MODULE = watchOSSwiftTest_Extension;
 				INFOPLIST_FILE = Framework/watchOSSwiftTest/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.iOSSwiftTest.watchkitapp;
@@ -2232,6 +2244,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "Framework/watchOSSwiftTest Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.iOSSwiftTest.watchkitapp.watchkitextension;
@@ -2249,6 +2265,10 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "Framework/watchOSSwiftTest Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.deusty.iOSSwiftTest.watchkitapp.watchkitextension;
@@ -2358,7 +2378,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
+					"DD_LOG_LEVEL=DDLogLevelWarning",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/Framework/SwiftTest/Info.plist";
@@ -2380,6 +2400,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DD_LOG_LEVEL=DDLogLevelWarning",
+					"$(inherited)",
+				);
 				INFOPLIST_FILE = "$(SRCROOT)/Framework/SwiftTest/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07305D7B2167920B00C61363 /* SwiftLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 07305D7A216790F300C61363 /* SwiftLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07305D7C2167920C00C61363 /* SwiftLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 07305D7A216790F300C61363 /* SwiftLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07305D7D2167920C00C61363 /* SwiftLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 07305D7A216790F300C61363 /* SwiftLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		07305D7E2167920D00C61363 /* SwiftLogLevel.h in Headers */ = {isa = PBXBuildFile; fileRef = 07305D7A216790F300C61363 /* SwiftLogLevel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		07CA82901F90E89000FF0F17 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
 		07CA82911F90E89C00FF0F17 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19D90B261BBFA9DB00947169 /* CocoaLumberjack.framework */; };
 		07CA82921F90E8A800FF0F17 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 19190EDE1B84D812008D059E /* CocoaLumberjack.framework */; };
@@ -402,6 +406,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		07305D7A216790F300C61363 /* SwiftLogLevel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SwiftLogLevel.h; sourceTree = "<group>"; };
 		18F3BF0F1A81D8B700692297 /* CocoaLumberjackSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaLumberjackSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		18F3BF151A81D9A400692297 /* CocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjack.h; sourceTree = "<group>"; };
 		18F3BF5F1A81DD2E00692297 /* iOSSwiftTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSSwiftTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -809,6 +814,7 @@
 				DA9C20C9192A0E0000AB7171 /* DDTTYLogger.m */,
 				93483CFA1D09E39000AD40D6 /* CLIColor.h */,
 				93483CFB1D09E39000AD40D6 /* CLIColor.m */,
+				07305D7A216790F300C61363 /* SwiftLogLevel.h */,
 				DA9C20CA192A0E0000AB7171 /* Extensions */,
 			);
 			name = Lumberjack;
@@ -860,6 +866,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07305D7C2167920C00C61363 /* SwiftLogLevel.h in Headers */,
 				55F88BF81B3CB15C00E31255 /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -890,6 +897,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07305D7E2167920D00C61363 /* SwiftLogLevel.h in Headers */,
 				19190F0A1B84DB97008D059E /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -920,6 +928,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07305D7D2167920C00C61363 /* SwiftLogLevel.h in Headers */,
 				19D90B2C1BBFAA7500947169 /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -950,6 +959,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07305D7B2167920B00C61363 /* SwiftLogLevel.h in Headers */,
 				19FF46341B8B4EF800B43179 /* CocoaLumberjackSwift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #774 

### Pull Request Description

As described in #774, the previous `defaultDebugLevel` was a normal global variable, that could change at any time. Therefor the compiler did not strip strings that were logged with an inaccessible level.
This changes this by adding `@inlinable` to the Swift log functions (so the compiler is allowed to inline the code) and using a `static const` definition for the default log level. This definition now cannot be changed in Swift code, but needs to be defined either via the `GCC_PREPROCESSOR_DEFINITIONS` build setting, or using a `#define` in a bridging header of a Swift target.
