### PR TITLE
Make the import path local for simple static embedding.

### DIFF
--- a/Classes/DDFileLogger+Internal.h
+++ b/Classes/DDFileLogger+Internal.h
@@ -13,7 +13,7 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import <CocoaLumberjack/CocoaLumberjack.h>
+#import "CocoaLumberjack.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Classes/Extensions/DDFileLogger+Buffering.h
+++ b/Classes/Extensions/DDFileLogger+Buffering.h
@@ -13,7 +13,7 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-#import <CocoaLumberjack/CocoaLumberjack.h>
+#import "CocoaLumberjack.h"
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
### New Pull Request Checklist

* [ X] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [X ] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [ X] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [X ] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:

<CocoaLumberjack/CocoaLumberjack.h> not found in builds just using the source files.

### Pull Request Description

When using CocoaLumberjack by just importing the source and header files (no framework, no static library), the include <CocoaLumberjack/CocoaLumberjack.h> will not work. but simply using "CocoaLumberjack.h" does work and the original targets still compile.

