### PR TITLE
fix missing ios system framwork dependence

### DIFF
--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
   s.subspec 'Core' do |ss|
     ss.source_files         = 'Classes/CocoaLumberjack.h', 'Classes/DD*.{h,m}', 'Classes/Extensions/*.{h,m}', 'Classes/CLI/*.{h,m}'
     ss.private_header_files = 'Classes/DD*Internal.{h}'
+    ss.ios.frameworks       = [ "Foundation", "UIKit", "CoreGraphics"]
   end
 
   s.subspec 'Swift' do |ss|


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

While enable `use_frameworks` in Podfile, errors encountered while link the project cause CocoaLumberjack's podspec has leak of enough system framework dependence.

the error info:
```
Undefined symbols for architecture arm64:
  "_CGContextFillRect", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_CGContextRelease", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_CGColorSpaceRelease", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_OBJC_CLASS_$_UIColor", referenced from:
      objc-class-ref in DDTTYLogger.o
  "_CGContextSetFillColorWithColor", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_CGColorSpaceCreateDeviceRGB", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_CGBitmapContextCreate", referenced from:
      +[DDTTYLogger getRed:green:blue:fromColor:] in DDTTYLogger.o
  "_UIApplicationWillTerminateNotification", referenced from:
      -[DDLog init] in DDLog.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

To fix this, add the missing frameworks dependence to podspec 
...


