### PR TITLE
allow building for macCatalyst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ script:
     - xcodebuild clean build -project Integration/Integration.xcodeproj -scheme 'watchOSSwiftIntegration' -configuration Release -sdk watchsimulator -destination 'platform=iOS Simulator,name=iPhone 11 Pro' | xcpretty -c
 
     - echo "Run the tests"
-    - xcodebuild test -skip-testing:'iOS Tests/DDFileLoggerPerformanceTests' -project Tests/Tests.xcodeproj -scheme 'iOS Tests' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.3.1' GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
     - xcodebuild test -skip-testing:'iOS Tests/DDFileLoggerPerformanceTests' -project Tests/Tests.xcodeproj -scheme 'iOS Tests' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11 Pro,OS=latest' GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
     - xcodebuild test -skip-testing:'OS X Tests/DDFileLoggerPerformanceTests' -project Tests/Tests.xcodeproj -scheme 'OS X Tests' -sdk macosx GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
 

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -106,6 +106,9 @@ CURRENT_PROJECT_VERSION = 1
 // If enabled, the product will be treated as defining its own module. This enables automatic production of LLVM module map files when appropriate, and allows the product to be imported as a module.
 DEFINES_MODULE = YES
 
+// macOS Catalyst support
+DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER = NO
+
 // Determines the compatibility version of the resulting library, bundle, or framework binary.
 DYLIB_COMPATIBILITY_VERSION = 1
 
@@ -225,6 +228,9 @@ SKIP_INSTALL = YES
 
 // The list of supported platforms from which a base SDK can be used. This setting is used if the product can be built for multiple platforms using different SDKs.
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchsimulator watchos appletvsimulator appletvos
+
+// macOS Catalyst support
+SUPPORTS_MACCATALYST = YES
 
 // Swift language version
 SWIFT_VERSION = 5.0


### PR DESCRIPTION
This came up while using CocoaLumberjack as a framework dependency. Without `SUPPORTS_MACCATALYST` it didn't build for catalyst for me.
Adding this, allowed Xcode to use the targets as dependencies in a macCatalyst app.