### PR TITLE
Fix format string crash.

### DIFF
--- a/Classes/DDAssertMacros.h
+++ b/Classes/DDAssertMacros.h
@@ -20,7 +20,7 @@
         if (!(condition)) {                                                           \
             NSString *description = [NSString stringWithFormat:frmt, ## __VA_ARGS__]; \
             DDLogError(@"%@", description);                                           \
-            NSAssert(NO, description);                                                \
+            NSAssert(NO, @"%@", description);                                         \
         }
 #define DDAssertCondition(condition) DDAssert(condition, @"Condition not satisfied: %s", #condition)
 


### PR DESCRIPTION
Was seeing a BAD_ACCESS crash on one of my log statements because I was passing a string with a %@, and the NSAssert function expects a format string, not a literal.