### PR TITLE
Fix availability checks in DDLog.m. Also fix memory leak. Fixes #995

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add new queue label which will be hold by a manual created thread #932
 - DDFileLogger log message is overridden #924
 - Fix thread safety issue in DDFileLogger #986
+- Fix availability checks and memory leak #996
 
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -764,8 +764,9 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 
     _rollingTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.loggerQueue);
 
+    __weak __auto_type weakSelf = self;
     dispatch_source_set_event_handler(_rollingTimer, ^{ @autoreleasepool {
-                                                           [self maybeRollLogFileDueToAge];
+                                                           [weakSelf maybeRollLogFileDueToAge];
                                                        } });
 
     #if !OS_OBJECT_USE_OBJC
@@ -983,10 +984,11 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
                                                               DISPATCH_VNODE_DELETE | DISPATCH_VNODE_RENAME,
                                                               self.loggerQueue
                                                               );
-                
+
+                __weak __auto_type weakSelf = self;
                 dispatch_source_set_event_handler(self->_currentLogFileVnode, ^{ @autoreleasepool {
                     NSLogInfo(@"DDFileLogger: Current logfile was moved. Rolling it and creating a new one");
-                    [self rollLogFileNow];
+                    [weakSelf rollLogFileNow];
                 } });
                 
 #if !OS_OBJECT_USE_OBJC

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -28,6 +28,9 @@
 #import <Availability.h>
 #if TARGET_OS_IOS
     #import <UIKit/UIDevice.h>
+    #import <UIKit/UIApplication.h>
+#elif !defined(DD_CLI) && __has_include(<AppKit/NSApplication.h>)
+    #import <AppKit/NSApplication.h>
 #endif
 
 
@@ -180,24 +183,23 @@ static NSUInteger _numProcessors;
         self._loggers = [[NSMutableArray alloc] initWithCapacity:4];
         
 #if TARGET_OS_IOS
-        NSString *notificationName = @"UIApplicationWillTerminateNotification";
+        NSString *notificationName = UIApplicationWillTerminateNotification;
 #else
         NSString *notificationName = nil;
-        
+
         // On Command Line Tool apps AppKit may not be avaliable
-#ifdef NSAppKitVersionNumber10_0
-        
+#if !defined(DD_CLI) && __has_include(<AppKit/NSApplication.h>)
         if (NSApp) {
-            notificationName = @"NSApplicationWillTerminateNotification";
+            notificationName = NSApplicationWillTerminateNotification;
         }
-        
 #endif
-        
+
         if (!notificationName) {
             // If there is no NSApp -> we are running Command Line Tool app.
             // In this case terminate notification wouldn't be fired, so we use workaround.
+            __weak __auto_type weakSelf = self;
             atexit_b (^{
-                [self applicationWillTerminate:nil];
+                [weakSelf applicationWillTerminate:nil];
             });
         }
         


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #995 

### Pull Request Description

The availability checks in DDLog.m in `init` don't work anymore, because `NSAppKitVersionNumber10_0` is no longer a define.
This fixes this by checking for CLI tools with `DD_CLI` (which is used in other places) and `__has_include`.
Furthermore, the memory leak of custom DDLog objects captured in `atexit_b`.
And I've switched to use the constants provided by the frameworks for the notification names.
