### PR TITLE
add `DDLogSTD` to allow set the pipe for `DDTTYLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Public
 - New `willLogMessage:` and `didLogMessage:` methods on `DDFileLogger` which provide access to the current log file info.
+- New `DDLogSTD` enum and `std` property on `DDTTYLogger` which provide set the output pipe to `STDERR` or `STDOUT` for every log message.
 
 ## [3.5.3 - Xcode 10.2 on Apr 24th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.3)
 

--- a/Classes/CocoaLumberjack.swift
+++ b/Classes/CocoaLumberjack.swift
@@ -81,6 +81,7 @@ public func _DDLogMessage(_ message: @autoclosure () -> String,
                           function: StaticString,
                           line: UInt,
                           tag: Any?,
+                          std: DDLogSTD = .auto,
                           asynchronous: Bool,
                           ddlog: DDLog) {
     // The `dynamicLogLevel` will always be checked here (instead of being passed in).
@@ -95,6 +96,7 @@ public func _DDLogMessage(_ message: @autoclosure () -> String,
                                       function: String(describing: function),
                                       line: line,
                                       tag: tag,
+                                      std: std,
                                       options: [.copyFile, .copyFunction],
                                       timestamp: nil)
         ddlog.log(asynchronous: asynchronous, message: logMessage)

--- a/Classes/DDASLLogCapture.m
+++ b/Classes/DDASLLogCapture.m
@@ -120,6 +120,7 @@ static DDLogLevel _captureLevel = DDLogLevelVerbose;
                                                            function:nil
                                                                line:0
                                                                 tag:nil
+                                                                std:DDLogSTDAuto
                                                             options:0
                                                           timestamp:timeStamp];
     

--- a/Classes/DDLog.h
+++ b/Classes/DDLog.h
@@ -170,6 +170,26 @@ typedef NS_ENUM(NSUInteger, DDLogLevel){
     DDLogLevelAll       = NSUIntegerMax
 };
 
+/**
+ *  Log STD are used to choice which pipe to log. Only work for DDTTYLogger.
+ */
+typedef NS_ENUM(NSUInteger, DDLogSTD){
+    /**
+     *  Auto choice the STD base the log level: STDERR for DDLogLevelError
+     */
+    DDLogSTDAuto = 0,
+
+    /**
+     *  Use the STDOUT
+     */
+    DDLogSTDOut  = STDOUT_FILENO,
+
+    /**
+     *  Use the STDERR
+     */
+    DDLogSTDErr  = STDERR_FILENO
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -781,6 +801,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSString *_threadID;
     NSString *_threadName;
     NSString *_queueLabel;
+    DDLogSTD _std;
 }
 
 /**
@@ -810,6 +831,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
  *  @param function  the current function
  *  @param line      the current code line
  *  @param tag       potential tag
+ *  @param std       the output std
  *  @param options   a bitmask which supports DDLogMessageCopyFile and DDLogMessageCopyFunction.
  *  @param timestamp the log timestamp
  *
@@ -823,6 +845,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
                        function:(NSString * __nullable)function
                            line:(NSUInteger)line
                             tag:(id __nullable)tag
+                            std:(DDLogSTD)std
                         options:(DDLogMessageOptions)options
                       timestamp:(NSDate * __nullable)timestamp NS_DESIGNATED_INITIALIZER;
 
@@ -847,6 +870,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID
 @property (readonly, nonatomic) NSString *threadName;
 @property (readonly, nonatomic) NSString *queueLabel;
+@property (readonly, nonatomic) int stdPipe;
 
 @end
 

--- a/Classes/DDLog.m
+++ b/Classes/DDLog.m
@@ -502,6 +502,7 @@ static NSUInteger _numProcessors;
                                                             function:[NSString stringWithFormat:@"%s", function]
                                                                 line:line
                                                                  tag:tag
+                                                                 std:DDLogSTDAuto
                                                              options:(DDLogMessageOptions)0
                                                            timestamp:nil];
 
@@ -1033,6 +1034,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
                        function:(NSString *)function
                            line:(NSUInteger)line
                             tag:(id)tag
+                            std:(DDLogSTD)std
                         options:(DDLogMessageOptions)options
                       timestamp:(NSDate *)timestamp {
     if ((self = [super init])) {
@@ -1050,6 +1052,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 
         _line         = line;
         _tag          = tag;
+        _std          = std;
         _options      = options;
         _timestamp    = timestamp ?: [NSDate new];
 
@@ -1075,6 +1078,14 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     return self;
 }
 
+- (int)stdPipe {
+    DDLogSTD std = _std;
+    if (std == DDLogSTDAuto) {
+        std = _level == DDLogLevelError ? DDLogSTDErr : DDLogSTDOut;
+    }
+    return std;
+}
+
 - (id)copyWithZone:(NSZone * __attribute__((unused)))zone {
     DDLogMessage *newMessage = [DDLogMessage new];
 
@@ -1087,6 +1098,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     newMessage->_function = _function;
     newMessage->_line = _line;
     newMessage->_tag = _tag;
+    newMessage->_std = _std;
     newMessage->_options = _options;
     newMessage->_timestamp = _timestamp;
     newMessage->_threadID = _threadID;

--- a/Classes/DDTTYLogger.m
+++ b/Classes/DDTTYLogger.m
@@ -1227,7 +1227,7 @@ static DDTTYLogger *sharedInstance;
             return;
         }
 
-        // Write the log message to STDERR
+        // Write the log message to logMessage.stdPipe
 
         if (isFormatted) {
             // The log message has already been formatted.
@@ -1262,7 +1262,7 @@ static DDTTYLogger *sharedInstance;
                 v[3].iov_len = (msg[msgLen] == '\n') ? 0 : 1;
             }
 
-            writev(STDERR_FILENO, v, iovec_len);
+            writev(logMessage.stdPipe, v, iovec_len);
         } else {
             // The log message is unformatted, so apply standard NSLog style formatting.
 
@@ -1357,7 +1357,7 @@ static DDTTYLogger *sharedInstance;
             v[11].iov_base = "\n";
             v[11].iov_len = (msg[msgLen] == '\n') ? 0 : 1;
 
-            writev(STDERR_FILENO, v, 13);
+            writev(logMessage.stdPipe, v, 13);
         }
 
         if (!useStack) {


### PR DESCRIPTION
The TTYLogger will always print the log to STDERR, I want to handle the pipe for the every log message.

The `std` paramter will only for TTY, so I do not add it to the `log` in the DDLog.