### PR TITLE
Update Danger and Dangerfile #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -72,13 +72,13 @@ if modified_carthage_xcode_project
     next unless File.file?(project_file)
     File.readlines(project_file).each_with_index do |line, index|
 	  if line.include?("sourceTree = SOURCE_ROOT;") and line.include?("PBXFileReference")
-        warn("Files should be in sync with project structure", file: project_file, line: index+1) 
+        warn("Files should be in sync with project structure", file: project_file, line: index+1)
 	  end
 	  line_containing_setting = line.match(/[A-Z_]+ = .*;/)
 	  if line_containing_setting
 	    setting = line_containing_setting[0].split(' = ')[0]
 	    if !accepted_settings.include?(setting)
-	      warn("Xcode settings need to remain in Configs/*.xcconfig. Please move " + setting + " to the xcodeproj file")
+	      warn("Xcode settings need to remain in Configs/*.xcconfig. Please move " + setting + " to the xcconfig file")
 	    end
 	  end
 	end
@@ -113,6 +113,15 @@ demos_copyright_lines = [
 "//"
 ]
 
+benchmarking_copyright_lines = [
+"//",
+"//  ",
+"//  ",
+"//",
+"//  CococaLumberjack Benchmarking",
+"//"
+]
+
 # sourcefiles_to_check = Dir.glob("*/*/*") # uncomment when we want to test all the files (locally)
 
 sourcefiles_to_check = (git.modified_files + git.added_files).uniq
@@ -122,10 +131,12 @@ sourcefiles_to_check.each do |sourcefile|
   next unless (fileExtension===".swift" or fileExtension===".h" or fileExtension===".m")
   next unless File.file?(sourcefile)
 
-  # decision: source files will check against source_copyright_lines, while demos against demos_copyright_lines
+  # Use correct copyright lines depending on source file location
   copyright_lines = source_copyright_lines
   if sourcefile.start_with?("Demos/")
     copyright_lines = demos_copyright_lines
+  elsif sourcefile.start_with?("Benchmarking/")
+    copyright_lines = benchmarking_copyright_lines
   end
   File.readlines(sourcefile)[0..copyright_lines.count-1].each_with_index do |line, index|
     if !line.include?(copyright_lines[index])
@@ -136,5 +147,5 @@ sourcefiles_to_check.each do |sourcefile|
   end
 end
 if invalid_copyright === true
-  warn("Copyright is not valid. See our default copyright in all of our files (Classed and Demos use different format).")
+  warn("Copyright is not valid. See our default copyright in all of our files (Classes, Demos and Benchmarking use different formats).")
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.7.0)
+    danger (5.11.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -23,11 +23,11 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-swiftlint (0.17.4)
+    danger-swiftlint (0.18.1)
       danger
       rake (> 10)
       thor (~> 0.19)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
@@ -40,14 +40,14 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (3.0.3)
-    rake (12.3.1)
+    rake (12.3.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.0)
-    unicode-display_width (1.4.0)
+    thor (0.20.3)
+    unicode-display_width (1.4.1)
 
 PLATFORMS
   ruby
@@ -57,4 +57,4 @@ DEPENDENCIES
   danger-swiftlint
 
 BUNDLED WITH
-   1.16.5
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   danger-swiftlint
 
 BUNDLED WITH
-   2.0.1
+   1.16.5


### PR DESCRIPTION
This updates Danger itself (by running `bundle update`) and the `Dangerfile`.
In the latter, the copyrights were updated for the new Benchmarking projects.
