### PR TITLE
Improve DDAssert & DDAssertionFailure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Public
 - Additional compatibility with Swift 5 (backwards compatible with Swift 4) (#1043)
+- improve DDAssert and DDAssertionFailure (#1060)
+  - evaluate message only once
+  - always log the assertion message
+  - fix undefined behaviour
 
 ### Internal
 - Remove banned APIs (#1056) (#1057)

--- a/Classes/DDAssert.swift
+++ b/Classes/DDAssert.swift
@@ -24,9 +24,9 @@
  *     The default is an empty string.
  */
 @inlinable
-public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     if !condition() {
-        DDLogError(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+        DDLogError(message(), level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
         Swift.assertionFailure(message(), file: file, line: line)
     }
 }
@@ -39,7 +39,7 @@ public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosu
  *   - message: A string to log (using `DDLogError`). The default is an empty string.
  */
 @inlinable
-public func DDAssertionFailure(_ message: @autoclosure () -> String = "", level: DDLogLevel = DDDefaultLogLevel, context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    DDLogError(message(), level: level, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+public func DDAssertionFailure(_ message: @autoclosure () -> String = "", context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
+    DDLogError(message(), level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
     Swift.assertionFailure(message(), file: file, line: line)
 }

--- a/Classes/DDAssert.swift
+++ b/Classes/DDAssert.swift
@@ -28,7 +28,9 @@ public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosu
     if !condition() {
         let evaluated = message()
         DDLogError(evaluated, level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
-        Swift.assertionFailure(evaluated, file: file, line: line)
+        #if DEBUG
+          Swift.assertionFailure(evaluated, file: file, line: line)
+        #endif
     }
 }
 
@@ -43,5 +45,7 @@ public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosu
 public func DDAssertionFailure(_ message: @autoclosure () -> String = "", context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     let evaluated = message()
     DDLogError(evaluated, level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
-    Swift.assertionFailure(evaluated, file: file, line: line)
+    #if DEBUG
+      Swift.assertionFailure(evaluated, file: file, line: line)
+    #endif
 }

--- a/Classes/DDAssert.swift
+++ b/Classes/DDAssert.swift
@@ -26,8 +26,9 @@
 @inlinable
 public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosure () -> String = "", context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
     if !condition() {
-        DDLogError(message(), level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
-        Swift.assertionFailure(message(), file: file, line: line)
+        let evaluated = message()
+        DDLogError(evaluated, level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+        Swift.assertionFailure(evaluated, file: file, line: line)
     }
 }
 
@@ -40,6 +41,7 @@ public func DDAssert(_ condition: @autoclosure () -> Bool, _ message: @autoclosu
  */
 @inlinable
 public func DDAssertionFailure(_ message: @autoclosure () -> String = "", context: Int = 0, file: StaticString = #file, function: StaticString = #function, line: UInt = #line, tag: Any? = nil, asynchronous async: Bool = false, ddlog: DDLog = DDLog.sharedInstance) {
-    DDLogError(message(), level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
-    Swift.assertionFailure(message(), file: file, line: line)
+    let evaluated = message()
+    DDLogError(evaluated, level: .all, context: context, file: file, function: function, line: line, tag: tag, asynchronous: async, ddlog: ddlog)
+    Swift.assertionFailure(evaluated, file: file, line: line)
 }


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [n/a] I have added the required tests to prove the fix/feature I am adding
* [n/a] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description
This PR improves the newly added DDAssert and DDAssertionFailure:
* evaluate message only once to prevent side-effects
* always log the assertion message
* only call assertionFailure in DEBUG builds (fixes undefined behaviour)
  We shouldn't be calling assertionFailure in non-debug builds. Docs for assertionFailure say:
  ```
  /// In -Ounchecked builds, the optimizer may assume that this function is
  ///   never called. Failure to satisfy that assumption is a serious
  ///   programming error.
  ```
