### PR TITLE
Updated gemfile dependencies (used bundler 1.17.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    claide (1.0.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
@@ -11,43 +11,49 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.11.1)
+    danger (6.3.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1.5)
-      kramdown (~> 1.5)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.6)
+      kramdown (~> 2.0)
+      kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-swiftlint (0.18.1)
+    danger-swiftlint (0.24.2)
       danger
       rake (> 10)
       thor (~> 0.19)
-    faraday (0.15.4)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
-    git (1.5.0)
-    kramdown (1.17.0)
-    multipart-post (2.0.0)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    git (1.6.0)
+      rchardet (~> 1.8)
+    kramdown (2.1.0)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.13.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    public_suffix (3.0.3)
-    rake (12.3.2)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    public_suffix (4.0.4)
+    rake (13.0.1)
+    rchardet (1.8.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.3)
-    unicode-display_width (1.4.1)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -57,4 +63,4 @@ DEPENDENCIES
   danger-swiftlint
 
 BUNDLED WITH
-   1.16.5
+   1.17.1


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues:
```
1 rake vulnerability found in Gemfile.lock on Feb 29
Remediation

Upgrade rake to version 12.3.3 or later. For example:

gem "rake", ">= 12.3.3"
Always verify the validity and compatibility of suggestions with your codebase.

CVE-2020-8130

moderate severity
Vulnerable versions: <= 12.3.2
Patched version: 12.3.3
There is an OS command injection vulnerability in Ruby Rake before 12.3.3 in Rake::FileList when supplying a filename that begins with the pipe character |.
```

### Pull Request Description

Fix the vulnerability reported by Github and also update our gemfile stack - did not yet update to bundler 2.

