### PR TITLE
Add global variable to control async logging in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## [3.5.0 - Xcode 10 on ?? ??, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.0)
+## [3.5.0 - Xcode 10 on ?? ??, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.0)
 
 ### Public
 - Added `logFileHeader` property to `DDLogFileManagerDefault`. Override to set header for each created file. #998
 - `DDFileLogger` now accepts a `dispatch_queue_t` which it uses to run callbacks. If not provided, the default global queue is used. #1003
-- Added opt-in buffing to `DDFileLogger`. Call `wrapWithBuffer` to create a file logger which buffers. #1001, #1012
+- Added opt-in buffering to `DDFileLogger`. Call `wrapWithBuffer` to create a file logger which buffers. #1001, #1012
 - Add `DDAssert` and `DDAssertionFailure` functions for Swift #934
+- Add `DDDefaultLogLevel` define for Swift (which can be set in `GCC_PREPROCESSOR_DEFINITIONS`) to set default log level (enables stripping for strings that are not logged). #952
+- Add `asyncLoggingEnabled` global variable to control asynchronous logging. #1019
 
 ### Internal
 - Prevent memory access errors caused by a failed fetch #944

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `DDFileLogger` now accepts a `dispatch_queue_t` which it uses to run callbacks. If not provided, the default global queue is used. #1003
 - Added opt-in buffering to `DDFileLogger`. Call `wrapWithBuffer` to create a file logger which buffers. #1001, #1012
 - Add `DDAssert` and `DDAssertionFailure` functions for Swift #934
-- Add `DDDefaultLogLevel` define for Swift (which can be set in `GCC_PREPROCESSOR_DEFINITIONS`) to set default log level (enables stripping for strings that are not logged). #952
+- Add `DD_LOG_LEVEL` define (which can be set in `GCC_PREPROCESSOR_DEFINITIONS`) for Swift to set default log level (enables stripping for strings that are not logged). #952
 - Add `asyncLoggingEnabled` global variable to control asynchronous logging. #1019
 
 ### Internal
@@ -15,7 +15,6 @@
 - `DispatchQueueFormatter` knows about `com.apple.root.default-qos.overcommit` now #932
 - Fix thread safety issues in `DDFileLogger`. Makes it a little harder to deadlock in some cases. #986, #1003, #946
 - Fix availability checks and memory leak #996
-- Use static const for default log level so Swift can strip strings #952
 
 ### Repository
 - Reduce podspec to two subspecs and remove customized modulemap #976

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -13,8 +13,6 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-import Foundation
-
 extension DDLogFlag {
     public static func from(_ logLevel: DDLogLevel) -> DDLogFlag {
         return DDLogFlag(rawValue: logLevel.rawValue)
@@ -71,38 +69,100 @@ public func resetDefaultDebugLevel() {
     resetDynamicLogLevel()
 }
 
+/// If `true`, all logs (except errors) are logged asynchronously by default.
+public var asyncLoggingEnabled = true
+
 @inlinable
-public func _DDLogMessage(_ message: @autoclosure () -> String, level: DDLogLevel, flag: DDLogFlag, context: Int, file: StaticString, function: StaticString, line: UInt, tag: Any?, asynchronous: Bool, ddlog: DDLog) {
-    // The `dynamicLogLevel` will always be checked here (instead of being passed in). We cannot "mix" it with the `DDDefaultLogLevel`, because otherwise the compiler won't strip strings that are not logged.
+public func _DDLogMessage(_ message: @autoclosure () -> String,
+                          level: DDLogLevel,
+                          flag: DDLogFlag,
+                          context: Int,
+                          file: StaticString,
+                          function: StaticString,
+                          line: UInt,
+                          tag: Any?,
+                          asynchronous: Bool,
+                          ddlog: DDLog) {
+    // The `dynamicLogLevel` will always be checked here (instead of being passed in).
+    // We cannot "mix" it with the `DDDefaultLogLevel`, because otherwise the compiler won't strip strings that are not logged.
     if level.rawValue & flag.rawValue != 0 && dynamicLogLevel.rawValue & flag.rawValue != 0 {
         // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
-        let logMessage = DDLogMessage(message: message(), level: level, flag: flag, context: context, file: String(describing: file), function: String(describing: function), line: line, tag: tag, options: [.copyFile, .copyFunction], timestamp: nil)
+        let logMessage = DDLogMessage(message: message(),
+                                      level: level,
+                                      flag: flag,
+                                      context: context,
+                                      file: String(describing: file),
+                                      function: String(describing: function),
+                                      line: line,
+                                      tag: tag,
+                                      options: [.copyFile, .copyFunction],
+                                      timestamp: nil)
         ddlog.log(asynchronous: asynchronous, message: logMessage)
     }
 }
 
 @inlinable
-public func DDLogDebug(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDLogDebug(_ message: @autoclosure () -> String,
+                       level: DDLogLevel = DDDefaultLogLevel,
+                       context: Int = 0,
+                       file: StaticString = #file,
+                       function: StaticString = #function,
+                       line: UInt = #line,
+                       tag: Any? = nil,
+                       asynchronous async: Bool = asyncLoggingEnabled,
+                       ddlog: DDLog = .sharedInstance) {
     _DDLogMessage(message, level: level, flag: .debug, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
 @inlinable
-public func DDLogInfo(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDLogInfo(_ message: @autoclosure () -> String,
+                      level: DDLogLevel = DDDefaultLogLevel,
+                      context: Int = 0,
+                      file: StaticString = #file,
+                      function: StaticString = #function,
+                      line: UInt = #line,
+                      tag: Any? = nil,
+                      asynchronous async: Bool = asyncLoggingEnabled,
+                      ddlog: DDLog = .sharedInstance) {
     _DDLogMessage(message, level: level, flag: .info, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
 @inlinable
-public func DDLogWarn(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDLogWarn(_ message: @autoclosure () -> String,
+                      level: DDLogLevel = DDDefaultLogLevel,
+                      context: Int = 0,
+                      file: StaticString = #file,
+                      function: StaticString = #function,
+                      line: UInt = #line,
+                      tag: Any? = nil,
+                      asynchronous async: Bool = asyncLoggingEnabled,
+                      ddlog: DDLog = .sharedInstance) {
     _DDLogMessage(message, level: level, flag: .warning, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
 @inlinable
-public func DDLogVerbose(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = true, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDLogVerbose(_ message: @autoclosure () -> String,
+                         level: DDLogLevel = DDDefaultLogLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = asyncLoggingEnabled,
+                         ddlog: DDLog = .sharedInstance) {
     _DDLogMessage(message, level: level, flag: .verbose, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 
 @inlinable
-public func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDLogError(_ message: @autoclosure () -> String,
+                       level: DDLogLevel = DDDefaultLogLevel,
+                       context: Int = 0,
+                       file: StaticString = #file,
+                       function: StaticString = #function,
+                       line: UInt = #line,
+                       tag: Any? = nil,
+                       asynchronous async: Bool = false,
+                       ddlog: DDLog = .sharedInstance) {
     _DDLogMessage(message, level: level, flag: .error, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
 }
 

--- a/Documentation/ProblemSolution.md
+++ b/Documentation/ProblemSolution.md
@@ -12,6 +12,11 @@ By default, for maximum performance, CocoaLumberjack logs messages asynchronousl
 #define LOG_ASYNC_ENABLED NO
 ```
 
+In Swift there's a global variable you an set to achieve the same:
+```swift
+asyncLoggingEnabled = false
+```
+
 This will disable asynchronous logging just for the extension, improving its reliability there.
 
 ### NSConcreteStackBlock


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #665 

### Pull Request Description

This adds a global variable in Swift (`asyncLoggingEnabled`) which is then used in all log-functions (except `DDLogError`) to define whether logs are written asynchronously or not.

