### PR TITLE
Improvement to PR #957 by creating DDAtomicCounter class

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -18,7 +18,6 @@
 #import <unistd.h>
 #import <sys/attr.h>
 #import <sys/xattr.h>
-#import <libkern/OSAtomic.h>
 
 #if !__has_feature(objc_arc)
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -25,7 +25,6 @@
 #import <objc/runtime.h>
 #import <mach/mach_host.h>
 #import <mach/host_info.h>
-#import <libkern/OSAtomic.h>
 #import <Availability.h>
 #if TARGET_OS_IOS
     #import <UIKit/UIDevice.h>

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.h
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.h
@@ -175,3 +175,17 @@ typedef NS_ENUM(NSUInteger, DDDispatchQueueLogFormatterMode){
 - (NSString *)formatLogMessage:(DDLogMessage *)logMessage;
 
 @end
+
+#pragma mark - DDAtomicCounter
+
+@protocol DDAtomicCountable <NSObject>
+
+- (instancetype)initWithDefaultValue:(int32_t)defaultValue;
+- (int32_t)increment;
+- (int32_t)decrement;
+- (int32_t)value;
+
+@end
+
+@interface DDAtomicCounter: NSObject<DDAtomicCountable>
+@end

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -271,8 +271,7 @@
 }
 
 - (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
-    int32_t count = [_atomicLoggerCounter increment];
-    NSAssert(count <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
+    NSAssert([_atomicLoggerCounter increment] <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
 }
 
 - (void)willRemoveFromLogger:(id <DDLogger> __attribute__((unused)))logger {

--- a/Classes/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Classes/Extensions/DDDispatchQueueLogFormatter.m
@@ -17,26 +17,16 @@
 #import <pthread/pthread.h>
 #import <objc/runtime.h>
 
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-#import <stdatomic.h>
-#else
-#import <libkern/OSAtomic.h>
-#endif
-
 #if !__has_feature(objc_arc)
 #error This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
 #endif
 
+#pragma mark - DDDispatchQueueLogFormatter
+
 @interface DDDispatchQueueLogFormatter () {
     DDDispatchQueueLogFormatterMode _mode;
     NSString *_dateFormatterKey;
-
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    _Atomic(int32_t) _atomicLoggerCount;
-#else
-    int32_t _atomicLoggerCount;
-#endif
-
+    DDAtomicCounter *_atomicLoggerCounter;
     NSDateFormatter *_threadUnsafeDateFormatter; // Use [self stringFromDate]
     
     pthread_mutex_t _mutex;
@@ -68,7 +58,7 @@
         // now `cls` is the class that provides implementation for `configureDateFormatter:`
         _dateFormatterKey = [NSString stringWithFormat:@"%s_NSDateFormatter", class_getName(cls)];
 
-        _atomicLoggerCount = 0;
+        _atomicLoggerCounter = [[DDAtomicCounter alloc] initWithDefaultValue:0];
         _threadUnsafeDateFormatter = nil;
 
         _minQueueLength = 0;
@@ -281,23 +271,66 @@
 }
 
 - (void)didAddToLogger:(id <DDLogger>  __attribute__((unused)))logger {
-    int32_t count = 0;
-
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    atomic_fetch_add_explicit(&_atomicLoggerCount, 1, memory_order_relaxed);
-#else
-    count = OSAtomicIncrement32(&_atomicLoggerCount);
-#endif
-
+    int32_t count = [_atomicLoggerCounter increment];
     NSAssert(count <= 1 || _mode == DDDispatchQueueLogFormatterModeShareble, @"Can't reuse formatter with multiple loggers in non-shareable mode.");
 }
 
 - (void)willRemoveFromLogger:(id <DDLogger> __attribute__((unused)))logger {
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    atomic_fetch_sub_explicit(&_atomicLoggerCount, 1, memory_order_relaxed);
+    [_atomicLoggerCounter decrement];
+}
+
+@end
+
+#pragma mark - DDAtomicCounter
+
+#define DD_OSATOMIC_API_DEPRECATED (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
+
+#if DD_OSATOMIC_API_DEPRECATED
+#import <stdatomic.h>
 #else
-    OSAtomicDecrement32(&_atomicLoggerCount);
+#import <libkern/OSAtomic.h>
+#endif
+
+@interface DDAtomicCounter() {
+#if DD_OSATOMIC_API_DEPRECATED
+    _Atomic(int32_t) _value;
+#else
+    int32_t _value;
 #endif
 }
+@end
+
+@implementation DDAtomicCounter
+
+- (instancetype)initWithDefaultValue:(int32_t)defaultValue {
+    if ((self = [super init])) {
+        _value = defaultValue;
+    }
+    return self;
+}
+
+- (int32_t)value {
+    return _value;
+}
+
+#if DD_OSATOMIC_API_DEPRECATED
+- (int32_t)increment {
+    atomic_fetch_add_explicit(&_value, 1, memory_order_relaxed);
+    return _value;
+}
+
+- (int32_t)decrement {
+    atomic_fetch_sub_explicit(&_value, 1, memory_order_relaxed);
+    return _value;
+}
+#else
+- (int32_t)increment {
+    return OSAtomicIncrement32(&_value);
+}
+
+- (int32_t)decrement {
+    return OSAtomicDecrement32(&_value);
+}
+#endif
 
 @end

--- a/Documentation/CustomFormatters.md
+++ b/Documentation/CustomFormatters.md
@@ -236,19 +236,8 @@ MyCustomFormatter.m
 ```objective-c
 #import "MyCustomFormatter.h"
 
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-#import <stdatomic.h>
-#else
-#import <libkern/OSAtomic.h>
-#endif
-
 @interface MyCustomFormatter () {
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    _Atomic(int32_t) atomicLoggerCount;
-#else
-    int32_t atomicLoggerCount;
-#endif
-
+    DDAtomicCounter *atomicLoggerCounter;
     NSDateFormatter *threadUnsafeDateFormatter;
 }
 
@@ -257,7 +246,7 @@ MyCustomFormatter.m
 @implementation MyCustomFormatter
 
 - (NSString *)stringFromDate:(NSDate *)date {
-    int32_t loggerCount = OSAtomicAdd32(0, &atomicLoggerCount);
+    int32_t loggerCount = [atomicLoggerCounter value];
     
     if (loggerCount <= 1) {
         // Single-threaded mode.
@@ -305,19 +294,11 @@ MyCustomFormatter.m
 }
 
 - (void)didAddToLogger:(id <DDLogger>)logger {
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    atomic_fetch_add_explicit(&atomicLoggerCount, 1, memory_order_relaxed);
-#else
-    OSAtomicIncrement32(&atomicLoggerCount);
-#endif
+    [atomicLoggerCounter increment];
 }
 
 - (void)willRemoveFromLogger:(id <DDLogger>)logger {
-#if (TARGET_OS_OSX && MAC_OS_X_VERSION_MIN_REQUIRED >= 101200) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 100000) || (TARGET_OS_WATCH && __WATCH_OS_VERSION_MIN_REQUIRED >= 30000) || (TARGET_OS_TV && __TV_OS_VERSION_MIN_REQUIRED >= 100000)
-    atomic_fetch_sub_explicit(&atomicLoggerCount, 1, memory_order_relaxed);
-#else
-    OSAtomicDecrement32(&atomicLoggerCount);
-#endif
+    [atomicLoggerCounter decrement];
 }
 
 @end

--- a/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
+++ b/Tests/CocoaLumberjack Tests.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		127BFA7C51A74CD671B24C5B /* Pods_OS_X_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F81D12D74290B60D80C6DA6C /* Pods_OS_X_Tests.framework */; };
 		432B534D1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */; };
 		432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */; };
+		80AC19B12170AC54007800DC /* DDAtomicCounterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */; };
+		80AC19B22170AC58007800DC /* DDAtomicCounterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */; };
 		E982AAF21AE2C25800088365 /* DDLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E982AAF11AE2C25800088365 /* DDLogTests.m */; };
 		E982AAF31AE2C25800088365 /* DDLogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E982AAF11AE2C25800088365 /* DDLogTests.m */; };
 		E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */; };
@@ -25,6 +27,7 @@
 		432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDBasicLoggingTests.m; sourceTree = "<group>"; };
 		6C482E729E790B10F0513D4B /* Pods_iOS_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iOS_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70242FDBEF27BBA94EEC35C6 /* Pods-OS X Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.release.xcconfig"; sourceTree = "<group>"; };
+		80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDAtomicCounterTests.m; sourceTree = "<group>"; };
 		CCBAE26EBA1DD5C4D8EAF9A6 /* Pods-OS X Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OS X Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OS X Tests/Pods-OS X Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		DA1B17371AB067EF004705E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E982AAF11AE2C25800088365 /* DDLogTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDLogTests.m; sourceTree = "<group>"; };
@@ -87,6 +90,7 @@
 				432B534C1AAE43A200843E69 /* DDBasicLoggingTests.m */,
 				E982AAF11AE2C25800088365 /* DDLogTests.m */,
 				E9D3C9E21AE28AF400E795C5 /* DDLogMessageTests.m */,
+				80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -286,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E982AAF21AE2C25800088365 /* DDLogTests.m in Sources */,
+				80AC19B12170AC54007800DC /* DDAtomicCounterTests.m in Sources */,
 				E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534D1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);
@@ -296,6 +301,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E982AAF31AE2C25800088365 /* DDLogTests.m in Sources */,
+				80AC19B22170AC58007800DC /* DDAtomicCounterTests.m in Sources */,
 				E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 				432B534E1AAE43A200843E69 /* DDBasicLoggingTests.m in Sources */,
 			);

--- a/Tests/Tests/DDAtomicCounterTests.m
+++ b/Tests/Tests/DDAtomicCounterTests.m
@@ -1,0 +1,61 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2014-2016, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+#import <XCTest/XCTest.h>
+#import "DDDispatchQueueLogFormatter.h"
+#import <Expecta/Expecta.h>
+
+@interface DDAtomicCounterTests : XCTestCase
+
+@end
+
+@implementation DDAtomicCounterTests
+
+- (void)testSimpleAtomicCounter {
+    DDAtomicCounter *atomicCounter = [[DDAtomicCounter alloc] initWithDefaultValue:0];
+    expect([atomicCounter value]).to.equal(0);
+    expect([atomicCounter increment]).to.equal(1);
+    expect([atomicCounter value]).to.equal(1);
+    expect([atomicCounter decrement]).to.equal(0);
+    expect([atomicCounter value]).to.equal(0);
+}
+
+- (void)testMultithreadAtomicCounter {
+    DDAtomicCounter *atomicCounter = [[DDAtomicCounter alloc] initWithDefaultValue:0];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Multithread atomic counter"];
+    dispatch_queue_global_t globalQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    __block BOOL firstOpDidFinish = NO;
+    __block BOOL secondOpDidFinish = NO;
+    dispatch_async(globalQueue, ^{
+        [atomicCounter increment];
+        expect([atomicCounter value]).to.equal(2);
+        firstOpDidFinish = YES;
+        if (firstOpDidFinish && secondOpDidFinish) {
+            [expectation fulfill];
+        }
+    });
+    dispatch_async(globalQueue, ^{
+        [atomicCounter increment];
+        expect([atomicCounter value]).to.equal(2);
+        secondOpDidFinish = YES;
+        if (firstOpDidFinish && secondOpDidFinish) {
+            [expectation fulfill];
+        }
+    });
+    
+    [self waitForExpectationsWithTimeout:5.0 handler:nil];
+}
+
+@end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #957 

### Pull Request Description

Improvement to PR #957 Replace `OSAtomic` with `stdatomic` in `DDDispatchQueueLogFormatter`
Created a `DDAtomicCounter` class with `DDAtomicCountable` protocol that encapsulates the atomic counting logic.
Using another macro `DD_OSATOMIC_API_DEPRECATED` instead of all the checks for min os version
Cleaned up the imports of `OSAtomic.h`
Added some basic tests of this new class

