### PR TITLE
Replace OSAtomic with stdatomic in DDDispatchQueueLogFormatter

### DIFF
--- a/Classes/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.h
@@ -14,7 +14,6 @@
 //   prior written permission of Deusty, LLC.
 
 #import <Foundation/Foundation.h>
-#import <libkern/OSAtomic.h>
 
 // Disable legacy macros
 #ifndef DD_LEGACY_MACROS

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -17,6 +17,12 @@
 #import <pthread/pthread.h>
 #import <objc/runtime.h>
 
+#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
+#import <stdatomic.h>
+#else
+#import <libkern/OSAtomic.h>
+#endif
+
 #if !__has_feature(objc_arc)
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
@@ -24,8 +30,13 @@
 @interface DDDispatchQueueLogFormatter () {
     DDDispatchQueueLogFormatterMode _mode;
     NSString *_dateFormatterKey;
-    
+
+#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
+    _Atomic(int32_t) _atomicLoggerCount;
+#else
     int32_t _atomicLoggerCount;
+#endif
+
     NSDateFormatter *_threadUnsafeDateFormatter; // Use [self stringFromDate]
     
     pthread_mutex_t _mutex;
@@ -271,12 +282,22 @@
 
 - (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
     int32_t count = 0;
+
+#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
+    atomic_fetch_add_explicit(&_atomicLoggerCount, 1, memory_order_relaxed);
+#else
     count = OSAtomicIncrement32(&_atomicLoggerCount);
+#endif
+
     NSAssert(count <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
 }
 
 - (void)willRemoveFromLogger:(id <DDLogger> __attribute__((unused)))logger {
+#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
+    atomic_fetch_sub_explicit(&_atomicLoggerCount, 1, memory_order_relaxed);
+#else
     OSAtomicDecrement32(&_atomicLoggerCount);
+#endif
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

OSAtomicIncrement32 and OSAtomicDecrement32 were deprecated in iOS 10/macOS 10.12/watchOS 3. This doesn't affect anything when targeting earlier releases, but we build lumberjack with newer deployment targets so this silences a couple of warnings.

Similarly asl_log has been deprecated and replaced by os_log. I'm going to look in to conditionally using asl/os based on deployment target as well.