### PR TITLE
WIP: Enable BUILD_LIBRARY_FOR_DISTRIBUTION for Release configuration

### DIFF
--- a/Configs/Module-Release.xcconfig
+++ b/Configs/Module-Release.xcconfig
@@ -3,6 +3,10 @@
 
 #include "Module-Shared.xcconfig"
 
+// Ensures that your libraries are built for distribution. For Swift, this enables support for library evolution and generation of a module interface file.
+
+BUILD_LIBRARY_FOR_DISTRIBUTION = YES
+
 // Specifies whether binary files that are copied during the build, such as in a Copy Bundle Resources or Copy Files build phase, should be stripped of debugging symbols.
 COPY_PHASE_STRIP = YES
 


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [X] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Hello there,

#### The problem

Right now, if you will try to reuse `CocoaLumberjack` built with Swift 5.1 Toolchain with Xcode 11.2 (11.2.1GM) you get an error:

```
./Badoo/Platform/Foundation/source/logging/BPFLog.swift:6:8: 
    Module compiled with Swift 5.1 cannot be imported by the Swift 5.1.2 compiler: 
    ./Badoo/ThirdParty/Carthage/Build/iOS/CocoaLumberjackSwift.framework/Modules/CocoaLumberjackSwift.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
```

#### Solution

Swift 5.1 is here with Module Stability support, and to be able to reuse `CocoaLumberjack` binaries between Swift Toolchains >= 5.1 we have to build it with `BUILD_LIBRARY_FOR_DISTRIBUTION = YES` option. In this pull request, the `BUILD_LIBRARY_FOR_DISTRIBUTION` option is enabled for the `Release` configuration.

This is the year when we blame Apple for missing documentation and this is the case. In general, this option does the following: 

> Ensures that your libraries are built for distribution. For Swift, this enables support for library evolution and generation of a module interface file.

If you want to know more, check ["Binary Frameworks in Swift"](https://developer.apple.com/videos/play/wwdc2019/416/) session from WWDC'19.

We tested the solution, and it works just fine. You can build `CocoaLumberjack` with Swift 5.1 Toolchain and it will work/link for both Xcode 11.1-11.2 (aka, Swift 5.1 and Swift 5.1.1).

Cheers,
Artem | Badoo