### PR TITLE
Reduce podspec to 3 subspecs(Core, CLI, and Swift)

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc   = true
 
-  s.preserve_paths = 'README.md', 'Classes/CocoaLumberjack.swift', 'Framework/Lumberjack/CocoaLumberjack.modulemap'
+  s.preserve_paths = 'README.md'
 
   s.ios.deployment_target     = '8.0'
   s.osx.deployment_target     = '10.10'

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -25,33 +25,22 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = '9.0'
   s.swift_version = '4.2'
 
-  s.default_subspecs = 'Default', 'Extensions'
-
-  s.subspec 'Default' do |ss|
-    ss.source_files         = 'Classes/CocoaLumberjack.h', 'Classes/DD*.{h,m}'
-    ss.public_header_files  = 'Classes/CocoaLumberjack.h', 'Classes/DD*.h'
-  end
+  s.default_subspecs = 'Core'
 
   s.subspec 'Core' do |ss|
-    ss.source_files         = 'Classes/DD*.{h,m}'
-    ss.public_header_files  = 'Classes/DD*.h'
-  end
-
-  s.subspec 'Extensions' do |ss|
-    ss.dependency 'CocoaLumberjack/Default'
-    ss.source_files         = 'Classes/Extensions/*.{h,m}'
-    ss.public_header_files  = 'Classes/Extensions/*.h'
+    ss.source_files         = 'Classes/CocoaLumberjack.h', 'Classes/DD*.{h,m}', 'Classes/Extensions/*.{h,m}'
+    ss.public_header_files  = 'Classes/CocoaLumberjack.h', 'Classes/DD*.h',     'Classes/Extensions/*.h'
   end
 
   s.subspec 'CLI' do |ss|
     ss.osx.deployment_target    = '10.10'
-    ss.osx.dependency 'CocoaLumberjack/Default'
+    ss.osx.dependency 'CocoaLumberjack/Core'
     ss.osx.source_files         = 'Classes/CLI/*.{h,m}'
     ss.osx.public_header_files  = 'Classes/CLI/*.h'
   end
 
   s.subspec 'Swift' do |ss|
-    ss.dependency 'CocoaLumberjack/Default'
+    ss.dependency 'CocoaLumberjack/Core'
     ss.source_files        = 'Classes/CocoaLumberjack.swift', 'Classes/DDAssert.swift', 'Classes/SwiftLogLevel.h'
     ss.public_header_files = 'Classes/SwiftLogLevel.h'
   end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #954 

### Pull Request Description

Reduces podspec to 3 subspaces(Core, CLI, and Swift) to simplify usage of CocoaPods.
And the default spec has been including `Classes/Extensions/*` until now, but swift subspec has not.
This PR reduces this difference.

