### PR TITLE
Disable bitcode on macOS builds

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -114,6 +114,7 @@ DYLIB_INSTALL_NAME_BASE = @rpath
 
 // Activating this setting indicates that the target or project should generate bitcode during compilation for platforms and architectures that support it. For Archive builds, bitcode will be generated in the linked binary for submission to the App Store. For other builds, the compiler and linker will check whether the code complies with the requirements for bitcode generation, but will not generate actual bitcode.
 ENABLE_BITCODE = YES
+ENABLE_BITCODE[sdk=macosx*] = NO
 
 // Controls whether `objc_msgSend` calls must be cast to the appropriate function pointer type before being called.
 ENABLE_STRICT_OBJC_MSGSEND = YES


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...


### Pull Request Description
Fixes error on macOS build using `Lumberjack.xcodeproj`:
`target 'CocoaLumberjack' has bitcode enabled (ENABLE_BITCODE = YES), but it is not supported for the 'macosx' platform`
Strange thing, that `xcodebuild` doesn't fail