### PR TITLE
DDFileLogger queues and refactoring

### DIFF
--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -302,9 +302,7 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 /**
  *  The standard implementation for a file logger
  */
-@interface DDFileLogger : DDAbstractLogger <DDLogger> {
-	DDLogFileInfo *_currentLogFileInfo;
-}
+@interface DDFileLogger : DDAbstractLogger <DDLogger>
 
 /**
  *  Default initializer


### PR DESCRIPTION
- Use already provided queue to manage access to variables in file logger. The queue is created in the abstract superclass as a serial queue, which fits our needs.
- Prefix internal methods meant to be called on internal queue and add asserts to avoid further threading issues.
- Refactor out some if statements determining which log files to archive.
- Add DISPATCH_VNODE_REVOKE to vnode observation flags.
- Remove usage of `fileExistsAtPath:`, instead just attempt the operation. withIntermediateDirectories: YES doesn't return error if directory exists.

