### PR TITLE
Fixes an issue where log messages were being combined or truncated when logged at high speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add `DDAssert` and `DDAssertionFailure` functions for Swift #934
 - Fixed compiler warnings #931
 - Add new queue label which will be hold by a manual created thread #932
+- DDFileLogger log message is overridden #924
 
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1019,6 +1019,7 @@ static int exception_count = 0;
         @try {
             [self willLogMessage];
 			
+            [[self currentLogFileHandle] seekToEndOfFile];
             [[self currentLogFileHandle] writeData:logData];
 
             [self didLogMessage];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: On macOS 10.14, log messages are being jumbled when written to disk. The NSFileHandle is not writing to the end of the file correctly resulting in output that overwrites other log messages. I didn't have this problem in 10.13; it appears to be a new issue in 10.14.

Example:
```
2018/11/12 15:16:51:302  Import Prot2018/11/12 152018/11/12 15:16:51:304  Import Serv2018/11/12 15:2018/11/12 15:16:51:306  Import Serv2018/11/12 152018/11/12 15:16:51:307  Import Serv2018/11/12 15:2018/11/12 15:16:51:309  Import Servers Started.
```

### Pull Request Description

This pull requests makes sure to seek to the end of the log file before writing the log message. 

