### PR TITLE
Let Travis only build for pushes to master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 language: objective-c
 osx_image: xcode10
 
+branches:
+    only:
+        - master
+
 env:
   global:
     - LC_CTYPE=en_US.UTF-8
@@ -77,7 +81,7 @@ script:
     - xcodebuild clean build -workspace Demos/Demos.xcworkspace -scheme 'TextXcodeColors (Mobile)' -configuration Release -sdk iphonesimulator | xcpretty -c
     - xcodebuild clean build -workspace Demos/Demos.xcworkspace -scheme 'UniversalApp' -configuration Release -sdk iphonesimulator | xcpretty -c
     - xcodebuild clean build -workspace Demos/Demos.xcworkspace -scheme 'WebServerIPhone' -configuration Release -sdk iphonesimulator | xcpretty -c
-    
+
     - bundle exec danger
 
 after_success:


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Travis currently builds all pushes to all branches in the repo. This limits Travis to the master branch. PR builds should not be affected by this. In fact, Travis should only do one build per PR now, instead of also doing a push-triggered build (at least for the PRs coming from branches in this repo).
