### PR TITLE
Deal with errors during log file creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-> ## [3.6.1 - Xcode 11.1 on ???](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.1)
+## [3.6.1 - Xcode 11.1 on ???](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.1)
+
+### Public
+- Improve error handling during log file creation in DDFileLogger & DDLogFileManager (#1103 / #1111)
 
 ### Internal
 - Fix rolling timer being rescheduled rapidly due to leeway (#1106 / #1107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Public
 - Improve error handling during log file creation in DDFileLogger & DDLogFileManager (#1103 / #1111)
+- Improve Swift nullability annotations of DDLogFileInfo (#1112 / #1111)
 
 ### Internal
 - Fix rolling timer being rescheduled rapidly due to leeway (#1106 / #1107)

--- a/Sources/CocoaLumberjack/include/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/DDFileLogger.h
@@ -148,9 +148,16 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  * This method is executed directly on the file logger's internal queue.
  * The file has to exist by the time the method returns.
  **/
-- (NSString *)createNewLogFile;
+- (nullable NSString *)createNewLogFileWithError:(NSError **)error;
 
 @optional
+
+// Private methods (only to be used by DDFileLogger)
+/**
+ * Creates a new log file ignoring any errors. Deprecated in favor of `-createNewLogFileWithError:`.
+ * Will only be called if `-createNewLogFileWithError:` is not implemented.
+ **/
+- (nullable NSString *)createNewLogFile __attribute__((deprecated("Use -createNewLogFileWithError:"))) NS_SWIFT_UNAVAILABLE("Use -createNewLogFileWithError:");
 
 // Notifications from DDFileLogger
 
@@ -456,9 +463,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  * If there is an existing log file that is suitable,
  * within the constraints of `maximumFileSize` and `rollingFrequency`, then it is returned.
  *
- * Otherwise a new file is created and returned.
+ * Otherwise a new file is created and returned. If this failes, `NULL` is returned.
  **/
-@property (nonatomic, readonly, strong) DDLogFileInfo *currentLogFileInfo;
+@property (nonatomic, nullable, readonly, strong) DDLogFileInfo *currentLogFileInfo;
 
 @end
 
@@ -500,7 +507,7 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 @property (nonatomic, readwrite) BOOL isArchived;
 
-+ (instancetype)logFileWithPath:(NSString *)filePath NS_SWIFT_UNAVAILABLE("Use init(filePath:)");
++ (nullable instancetype)logFileWithPath:(nullable NSString *)filePath NS_SWIFT_UNAVAILABLE("Use init(filePath:)");
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithFilePath:(NSString *)filePath NS_DESIGNATED_INITIALIZER;

--- a/Sources/CocoaLumberjack/include/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/DDFileLogger.h
@@ -492,14 +492,10 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 @property (strong, nonatomic, readonly) NSString *filePath;
 @property (strong, nonatomic, readonly) NSString *fileName;
 
-#if FOUNDATION_SWIFT_SDK_EPOCH_AT_LEAST(8)
 @property (strong, nonatomic, readonly) NSDictionary<NSFileAttributeKey, id> *fileAttributes;
-#else
-@property (strong, nonatomic, readonly) NSDictionary<NSString *, id> *fileAttributes;
-#endif
 
-@property (strong, nonatomic, readonly) NSDate *creationDate;
-@property (strong, nonatomic, readonly) NSDate *modificationDate;
+@property (strong, nonatomic, nullable, readonly) NSDate *creationDate;
+@property (strong, nonatomic, nullable, readonly) NSDate *modificationDate;
 
 @property (nonatomic, readonly) unsigned long long fileSize;
 

--- a/Tests/CocoaLumberjackTests/DDLogFileManagerTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogFileManagerTests.m
@@ -40,10 +40,12 @@
 }
 
 - (void)testCreateNewLogFile {
-    NSString *filePath = [self.logFileManager createNewLogFile];
+    __autoreleasing NSError *creationError;
+    NSString *filePath = [self.logFileManager createNewLogFileWithError:&creationError];
+    XCTAssertNil(creationError);
     XCTAssertTrue([self.logFileManager isLogFile:[NSURL fileURLWithPath:filePath].lastPathComponent]);
 
-    NSError *error = nil;
+    __autoreleasing NSError *error = nil;
     NSData *data = [NSData dataWithContentsOfFile:filePath options:NSDataReadingUncached error:&error];
     XCTAssertNil(error);
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1103 

### Pull Request Description

As outlined in #1103, we might return nil from `-[DDLogFileManagerDefault createNewLogFile]` if critical errors occurred a few times in a row. 
I've changed the API now to allow propagating the errors (since `DDLogFileManager` is a protocol) and deal with them in `DDFileLogger`. Still, the nullability annotation of `currentLogFileInfo` had to change to `nullable` since we have to return null there, if the creation of a log file fails.
