### PR TITLE
fixed an issue with log archiving in the simulator

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -969,7 +969,7 @@ unsigned long long const kDDDefaultLogFilesDiskQuota   = 20 * 1024 * 1024; // 20
         BOOL isUntilFirstAuth = [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication];
         BOOL isNone = [key isEqualToString:NSFileProtectionNone];
 
-        if (!isUntilFirstAuth && !isNone) {
+        if (key != nil && !isUntilFirstAuth && !isNone) {
             return YES;
         }
     }


### PR DESCRIPTION
This fixes a regression introduced in d0fed54ea39d710918f5b9d3627d32a50f889c46. The code that checks the previously used NSFileProtectionType key needs to check if the returned key isn't nil, which happens in the simulator (and possibly some other environments where file protection API is not available).

Without this additional check, when the file logger is used in the simulator in an app that can run in the background, the log file is always rotated at launch regardless how large or how old it is (because both key comparisons here return false, so YES is returned from this code block).

