### PR TITLE
Sync internal queues to prevent cleaning up log files too soon in tests

### DIFF
--- a/Tests/Tests/DDFileLoggerTests.m
+++ b/Tests/Tests/DDFileLoggerTests.m
@@ -40,7 +40,9 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     
     [DDLog removeAllLoggers];
     // We need to sync all involved queues to wait for the post-removal processing of the logger to finish before deleting the files.
+    NSAssert(![self->logger isOnGlobalLoggingQueue], @"Trouble ahead!");
     dispatch_sync([DDLog loggingQueue], ^{
+        NSAssert(![self->logger isOnInternalLoggerQueue], @"Trouble ahead!");
         dispatch_sync(self->logger.loggerQueue, ^{
             /* noop */
         });

--- a/Tests/Tests/DDFileLoggerTests.m
+++ b/Tests/Tests/DDFileLoggerTests.m
@@ -39,6 +39,12 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     [super tearDown];
     
     [DDLog removeAllLoggers];
+    // We need to sync all involved queues to wait for the post-removal processing of the logger to finish before deleting the files.
+    dispatch_sync([DDLog loggingQueue], ^{
+        dispatch_sync(self->logger.loggerQueue, ^{
+            /* noop */
+        });
+    });
     
     NSError *error = nil;
     __auto_type contents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:logsDirectory error:&error];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

On the iOS simulator, we would have a race condition where test files would be cleaned up before the tested file logger was able to clean up after itself. This fixes this by syncing DDLog's queue and the file logger's queue before deleting the log files/.