### PR TITLE
Make umbrella header import all public .h files with proper public import syntax

### DIFF
--- a/Classes/CocoaLumberjack.h
+++ b/Classes/CocoaLumberjack.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2016, Deusty, LLC
+// Copyright (c) 2010-2018, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -59,6 +59,12 @@
 
 #import <Foundation/Foundation.h>
 
+//! Project version number for CocoaLumberjack.
+FOUNDATION_EXPORT double CocoaLumberjackVersionNumber;
+
+//! Project version string for CocoaLumberjack.
+FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
+
 // Disable legacy macros
 #ifndef DD_LEGACY_MACROS
     #define DD_LEGACY_MACROS 0
@@ -69,20 +75,29 @@
 
 // Main macros
 #import <CocoaLumberjack/DDLogMacros.h>
-#import <CocoaLumberjack/DDLog+LOGV.h>
 #import <CocoaLumberjack/DDAssertMacros.h>
 
 // Capture ASL
 #import <CocoaLumberjack/DDASLLogCapture.h>
 
 // Loggers
-#import <CocoaLumberjack/DDAbstractDatabaseLogger.h>
+#import <CocoaLumberjack/DDLoggerNames.h>
+
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
 #import <CocoaLumberjack/DDOSLogger.h>
 
+// Extensions
+#import <CocoaLumberjack/DDContextFilterLogFormatter.h>
+#import <CocoaLumberjack/DDDispatchQueueLogFormatter.h>
+#import <CocoaLumberjack/DDMultiFormatter.h>
+#import <CocoaLumberjack/DDFileLogger+Buffering.h>
+
 // CLI
-#if __has_include("CLIColor.h") && TARGET_OS_OSX
 #import <CocoaLumberjack/CLIColor.h>
-#endif
+
+// etc
+#import <CocoaLumberjack/DDAbstractDatabaseLogger.h>
+#import <CocoaLumberjack/DDLog+LOGV.h>
+#import <CocoaLumberjack/DDLegacyMacros.h>

--- a/Classes/CocoaLumberjack.h
+++ b/Classes/CocoaLumberjack.h
@@ -1,6 +1,6 @@
 // Software License Agreement (BSD License)
 //
-// Copyright (c) 2010-2018, Deusty, LLC
+// Copyright (c) 2010-2016, Deusty, LLC
 // All rights reserved.
 //
 // Redistribution and use of this software in source and binary forms,
@@ -59,45 +59,30 @@
 
 #import <Foundation/Foundation.h>
 
-//! Project version number for CocoaLumberjack.
-FOUNDATION_EXPORT double CocoaLumberjackVersionNumber;
-
-//! Project version string for CocoaLumberjack.
-FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
-
 // Disable legacy macros
 #ifndef DD_LEGACY_MACROS
     #define DD_LEGACY_MACROS 0
 #endif
 
 // Core
-#import "DDLog.h"
+#import <CocoaLumberjack/DDLog.h>
 
 // Main macros
-#import "DDLogMacros.h"
-#import "DDAssertMacros.h"
+#import <CocoaLumberjack/DDLogMacros.h>
+#import <CocoaLumberjack/DDLog+LOGV.h>
+#import <CocoaLumberjack/DDAssertMacros.h>
 
 // Capture ASL
-#import "DDASLLogCapture.h"
+#import <CocoaLumberjack/DDASLLogCapture.h>
 
 // Loggers
-#import "DDLoggerNames.h"
-
-#import "DDTTYLogger.h"
-#import "DDASLLogger.h"
-#import "DDFileLogger.h"
-#import "DDOSLogger.h"
-
-// Extensions
-#import "DDContextFilterLogFormatter.h"
-#import "DDDispatchQueueLogFormatter.h"
-#import "DDMultiFormatter.h"
-#import "DDFileLogger+Buffering.h"
+#import <CocoaLumberjack/DDAbstractDatabaseLogger.h>
+#import <CocoaLumberjack/DDTTYLogger.h>
+#import <CocoaLumberjack/DDASLLogger.h>
+#import <CocoaLumberjack/DDFileLogger.h>
+#import <CocoaLumberjack/DDOSLogger.h>
 
 // CLI
-#import "CLIColor.h"
-
-// etc
-#import "DDAbstractDatabaseLogger.h"
-#import "DDLog+LOGV.h"
-#import "DDLegacyMacros.h"
+#if __has_include("CLIColor.h") && TARGET_OS_OSX
+#import <CocoaLumberjack/CLIColor.h>
+#endif


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Umbrella headers need to import all public Objective-C header files. Without this, projects may get compiler warnings like: `/<module-includes>:1:1: Umbrella header for module 'CocoaLumberjack' does not include header 'DDLog+LOGV.h'`

This PR adds all public header files to the CocoaLumberjack umbrella header. It also changes the import syntax to use #import <CocoaLumberjack/PublicHeader.h>, which is the proper way to import module-specific files in a public header.

...
