### PR TITLE
Simplify checking for command-comment & prevent build failures

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -34,16 +34,11 @@ jobs:
 
   run-danger-for-external-pr:
     runs-on: ubuntu-latest
-    if: github.event_name == 'issue_comment' && github.event.issue.pull_request != null
+    if: |
+      github.event_name == 'issue_comment' && github.event.action == 'created'
+      && github.event.issue.pull_request != null
+      && startsWith(github.event.comment.body, '/run_checks')
     steps:
-      - uses: xt0rted/slash-command-action@v1
-        with:
-          repo-token: ${{secrets.GITHUB_TOKEN}}
-          command: run_checks
-          reaction: true
-          reaction-type: "+1"
-          allow-edits: false
-          permission-level: write
       - uses: actions/github-script@v2
         id: pr-details
         with:

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -43,11 +43,10 @@ jobs:
         id: pr-details
         with:
           script: |
-            const pathComponents = new URL(context.payload.issue.pull_request.url).path.split("/");
             const { data: pullRequest } = await octokit.pulls.get({
-              owner: pathComponents[1],
-              repo: pathComponents[2],
-              pull_number: pathComponents[4]
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: github.event.issue.number
             });
             return pullRequest;
       - uses: actions/checkout@v2

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -102,8 +102,7 @@ if xcodeProjectWasModified {
                     warn(message: "Files should be in sync with project structure", file: projectFile, line: offset + 1)
                 }
                 if let range = line.range(of: "[A-Z_]+ = .*;", options: .regularExpression) {
-                    let parts = line[range].split(separator: " = ").dropLast()
-                    let setting = String(parts[parts.startIndex])
+                    let setting = String(line[range].prefix(while: { $0 != " " }))
                     if !acceptedSettings.contains(setting) {
                         warn(message: "Xcode settings need to remain in Configs/*.xcconfig. Please move " + setting + " to the xcconfig file", file: projectFile, line: offset + 1)
                     }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -17,6 +17,10 @@ fileprivate extension Danger.File {
     var isSwiftPackageDefintion: Bool {
         hasPrefix("Package") && hasSuffix(".swift")
     }
+
+    var isDangerfile: Bool {
+        self == "Dangerfile.swift"
+    }
 }
 
 let danger = Danger()
@@ -152,6 +156,7 @@ let sourcefilesToCheck = Set(git.modifiedFiles + git.createdFiles)
 let filesWithInvalidCopyright = sourcefilesToCheck.lazy
     .filter { $0.isSourceFile }
     .filter { !$0.isSwiftPackageDefintion }
+    .filter { !$0.isDangerfile }
     .filter { !$0.isInVendor && !$0.isInFMDB }
     .filter { FileManager.default.fileExists(atPath: $0) }
     .filter {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This is a small fix on top of #1140 that simplifies the check for command-comments and with that prevents build failures if no command was found.

