### PR TITLE
Add danger support for PR checks

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+  - line_length
+  - function_parameter_count
+
+opt_in_rules:
+  - empty_count
+  - force_unwrapping

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,5 +130,8 @@ script:
     - pod install --project-directory=CaptureASL
     - xcodebuild clean build -workspace Demos.xcworkspace -scheme 'CaptureASL' -configuration Release -sdk iphonesimulator | xcpretty -c
 
+    - cd ..
+    - bundle exec danger
+
 after_success:
     - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [3.5.0 - Xcode 10 on ?? ??, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.0)
+- Add danger support for PR checks #962 - fixes #956
+- Merged framework targets + using `xcconfig` + deployment target `iOS 8` and `Mac OS 10.10` #959 e97da34
+- Doc update #955 e7414ae 0239196 #933
+- Replace `OSAtomic` with `stdatomic` in `DDDispatchQueueLogFormatter` #957 #958
+- Add Stale Bot + configuration #953
+- Use static const for default log level so Swift can strip strings #952
+- Update to Xcode 10 and Swift 4.2 complier #950
+- Xcode 10 scheme changes #949
+- Synchronous access to `currentLogFileHandle` #946
+- Full links to Docs and other resources so they are resolved on external pages (i.e. https://cocoapods.org/pods/CocoaLumberjack) e9d6971
+- Proper BSD 3-Clause License (the old one was incomplete) #942
+- Prevent memory access errors caused by a failed fetch #944
+- Fix common warnings emitted by `-Wall` `-Wconversion` `-Wextra` etc #943
+- Updated to CocoaPods 1.5.3 2d0590f
+- Uses Xcode 9.4 image for tests #939
+- Xcode (schemes) version bumps #938
+- Add `DDAssert` and `DDAssertionFailure` functions for Swift #934
+- Fixed compiler warnings #931
+- Add new queue label which will be hold by a manual created thread #932
+
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912
 - Fixed typo in pull request template #913

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -23,7 +23,7 @@ extension DDLogFlag {
 	public init(_ logLevel: DDLogLevel) {
         self = DDLogFlag(rawValue: logLevel.rawValue)
 	}
-    
+
     /// Returns the log level, or the lowest equivalant.
     public func toLogLevel() -> DDLogLevel {
         if let ourValid = DDLogLevel(rawValue: rawValue) {
@@ -55,7 +55,6 @@ public var dynamicLogLevel = DDLogLevel.all
 public func resetDynamicLogLevel() {
     dynamicLogLevel = .all
 }
-
 
 @available(*, deprecated, message: "Please use dynamicLogLevel", renamed: "dynamicLogLevel")
 public var defaultDebugLevel: DDLogLevel {
@@ -110,7 +109,7 @@ public func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel =
 /// Returns a String of the current filename, without full path or extension.
 ///
 /// Analogous to the C preprocessor macro `THIS_FILE`.
-public func CurrentFileName(_ fileName: StaticString = #file) -> String {
+public func currentFileName(_ fileName: StaticString = #file) -> String {
     var str = String(describing: fileName)
     if let idx = str.range(of: "/", options: .backwards)?.upperBound {
         str = String(str[idx...])
@@ -119,4 +118,11 @@ public func CurrentFileName(_ fileName: StaticString = #file) -> String {
         str = String(str[..<idx])
     }
     return str
+}
+
+// swiftlint:disable identifier_name
+// swiftlint doesn't like func names that begin with a capital letter - deprecated
+@available(*, deprecated, message: "Please use currentFileName", renamed: "currentFileName")
+public func CurrentFileName(_ fileName: StaticString = #file) -> String {
+    return currentFileName(fileName)
 }

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,86 @@
+# Sometimes it's a README fix, or something like that - which isn't relevant for
+# including in a project's CHANGELOG for example
+declared_trivial = github.pr_title.include? "#trivial"
+has_app_changes = !git.modified_files.grep(/Classes/).empty?
+
+# Make it more obvious that a PR is a work in progress and shouldn't be merged yet
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+
+# Warn when there is a big PR
+warn("Big PR") if git.lines_of_code > 500
+
+# Changelog entries are required for changes to library files.
+no_changelog_entry = !git.modified_files.include?("CHANGELOG.md")
+if has_app_changes && no_changelog_entry && !declared_trivial
+  warn("Any changes to library code should be reflected in the CHANGELOG. Please consider adding a note there about your change.")
+end
+
+# Added (or removed) library files need to be added (or removed) from the
+# Carthage Xcode project to avoid breaking things for our Carthage users.
+added_library_files = !(git.added_files.grep(/Classes.*\.{h,m,swift}/).empty?)
+deleted_library_files = !(git.deleted_files.grep(/Classes.*\.{h,m,swift}/).empty?)
+modified_carthage_xcode_project = !(git.modified_files.grep(/Lumberjack\.xcodeproj/).empty?)
+if (added_library_files || deleted_library_files) && !modified_carthage_xcode_project
+  fail("Added or removed library files require the Carthage Xcode project to be updated.")
+end
+
+# Warn when library files has been updated but not tests.
+tests_updated = !git.modified_files.grep(/Tests/).empty?
+if has_app_changes && !tests_updated
+  warn("The library files were changed, but the tests remained unmodified. Consider updating or adding to the tests to match the library changes.")
+end
+
+# Run SwiftLint
+swiftlint.lint_files "Classes/*.swift"
+
+# Check if Carthage modified and CocoaPods didn't or vice-versa
+modified_cocoapods = !(git.modified_files.grep(/CocoaLumberjack\.podspec/).empty?)
+if modified_carthage_xcode_project && !modified_cocoapods
+  warn("The Carthage project was modified but CocoaPods podspec wasn't. Did you forget to update the podspec?")
+end
+if !modified_carthage_xcode_project && modified_cocoapods
+  warn("The CocoaPods podspec was modified but the Carthage project wasn't. Did you forget to update the xcodeproj?")
+end
+
+# Check xcodeproj settings are not changed
+# Check to see if any of our project files contains a line with "SOURCE_ROOT" which indicates that the file isn't in sync with Finder.
+accepted_settings = [
+"APPLICATION_EXTENSION_API_ONLY",
+"ASSETCATALOG_COMPILER_APPICON_NAME",
+"ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME",
+"ATTRIBUTES",
+"CODE_SIGN_IDENTITY",
+"COMBINE_HIDPI_IMAGES",
+"FRAMEWORK_VERSION",
+"GCC_PRECOMPILE_PREFIX_HEADER",
+"GCC_PREFIX_HEADER",
+"IBSC_MODULE",
+"INFOPLIST_FILE",
+"MODULEMAP_FILE",
+"PRIVATE_HEADERS_FOLDER_PATH",
+"PRODUCT_BUNDLE_IDENTIFIER",
+"PRODUCT_NAME",
+"PUBLIC_HEADERS_FOLDER_PATH",
+"SDKROOT",
+"SUPPORTED_PLATFORMS",
+"TARGETED_DEVICE_FAMILY",
+"WRAPPER_EXTENSION"
+]
+
+if modified_carthage_xcode_project
+  ["Lumberjack.xcodeproj/project.pbxproj"].each do |project_file|
+    next unless File.file?(project_file)
+    File.readlines(project_file).each_with_index do |line, index|
+	  if line.include?("sourceTree = SOURCE_ROOT;") and line.include?("PBXFileReference")
+        warn("Files should be in sync with project structure", file: project_file, line: index+1) 
+	  end
+	  line_containing_setting = line.match(/[A-Z_]+ = .*;/)
+	  if line_containing_setting
+	    setting = line_containing_setting[0].split(' = ')[0]
+	    if !accepted_settings.include?(setting)
+	      warn("Xcode settings need to remain in Configs/*.xcconfig. Please move " + setting + " to the xcodeproj file")
+	    end
+	  end
+	end
+  end
+end

--- a/Framework/Lumberjack.xcworkspace/contents.xcworkspacedata
+++ b/Framework/Lumberjack.xcworkspace/contents.xcworkspacedata
@@ -11,22 +11,28 @@
       location = "container:.."
       name = "Pod">
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/CocoaLumberjack.podspec">
+         location = "group:CHANGELOG.md">
       </FileRef>
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/CHANGELOG.md">
+         location = "group:CocoaLumberjack.podspec">
       </FileRef>
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/LICENSE">
+         location = "group:Dangerfile">
       </FileRef>
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/LumberjackLogo.png">
+         location = "group:Gemfile">
       </FileRef>
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/README.md">
+         location = "group:LICENSE">
       </FileRef>
       <FileRef
-         location = "group:/Users/bogdan/Github/CocoaLumberjack/uncrustify.cfg">
+         location = "group:LumberjackLogo.png">
+      </FileRef>
+      <FileRef
+         location = "group:README.md">
+      </FileRef>
+      <FileRef
+         location = "group:uncrustify.cfg">
       </FileRef>
    </Group>
    <FileRef

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'danger'
+gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,60 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    claide (1.0.2)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.7.0)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1.5)
+      kramdown (~> 1.5)
+      no_proxy_fix
+      octokit (~> 4.7)
+      terminal-table (~> 1)
+    danger-swiftlint (0.17.4)
+      danger
+      rake (> 10)
+      thor (~> 0.19)
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.5.0)
+    kramdown (1.17.0)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    no_proxy_fix (0.1.2)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (3.0.3)
+    rake (12.3.1)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    thor (0.20.0)
+    unicode-display_width (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+  danger-swiftlint
+
+BUNDLED WITH
+   1.16.5


### PR DESCRIPTION
Added [Danger](https://github.com/danger/danger) integration using their wizard (`bundle exec danger init`):
- Swift lint checks
- warning for PR marked In progress (using PR title)
- warning for big PRs (>500 lines of code)
- warning for source files changed without a change in `CHANGELOG.md`
- check if file additions/deletions from the `Classes` folder are matched by changes to `Lumberjack.xcodeproj`
- warn if the source files were changed but not the tests
- check if Carthage modified and CocoaPods didn't or vice-versa
- check the Xcode settings for new additions - they should be added to the `xcconfig` files
- also check for files added to the xcodeproj that don't match the folder structure (from Finder)

Repaired some Xcode proj paths to the metadata files (not affecting compilation).
