### PR TITLE
linting issue spotted by oclint/sonar

### DIFF
--- a/Sources/CocoaLumberjack/Supporting Files/DDLegacyMacros.h
+++ b/Sources/CocoaLumberjack/Supporting Files/DDLegacyMacros.h
@@ -61,7 +61,7 @@ Disable legacy macros by importing CocoaLumberjack.h or DDLogMacros.h instead of
             format : (frmt), ## __VA_ARGS__]
 
 #define LOG_MAYBE(async, lvl, flg, ctx, fnct, frmt, ...)                       \
-        do { if(lvl & flg) LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if((lvl & flg) != 0) LOG_MACRO(async, lvl, flg, ctx, nil, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_OBJC_MAYBE(async, lvl, flg, ctx, frmt, ...) \
         LOG_MAYBE(async, lvl, flg, ctx, __PRETTY_FUNCTION__, frmt, ## __VA_ARGS__)

--- a/Sources/CocoaLumberjack/include/DDLogMacros.h
+++ b/Sources/CocoaLumberjack/include/DDLogMacros.h
@@ -80,10 +80,10 @@
  * We also define shorthand versions for asynchronous and synchronous logging.
  **/
 #define LOG_MAYBE(async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { if(lvl & flg) LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if((lvl & flg) != 0) LOG_MACRO(async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 #define LOG_MAYBE_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ...) \
-        do { if(lvl & flg) LOG_MACRO_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
+        do { if((lvl & flg) != 0) LOG_MACRO_TO_DDLOG(ddlog, async, lvl, flg, ctx, tag, fnct, frmt, ##__VA_ARGS__); } while(0)
 
 /**
  * Ready to use log macros with no context or tag.


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
This PR addresses an annoyance when using oclint/sonar. Because the condition happens in a macro it's considered part of the code base using it and not part of the module, hence it cannot be excluded unless disabling the whole rule or disabling it per usage, which it's super cumbersome.
The infringing rule is "bitwise operator in conditional" basically it's trying to prevent misuses of "&&" the same as "==" vs "=" in conditionals.
...

