### PR TITLE
Use dispatch_activate() instead of disptach_resume() wherever possible.

### DIFF
--- a/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
+++ b/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
@@ -185,9 +185,12 @@
 
             [self updateDeleteTimer];
 
-            if (_deleteTimer != NULL) {
+            // We are sure that -updateDeleteTimer did call dispatch_source_set_timer()
+            // since it has the same guards on _deleteInterval and _maxAge
+            if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))
+                dispatch_activate(_deleteTimer);
+            else
                 dispatch_resume(_deleteTimer);
-            }
         }
     }
 }

--- a/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
+++ b/Sources/CocoaLumberjack/DDAbstractDatabaseLogger.m
@@ -23,7 +23,11 @@
 @interface DDAbstractDatabaseLogger ()
 
 - (void)destroySaveTimer;
+- (void)updateAndResumeSaveTimer;
+- (void)createSuspendedSaveTimer;
 - (void)destroyDeleteTimer;
+- (void)updateDeleteTimer;
+- (void)createAndStartDeleteTimer;
 
 @end
 
@@ -88,9 +92,9 @@
     _unsavedCount = 0;
     _unsavedTime = 0;
 
-    if (_saveTimer && !_saveTimerSuspended) {
+    if (_saveTimer != NULL && _saveTimerSuspended == 0) {
         dispatch_suspend(_saveTimer);
-        _saveTimerSuspended = YES;
+        _saveTimerSuspended = 1;
     }
 }
 
@@ -107,32 +111,50 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 - (void)destroySaveTimer {
-    if (_saveTimer) {
+    if (_saveTimer != NULL) {
         dispatch_source_cancel(_saveTimer);
 
-        if (_saveTimerSuspended) {
-            // Must resume a timer before releasing it (or it will crash)
-            dispatch_resume(_saveTimer);
-            _saveTimerSuspended = NO;
+        // Must activate a timer before releasing it (or it will crash)
+        if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)) {
+            if (_saveTimerSuspended < 0) {
+                dispatch_activate(_saveTimer);
+            } else if (_saveTimerSuspended > 0) {
+                dispatch_resume(_saveTimer);
+            }
+        } else {
+            if (_saveTimerSuspended != 0) {
+                dispatch_resume(_saveTimer);
+            }
         }
 
         #if !OS_OBJECT_USE_OBJC
         dispatch_release(_saveTimer);
         #endif
         _saveTimer = NULL;
+        _saveTimerSuspended = 0;
     }
 }
 
 - (void)updateAndResumeSaveTimer {
-    if ((_saveTimer != NULL) && (_saveInterval > 0.0) && (_unsavedTime > 0.0)) {
+    if ((_saveTimer != NULL) && (_saveInterval > 0.0) && (_unsavedTime > 0)) {
         uint64_t interval = (uint64_t)(_saveInterval * (NSTimeInterval) NSEC_PER_SEC);
         dispatch_time_t startTime = dispatch_time(_unsavedTime, (int64_t)interval);
 
         dispatch_source_set_timer(_saveTimer, startTime, interval, 1ull * NSEC_PER_SEC);
 
-        if (_saveTimerSuspended) {
-            dispatch_resume(_saveTimer);
-            _saveTimerSuspended = NO;
+        if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)) {
+            if (_saveTimerSuspended < 0) {
+                dispatch_activate(_saveTimer);
+                _saveTimerSuspended = 0;
+            } else if (_saveTimerSuspended > 0) {
+                dispatch_resume(_saveTimer);
+                _saveTimerSuspended = 0;
+            }
+        } else {
+            if (_saveTimerSuspended != 0) {
+                dispatch_resume(_saveTimer);
+                _saveTimerSuspended = 0;
+            }
         }
     }
 }
@@ -145,12 +167,12 @@
                                                             [self performSaveAndSuspendSaveTimer];
                                                         } });
 
-        _saveTimerSuspended = YES;
+        _saveTimerSuspended = -1;
     }
 }
 
 - (void)destroyDeleteTimer {
-    if (_deleteTimer) {
+    if (_deleteTimer != NULL) {
         dispatch_source_cancel(_deleteTimer);
         #if !OS_OBJECT_USE_OBJC
         dispatch_release(_deleteTimer);

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -837,7 +837,11 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, delay);
 
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, (uint64_t)kDDRollingLeeway * NSEC_PER_SEC);
-    dispatch_resume(_rollingTimer);
+
+    if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))
+        dispatch_activate(_rollingTimer);
+    else
+        dispatch_resume(_rollingTimer);
 }
 
 - (void)rollLogFile {
@@ -1103,7 +1107,10 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     });
 #endif
 
-    dispatch_resume(_currentLogFileVnode);
+    if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))
+        dispatch_activate(_currentLogFileVnode);
+    else
+        dispatch_resume(_currentLogFileVnode);
 }
 
 - (NSFileHandle *)lt_currentLogFileHandle {

--- a/Sources/CocoaLumberjack/include/DDAbstractDatabaseLogger.h
+++ b/Sources/CocoaLumberjack/include/DDAbstractDatabaseLogger.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSTimeInterval _deleteInterval;
     BOOL _deleteOnEverySave;
     
-    BOOL _saveTimerSuspended;
+    NSInteger _saveTimerSuspended;
     NSUInteger _unsavedCount;
     dispatch_time_t _unsavedTime;
     dispatch_source_t _saveTimer;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This a simple PR that use dispatch_activate() instead of dispatch_resume() since it is the preferred method as stated in the doc:

```
 * For backward compatibility reasons, dispatch_resume() on an inactive and not
 * otherwise suspended dispatch source object has the same effect as calling
 * dispatch_activate(). For new code, using dispatch_activate() is preferred.
```
