### PR TITLE
Expose current log file info in `didLog` methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.5.3 - Xcode 10.2.1 on ?](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.4)
+
+### Public
+- New `willLogMessage:` and `didLogMessage:` methods which provide access to the current log file info.
+
 ## [3.5.3 - Xcode 10.2 on Apr 24th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.3)
 
 ### Public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [3.5.3 - Xcode 10.2.1 on ?](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.4)
 
 ### Public
-- New `willLogMessage:` and `didLogMessage:` methods which provide access to the current log file info.
+- New `willLogMessage:` and `didLogMessage:` methods on `DDFileLogger` which provide access to the current log file info.
 
 ## [3.5.3 - Xcode 10.2 on Apr 24th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.3)
 

--- a/Classes/DDFileLogger.h
+++ b/Classes/DDFileLogger.h
@@ -340,14 +340,24 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
                        completionQueue:(dispatch_queue_t __nullable)dispatchQueue NS_DESIGNATED_INITIALIZER;
 
 /**
+ *  Deprecated. Use `willLogMessage:`
+ */
+- (void)willLogMessage __attribute__((deprecated("Use -willLogMessage:"))) NS_REQUIRES_SUPER;
+
+/**
+ *  Deprecated. Use `didLogMessage:`
+ */
+- (void)didLogMessage __attribute__((deprecated("Use -didLogMessage:"))) NS_REQUIRES_SUPER;
+
+/**
  *  Called when the logger is about to write message. Call super before your implementation.
  */
-- (void)willLogMessage NS_REQUIRES_SUPER;
+- (void)willLogMessage:(DDLogFileInfo *)logFileInfo NS_REQUIRES_SUPER;
 
 /**
  *  Called when the logger wrote message. Call super after your implementation.
  */
-- (void)didLogMessage NS_REQUIRES_SUPER;
+- (void)didLogMessage:(DDLogFileInfo *)logFileInfo NS_REQUIRES_SUPER;
 
 /**
  *  Writes all in-memory log data to the permanent storage. Call super before your implementation.

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1135,6 +1135,14 @@ static int exception_count = 0;
 }
 
 - (void)didLogMessage {
+
+}
+
+- (void)willLogMessage:(DDLogFileInfo *)logFileInfo {
+
+}
+
+- (void)didLogMessage:(DDLogFileInfo *)logFileInfo {
     [self lt_maybeRollLogFileDueToSize];
 }
 
@@ -1217,13 +1225,23 @@ static int exception_count = 0;
     }
 
     @try {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [self willLogMessage];
+#pragma clang diagnostic pop
+
+        [self willLogMessage:_currentLogFileInfo];
 
         NSFileHandle *handle = [self lt_currentLogFileHandle];
         [handle seekToEndOfFile];
         [handle writeData:data];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         [self didLogMessage];
+#pragma clang diagnostic pop
+
+        [self didLogMessage:_currentLogFileInfo];
     } @catch (NSException *exception) {
         exception_count++;
 

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1223,7 +1223,11 @@ static int exception_count = 0;
     return [super methodSignatureForSelector:aSelector];
 }
 
-- (void)forwardInvocation:(NSInvocation *)anInvocation {}
+- (void)forwardInvocation:(NSInvocation *)anInvocation {
+    if (anInvocation.selector != @selector(dummyMethod)) {
+        [super forwardInvocation:anInvocation];
+    }
+}
 
 - (void)lt_logData:(NSData *)data {
     static BOOL implementsDeprecatedWillLog = NO;

--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -615,7 +615,10 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
 
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincomplete-implementation"
 @implementation DDFileLogger
+#pragma clang diagnostic pop
 
 - (instancetype)init {
     DDLogFileManagerDefault *defaultLogFileManager = [[DDLogFileManagerDefault alloc] init];
@@ -1208,6 +1211,19 @@ static int exception_count = 0;
         });
     }
 }
+
+- (void)dummyMethod {}
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector {
+    if (aSelector == @selector(willLogMessage) || aSelector == @selector(didLogMessage)) {
+        // Ignore calls to deprecated methods.
+        return [self methodSignatureForSelector:@selector(dummyMethod)];
+    }
+
+    return [super methodSignatureForSelector:aSelector];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation {}
 
 - (void)lt_logData:(NSData *)data {
     static BOOL implementsDeprecatedWillLog = NO;


### PR DESCRIPTION
I removed a public variable to provide queue protection in d0fed54ea39d710918f5b9d3627d32a50f889c46 . 