### PR TITLE
Prevent reuse of already archived log file info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## [3.5.1 - Xcode 10 on ???, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.1)
+## [3.5.2 - Xcode 10 on ???, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.2)
+
+### Public
+- Fix reusing of log files after rolling (#1042)
+
+## [3.5.1 - Xcode 10 on Feb 4th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.1)
 
 ### Public
 - Fix high CPU usage because of empty fileAttributes and / or too high rollingFrequceny (#1028)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Public
 - Fix reusing of log files after rolling (#1042)
-- Preliminary compatbility with Swift 5 (backwards compatible with Swift 4) (#1044)
+- Preliminary compatibility with Swift 5 (backwards compatible with Swift 4) (#1044)
 
 ## [3.5.1 - Xcode 10 on Feb 4th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Public
 - Fix reusing of log files after rolling (#1042)
+- Preliminary compatbility with Swift 5 (backwards compatible with Swift 4) (#1044)
 
 ## [3.5.1 - Xcode 10 on Feb 4th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.1)
 

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1014,10 +1014,9 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     }
 
     if (_currentLogFileInfo) {
-        BOOL isMostRecentLogArchived = _currentLogFileInfo.isArchived;
-        BOOL forceArchive = _doNotReuseLogFiles && isMostRecentLogArchived == NO;
-
-        if (forceArchive || [self lt_shouldLogFileBeArchived:_currentLogFileInfo]) {
+        if (_currentLogFileInfo.isArchived) {
+            _currentLogFileInfo = nil;
+        } else if (_doNotReuseLogFiles || [self lt_shouldLogFileBeArchived:_currentLogFileInfo]) {
             _currentLogFileInfo.isArchived = YES;
             NSString *archivedLogFilePath = [_currentLogFileInfo.fileName copy];
             _currentLogFileInfo = nil;

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1031,8 +1031,9 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     return _currentLogFileInfo;
 }
 
-- (BOOL)lt_shouldUseLogFile:(DDLogFileInfo *)logFileInfo {
+- (BOOL)lt_shouldUseLogFile:(nonnull DDLogFileInfo *)logFileInfo {
     NSAssert([self isOnInternalLoggerQueue], @"lt_ methods should be on logger queue.");
+    NSParameterAssert(logFileInfo);
 
     if (logFileInfo.isArchived) { // Archived log files are no longer valid for use.
         return NO;

--- a/Tests/Tests/DDFileLoggerTests.m
+++ b/Tests/Tests/DDFileLoggerTests.m
@@ -45,6 +45,25 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     [DDLog removeAllLoggers];
 }
 
+- (void)testLogFileRolling {
+    [DDLog addLogger:logger];
+    DDLogError(@"Some log in old file");
+    __auto_type oldLogFileInfo = [logger currentLogFileInfo];
+    __auto_type expectation = [self expectationWithDescription:@"Waiting for log file to be rolled"];
+    [logger rollLogFileWithCompletionBlock:^{
+        [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:3 handler:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
+    }];
+    __auto_type newLogFileInfo = [logger currentLogFileInfo];
+    XCTAssertNotNil(oldLogFileInfo);
+    XCTAssertNotNil(newLogFileInfo);
+    XCTAssertNotEqualObjects(oldLogFileInfo.filePath, newLogFileInfo.filePath);
+    XCTAssertTrue(oldLogFileInfo.isArchived);
+    XCTAssertFalse(newLogFileInfo.isArchived);
+}
+
 - (void)testWrapping {
     __auto_type wrapped = [logger wrapWithBuffer];
     XCTAssert([wrapped.class isSubclassOfClass:NSProxy.class]);


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1041 

### Pull Request Description

With the last refactoring for `DDFileLogger` it always used the latest log file, no matter whether it was already archived or not.
This now checks whether the log file info is archived and creates a new one in this case.
Also, a test case was added for log file rolling.