### PR TITLE
Duplicated log message code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix -didArchiveLogFile: returning the file name instead of the file path (#1078)
 - Fix setxattr() function usage (#1118)
 - Fix NSDateFormatter thread safety (#1121)
+- Fix -lt_dataForMessage: duplicated code (#1122)
 
 ## [3.6.0 - Xcode 11 on October 2nd, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.0)
 

--- a/Sources/CocoaLumberjack/DDFileLogger+Internal.h
+++ b/Sources/CocoaLumberjack/DDFileLogger+Internal.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 // Will assert if used outside logger's queue.
 - (void)lt_logData:(NSData *)data;
 
-- (NSData *)lt_dataForMessage:(DDLogMessage *)message;
+- (nullable NSData *)lt_dataForMessage:(DDLogMessage *)message;
 
 @end
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1130,26 +1130,14 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 static int exception_count = 0;
 
 - (void)logMessage:(DDLogMessage *)logMessage {
-    NSAssert([self isOnInternalLoggerQueue], @"logMessage should only be executed on internal queue.");
+    // Don't need to check for isOnInternalLoggerQueue, -lt_dataForMessage: will do it for us.
+    NSData *data = [self lt_dataForMessage:logMessage];
 
-    NSString *message = logMessage->_message;
-    BOOL isFormatted = NO;
-
-    if (_logFormatter != nil) {
-        message = [_logFormatter formatLogMessage:logMessage];
-        isFormatted = message != logMessage->_message;
-    }
-
-    if (message.length == 0) {
+    if (data.length == 0) {
         return;
     }
 
-    BOOL shouldFormat = !isFormatted || _automaticallyAppendNewlineForCustomFormatters;
-    if (shouldFormat && ![message hasSuffix:@"\n"]) {
-        message = [message stringByAppendingString:@"\n"];
-    }
-
-    [self lt_logData:[message dataUsingEncoding:NSUTF8StringEncoding]];
+    [self lt_logData:data];
 }
 
 - (void)willLogMessage:(DDLogFileInfo *)logFileInfo {
@@ -1312,7 +1300,7 @@ static int exception_count = 0;
     }
 
     if (message.length == 0) {
-        return [NSData new];
+        return nil;
     }
 
     BOOL shouldFormat = !isFormatted || _automaticallyAppendNewlineForCustomFormatters;

--- a/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
+++ b/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
@@ -119,7 +119,7 @@ static NSUInteger DDGetDefaultBufferSizeBytes() {
 
     [data enumerateByteRangesUsingBlock:^(const void * __nonnull bytes, NSRange byteRange, BOOL * __nonnull __unused stop) {
         NSUInteger bytesLength = byteRange.length;
-#ifndef NS_BLOCK_ASSERTIONS
+#ifdef NS_BLOCK_ASSERTIONS
         __unused
 #endif
         NSInteger written = [_buffer write:bytes maxLength:bytesLength];

--- a/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
+++ b/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
@@ -112,22 +112,25 @@ static NSUInteger DDGetDefaultBufferSizeBytes() {
 - (void)logMessage:(DDLogMessage *)logMessage {
     // Don't need to check for isOnInternalLoggerQueue, -lt_dataForMessage: will do it for us.
     NSData *data = [_fileLogger lt_dataForMessage:logMessage];
-    NSUInteger length = data.length;
-    if (length == 0) {
+
+    if (data.length == 0) {
         return;
     }
 
-#ifndef DEBUG
-    __unused
+    [data enumerateByteRangesUsingBlock:^(const void * __nonnull bytes, NSRange byteRange, BOOL * __nonnull __unused stop) {
+        NSUInteger bytesLength = byteRange.length;
+#ifndef NS_BLOCK_ASSERTIONS
+        __unused
 #endif
-    NSInteger written = [_buffer write:[data bytes] maxLength:length];
-    NSAssert(written == (NSInteger)length, @"Failed to write to memory buffer.");
+        NSInteger written = [_buffer write:bytes maxLength:bytesLength];
+        NSAssert(written > 0 && (NSUInteger)written == bytesLength, @"Failed to write to memory buffer.");
 
-    _currentBufferSizeBytes += length;
+        _currentBufferSizeBytes += bytesLength;
 
-    if (_currentBufferSizeBytes >= _maxBufferSizeBytes) {
-        [self lt_sendBufferedDataToFileLogger];
-    }
+        if (_currentBufferSizeBytes >= _maxBufferSizeBytes) {
+            [self lt_sendBufferedDataToFileLogger];
+        }
+    }];
 }
 
 - (void)flush {

--- a/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
+++ b/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
@@ -110,6 +110,7 @@ static NSUInteger DDGetDefaultBufferSizeBytes() {
 #pragma mark - Logging
 
 - (void)logMessage:(DDLogMessage *)logMessage {
+    // Don't need to check for isOnInternalLoggerQueue, -lt_dataForMessage: will do it for us.
     NSData *data = [_fileLogger lt_dataForMessage:logMessage];
     NSUInteger length = data.length;
     if (length == 0) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This PR fixes duplicated code of -lt_dataForMessage: method. I also changed the signature of -lt_dataForMessage: method which now returns a nullable NSData: it is faster than allocating and returning an empty NSData and data.length still returns zero if data is null.
Finally I prefer to use the modern -enumerateByteRangesUsingBlock: method for accessing NSData buffer. Indeed, it is better to use this rather than bytes property or -getBytes:length: method because they need NSData to map continuous buffer if it contains multiple buffers scattered in memory.