### PR TITLE
Tell StaleBot to leave Feature Requests alone

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - Important
   - Blocker
+  - Feature Request
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
As mentioned in #1009, stale bot currently also marks feature requests as stale. This fixes this by adding the Feature Request label to the `exemptLabels` in our stale.yml.