### PR TITLE
Add `useStandardStyleForCustomFormatters` property in DDTTYLogger, it…

### DIFF
--- a/Classes/DDTTYLogger.h
+++ b/Classes/DDTTYLogger.h
@@ -104,6 +104,12 @@
 @property (nonatomic, readwrite, assign) BOOL automaticallyAppendNewlineForCustomFormatters;
 
 /**
+ * Apply standard NSLog style formatting when use custom formatter,
+ * It will insert timestamp, thread id and so on. Default value is NO.
+ **/
+@property (nonatomic, assign) BOOL useStandardStyleForCustomFormatters;
+
+/**
  * The default color set (foregroundColor, backgroundColor) is:
  *
  * - DDLogFlagError   = (red, nil)

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -884,6 +884,7 @@ static DDTTYLogger *sharedInstance;
         _colorProfilesDict = [[NSMutableDictionary alloc] initWithCapacity:8];
 
         _automaticallyAppendNewlineForCustomFormatters = YES;
+        _useStandardStyleForCustomFormatters = NO;
     }
 
     return self;
@@ -1163,11 +1164,9 @@ static DDTTYLogger *sharedInstance;
 
 - (void)logMessage:(DDLogMessage *)logMessage {
     NSString *logMsg = logMessage->_message;
-    BOOL isFormatted = NO;
 
     if (_logFormatter) {
         logMsg = [_logFormatter formatLogMessage:logMessage];
-        isFormatted = logMsg != logMessage->_message;
     }
 
     if (logMsg) {
@@ -1229,8 +1228,7 @@ static DDTTYLogger *sharedInstance;
 
         // Write the log message to STDERR
 
-        if (isFormatted) {
-            // The log message has already been formatted.
+        if (_logFormatter && !_useStandardStyleForCustomFormatters) {
             int iovec_len = (_automaticallyAppendNewlineForCustomFormatters) ? 5 : 4;
             struct iovec v[iovec_len];
 
@@ -1264,7 +1262,7 @@ static DDTTYLogger *sharedInstance;
 
             writev(STDERR_FILENO, v, iovec_len);
         } else {
-            // The log message is unformatted, so apply standard NSLog style formatting.
+            // Apply standard NSLog style formatting.
 
             int len;
             char ts[24] = "";


### PR DESCRIPTION
I add a property `useStandardStyleForCustomFormatters` in DDTTYLogger, It will allow user apply the NSLogger Style to the custom logger formatter. And it will fix the #1080, too.