### PR TITLE
Bug 1078 / didArchiveLogFile returns the fileName instead of the filePath

### DIFF
--- a/Classes/DDFileLogger.m
+++ b/Classes/DDFileLogger.m
@@ -1046,7 +1046,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
     // If we're resuming, we need to check if the log file is allowed for reuse or needs to be archived.
     if (isResuming && (_doNotReuseLogFiles || [self lt_shouldLogFileBeArchived:logFileInfo])) {
         logFileInfo.isArchived = YES;
-        NSString *archivedLogFilePath = [logFileInfo.fileName copy];
+        NSString *archivedLogFilePath = [logFileInfo.filePath copy];
 
         if ([_logFileManager respondsToSelector:@selector(didArchiveLogFile:)]) {
             dispatch_async(_completionQueue, ^{


### PR DESCRIPTION
- The `didArchiveLogFile:` returns the `filePath` instead of the `fileName`. The commit 62e4ef1 introduced this mistake.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

