### PR TITLE
Added support for log file headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add new queue label which will be hold by a manual created thread #932
 - DDFileLogger log message is overridden #924
 - Fix thread safety issue in DDFileLogger #986
+- Added `initialFileContents` property to `DDLogFileManagerDefault` to set log file header
 
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - DDFileLogger log message is overridden #924
 - Fix thread safety issue in DDFileLogger #986
 - Fix availability checks and memory leak #996
-- Added `initialFileContents` property to `DDLogFileManagerDefault` to set log file header
+- Added `logFileHeader` property to `DDLogFileManagerDefault` which you can override to set log file header
 
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912

--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -252,9 +252,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  * New log files are created empty by default in `createNewLogFile:` method
  *
  * If you wish to specify a common file header to use in your log files,
- * you can set the initial log file contents by overriding `initialFileContents`
+ * you can set the initial log file contents by overriding `logFileHeader`
  **/
-@property (readonly, copy) NSString *initialFileContents;
+@property (readonly, copy) NSString *logFileHeader;
 
 /* Inherited from DDLogFileManager protocol:
 

--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -248,6 +248,14 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  **/
 - (BOOL)isLogFile:(NSString *)fileName NS_SWIFT_NAME(isLogFile(withName:));
 
+/**
+ * New log files are created empty by default in `createNewLogFile:` method
+ *
+ * If you wish to specify a common file header to use in your log files,
+ * you can set the initial log file contents by overriding `initialFileContents`
+ **/
+@property (readonly, copy) NSString *initialFileContents;
+
 /* Inherited from DDLogFileManager protocol:
 
    @property (readwrite, assign, atomic) NSUInteger maximumNumberOfLogFiles;

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -68,7 +68,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 - (void)deleteOldLogFiles;
 - (NSString *)defaultLogsDirectory;
 
-@property (readonly, copy) NSData *initialFileContentsData;
+@property (readonly, copy) NSData *logFileHeaderData;
 
 @end
 
@@ -429,12 +429,12 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     return [NSString stringWithFormat:@"%@ %@.log", appName, formattedDate];
 }
 
-- (NSString *)initialFileContents {
+- (NSString *)logFileHeader {
     return nil;
 }
 
-- (NSData *)initialFileContentsData {
-    NSString *fileContentsStr = [self initialFileContents];
+- (NSData *)logFileHeaderData {
+    NSString *fileContentsStr = [self logFileHeader];
     
     if (fileContentsStr == nil || [fileContentsStr length] == 0) {
         return nil;
@@ -450,7 +450,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 - (NSString *)createNewLogFile {
     NSString *fileName = [self newLogFileName];
     NSString *logsDirectory = [self logsDirectory];
-    NSData *fileContents = [self initialFileContentsData];
+    NSData *fileContents = [self logFileHeaderData];
 
     NSUInteger attempt = 1;
 

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -434,23 +434,23 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 }
 
 - (NSData *)logFileHeaderData {
-    NSString *fileContentsStr = [self logFileHeader];
+    NSString *fileHeaderStr = [self logFileHeader];
     
-    if (fileContentsStr == nil || [fileContentsStr length] == 0) {
+    if (fileHeaderStr == nil || [fileHeaderStr length] == 0) {
         return nil;
     }
     
     // Ensure that we have a newline at the end of the string
-    fileContentsStr = [NSString stringWithFormat:@"%@\n", fileContentsStr];
+    fileHeaderStr = [NSString stringWithFormat:@"%@\n", fileHeaderStr];
     
-    NSData *fileContentsData = [fileContentsStr dataUsingEncoding:NSUTF8StringEncoding];
-    return fileContentsData;
+    NSData *fileHeaderData = [fileHeaderStr dataUsingEncoding:NSUTF8StringEncoding];
+    return fileHeaderData;
 }
 
 - (NSString *)createNewLogFile {
     NSString *fileName = [self newLogFileName];
     NSString *logsDirectory = [self logsDirectory];
-    NSData *fileContents = [self logFileHeaderData];
+    NSData *fileHeader = [self logFileHeaderData];
 
     NSUInteger attempt = 1;
 
@@ -490,7 +490,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
             };
         #endif
 
-            [[NSFileManager defaultManager] createFileAtPath:filePath contents:fileContents attributes:attributes];
+            [[NSFileManager defaultManager] createFileAtPath:filePath contents:fileHeader attributes:attributes];
 
             // Since we just created a new log file, we may need to delete some old log files
             [self deleteOldLogFiles];

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -68,6 +68,8 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 - (void)deleteOldLogFiles;
 - (NSString *)defaultLogsDirectory;
 
+@property (readonly, copy) NSData *initialFileContentsData;
+
 @end
 
 @implementation DDLogFileManagerDefault
@@ -427,9 +429,28 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     return [NSString stringWithFormat:@"%@ %@.log", appName, formattedDate];
 }
 
+- (NSString *)initialFileContents {
+    return nil;
+}
+
+- (NSData *)initialFileContentsData {
+    NSString *fileContentsStr = [self initialFileContents];
+    
+    if (fileContentsStr == nil || [fileContentsStr length] == 0) {
+        return nil;
+    }
+    
+    // Ensure that we have a newline at the end of the string
+    fileContentsStr = [NSString stringWithFormat:@"%@\n", fileContentsStr];
+    
+    NSData *fileContentsData = [fileContentsStr dataUsingEncoding:NSUTF8StringEncoding];
+    return fileContentsData;
+}
+
 - (NSString *)createNewLogFile {
     NSString *fileName = [self newLogFileName];
     NSString *logsDirectory = [self logsDirectory];
+    NSData *fileContents = [self initialFileContentsData];
 
     NSUInteger attempt = 1;
 
@@ -469,7 +490,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
             };
         #endif
 
-            [[NSFileManager defaultManager] createFileAtPath:filePath contents:nil attributes:attributes];
+            [[NSFileManager defaultManager] createFileAtPath:filePath contents:fileContents attributes:attributes];
 
             // Since we just created a new log file, we may need to delete some old log files
             [self deleteOldLogFiles];

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		0A7E1D58217A86EF0011CFEB /* DDSMocking.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A7E1D56217A7A380011CFEB /* DDSMocking.m */; };
 		80AC19B12170AC54007800DC /* DDAtomicCounterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */; };
 		80AC19B22170AC58007800DC /* DDAtomicCounterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */; };
+		B2C90DDF21B9796400A72FD2 /* DDLogFileManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C90DDE21B9796400A72FD2 /* DDLogFileManagerTests.m */; };
+		B2C90DE321B9797800A72FD2 /* DDLogFileManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2C90DDE21B9796400A72FD2 /* DDLogFileManagerTests.m */; };
 		C7A5AB022191DA4D0074B29F /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C7A5AB012191DA4D0074B29F /* DDBasicLoggingTests.m */; };
 		C7A5AB032191DA4D0074B29F /* DDBasicLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C7A5AB012191DA4D0074B29F /* DDBasicLoggingTests.m */; };
 		C7A5AB052191DB530074B29F /* DDOSLoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C7A5AB042191DB530074B29F /* DDOSLoggingTests.m */; };
@@ -57,6 +59,7 @@
 		435F03B32174AB9600A86B2D /* Module-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Module-Debug.xcconfig"; sourceTree = "<group>"; };
 		435F03B42174AB9600A86B2D /* Module-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Module-Shared.xcconfig"; sourceTree = "<group>"; };
 		80AC19B02170AC54007800DC /* DDAtomicCounterTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDAtomicCounterTests.m; sourceTree = "<group>"; };
+		B2C90DDE21B9796400A72FD2 /* DDLogFileManagerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDLogFileManagerTests.m; sourceTree = "<group>"; };
 		C7A5AB012191DA4D0074B29F /* DDBasicLoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDBasicLoggingTests.m; sourceTree = "<group>"; };
 		C7A5AB042191DB530074B29F /* DDOSLoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DDOSLoggingTests.m; sourceTree = "<group>"; };
 		DA1B17371AB067EF004705E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -132,6 +135,7 @@
 				C7A5AB042191DB530074B29F /* DDOSLoggingTests.m */,
 				0A7E1D55217A7A380011CFEB /* DDSMocking.h */,
 				0A7E1D56217A7A380011CFEB /* DDSMocking.m */,
+				B2C90DDE21B9796400A72FD2 /* DDLogFileManagerTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -278,6 +282,7 @@
 				C7A5AB022191DA4D0074B29F /* DDBasicLoggingTests.m in Sources */,
 				E982AAF21AE2C25800088365 /* DDLogTests.m in Sources */,
 				80AC19B12170AC54007800DC /* DDAtomicCounterTests.m in Sources */,
+				B2C90DDF21B9796400A72FD2 /* DDLogFileManagerTests.m in Sources */,
 				E9D3C9E31AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -291,6 +296,7 @@
 				C7A5AB032191DA4D0074B29F /* DDBasicLoggingTests.m in Sources */,
 				E982AAF31AE2C25800088365 /* DDLogTests.m in Sources */,
 				80AC19B22170AC58007800DC /* DDAtomicCounterTests.m in Sources */,
+				B2C90DE321B9797800A72FD2 /* DDLogFileManagerTests.m in Sources */,
 				E9D3C9E41AE28AF400E795C5 /* DDLogMessageTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Tests/DDLogFileManagerTests.m
+++ b/Tests/Tests/DDLogFileManagerTests.m
@@ -32,8 +32,7 @@
 }
 
 - (void)setUpLogFileManager {
-    NSString *logsDirectory = NSTemporaryDirectory();
-    self.logFileManager = [[DDLogFileManagerDefault alloc] initWithLogsDirectory:logsDirectory];
+    self.logFileManager = [[DDLogFileManagerDefault alloc] initWithLogsDirectory:NSTemporaryDirectory()];
 }
 
 - (void)tearDown {
@@ -42,8 +41,7 @@
 }
 
 - (void)deleteLogFile:(NSString *)filePath {
-    NSError *error = nil;
-    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:nil]) {
         // file was deleted
         XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:filePath]);
     }
@@ -53,7 +51,7 @@
 }
 
 - (void)testCreateNewLogFile {
-    NSString *filePath = [self.logFileManager createNewLogFile];
+    __auto_type filePath = [self.logFileManager createNewLogFile];
     
     if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
         [self deleteLogFile:filePath];
@@ -64,11 +62,11 @@
 }
 
 - (void)testCreateNewLogFileAssertEmpty {
-    NSString *filePath = [self.logFileManager createNewLogFile];
+    __auto_type filePath = [self.logFileManager createNewLogFile];
     
     if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
         // check that log file is created empty
-        unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
+        __auto_type fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
         XCTAssertEqual(fileSize, 0);
 
         [self deleteLogFile:filePath];
@@ -105,8 +103,7 @@
 }
 
 - (void)setUpLogFileManager {
-    NSString *logsDirectory = NSTemporaryDirectory();
-    self.logFileManager = [[DDLogFileManagerOverride alloc] initWithLogsDirectory:logsDirectory];
+    self.logFileManager = [[DDLogFileManagerOverride alloc] initWithLogsDirectory:NSTemporaryDirectory()];
 }
 
 - (void)tearDown {
@@ -115,8 +112,7 @@
 }
 
 - (void)deleteLogFile:(NSString *)filePath {
-    NSError *error = nil;
-    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:nil]) {
         // file was deleted
         XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:filePath]);
     }
@@ -126,16 +122,16 @@
 }
 
 - (void)testCreateNewLogFileAssertCorrectContents {
-    NSString *filePath = [self.logFileManager createNewLogFile];
+    __auto_type filePath = [self.logFileManager createNewLogFile];
     
     if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
         // check that log file is _not_ created empty
-        unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
+        __auto_type fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
         XCTAssertNotEqual(fileSize, 0);
         
         // check that initial contents is equal to input text
-        NSString *strToFile = [NSString stringWithFormat:@"%@\n", [self.logFileManager logFileHeader]];
-        NSString *strFromFile = [NSString  stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
+        __auto_type strToFile = [NSString stringWithFormat:@"%@\n", [self.logFileManager logFileHeader]];
+        __auto_type strFromFile = [NSString  stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
         if(![strFromFile isEqualToString: strToFile]) {
             XCTFail("Log file contents is incorrect!");
         }

--- a/Tests/Tests/DDLogFileManagerTests.m
+++ b/Tests/Tests/DDLogFileManagerTests.m
@@ -1,0 +1,154 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2018, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+@import XCTest;
+#import <CocoaLumberjack/CocoaLumberjack.h>
+
+
+#pragma mark Test Case for DDLogFileManagerDefault
+// Feel free to extend :-)
+
+@interface DDLogFileManagerDefaultTests : XCTestCase
+@property (nonatomic, strong, readwrite) DDLogFileManagerDefault *logFileManager;
+@end
+
+@implementation DDLogFileManagerDefaultTests
+
+- (void)setUp {
+    [super setUp];
+    [self setUpLogFileManager];
+}
+
+- (void)setUpLogFileManager {
+    NSString *logsDirectory = NSTemporaryDirectory();
+    self.logFileManager = [[DDLogFileManagerDefault alloc] initWithLogsDirectory:logsDirectory];
+}
+
+- (void)tearDown {
+    self.logFileManager = nil;
+    [super tearDown];
+}
+
+- (void)deleteLogFile:(NSString *)filePath {
+    NSError *error = nil;
+    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+        // file was deleted
+        XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:filePath]);
+    }
+    else {
+        XCTFail("Log file was not deleted!");
+    }
+}
+
+- (void)testCreateNewLogFile {
+    NSString *filePath = [self.logFileManager createNewLogFile];
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        [self deleteLogFile:filePath];
+    }
+    else {
+        XCTFail("Log file was not created!");
+    }
+}
+
+- (void)testCreateNewLogFileAssertEmpty {
+    NSString *filePath = [self.logFileManager createNewLogFile];
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        // check that log file is created empty
+        unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
+        XCTAssertEqual(fileSize, 0);
+
+        [self deleteLogFile:filePath];
+    }
+    else {
+        XCTFail("Log file was not created!");
+    }
+}
+
+@end
+
+
+#pragma mark Test Case for DDLogFileManagerOverride
+
+@interface DDLogFileManagerOverride : DDLogFileManagerDefault
+@end
+
+@implementation DDLogFileManagerOverride
+- (NSString *)logFileHeader {
+    return @"This is a test!";
+}
+@end
+
+
+@interface DDLogFileManagerOverrideTests : XCTestCase
+@property (nonatomic, strong, readwrite) DDLogFileManagerOverride *logFileManager;
+@end
+
+@implementation DDLogFileManagerOverrideTests
+
+- (void)setUp {
+    [super setUp];
+    [self setUpLogFileManager];
+}
+
+- (void)setUpLogFileManager {
+    NSString *logsDirectory = NSTemporaryDirectory();
+    self.logFileManager = [[DDLogFileManagerOverride alloc] initWithLogsDirectory:logsDirectory];
+}
+
+- (void)tearDown {
+    self.logFileManager = nil;
+    [super tearDown];
+}
+
+- (void)deleteLogFile:(NSString *)filePath {
+    NSError *error = nil;
+    if ([[NSFileManager defaultManager] removeItemAtPath:filePath error:&error]) {
+        // file was deleted
+        XCTAssertFalse([[NSFileManager defaultManager] fileExistsAtPath:filePath]);
+    }
+    else {
+        XCTFail("Log file was not deleted!");
+    }
+}
+
+- (void)testCreateNewLogFileAssertCorrectContents {
+    NSString *filePath = [self.logFileManager createNewLogFile];
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:filePath]) {
+        // check that log file is _not_ created empty
+        unsigned long long fileSize = [[[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:nil][NSFileSize] unsignedLongLongValue];
+        XCTAssertNotEqual(fileSize, 0);
+        
+        // check that initial contents is equal to input text
+        NSString *strToFile = [NSString stringWithFormat:@"%@\n", [self.logFileManager logFileHeader]];
+        NSString *strFromFile = [NSString  stringWithContentsOfFile:filePath encoding:NSUTF8StringEncoding error:nil];
+        if(![strFromFile isEqualToString: strToFile]) {
+            XCTFail("Log file contents is incorrect!");
+        }
+        
+        [self deleteLogFile:filePath];
+    }
+    else {
+        XCTFail("Log file was not created!");
+    }
+}
+
+//- (void)testCreateNewLogFileWithNewLogFileName {
+//}
+
+@end
+


### PR DESCRIPTION
Added property `initialFileContents` to `DDLogFileManagerDefault` to support headers in log files.
Override implementation of `initialFileContents` to insert header text at the beginning of every log file created by the `createNewLogFile:` method.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

We wish to include the version and build date of our application at the beginning of the log files generated by CocoaLumberjack. I have not been able to find any obvious way of doing this so I propose adding an `initialFileContents` property to `DDLogFileManagerDefault` which the  `createNewLogFile:` method then uses as an argument for the 'contents' parameter (instead of nil) when calling `createFileAtPath:contents:attributes:`

The intention is to achieve something which is possible in NLog (though NLog is a very different beast), using `LayoutWithHeaderAndFooter`.