### PR TITLE
Drop iOS 8, remove unnecessary code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [3.6.2 - Xcode 11.4 on ???, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 
 ### Public
+- **Breaking change**: Dropped support for iOS 8 (#1153)
 - Fix warnings when building with SPM bundled with Swift 5.2 / Xcode 11.4 (#1132)
 - Added Swift name for DDQualityOfServiceName constants.
 - Don't localize timestamps in `DDefaultFileLogFormatter` (#1151)

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = 'README.md'
 
-  s.ios.deployment_target     = '8.0'
+  s.ios.deployment_target     = '9.0'
   s.osx.deployment_target     = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target    = '9.0'

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -189,7 +189,7 @@ GCC_WARN_UNUSED_VARIABLE = YES
 HEADER_SEARCH_PATHS = $(inherited)
 
 // Code will load on this and later versions of iOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
-IPHONEOS_DEPLOYMENT_TARGET = 8.0
+IPHONEOS_DEPLOYMENT_TARGET = 9.0
 
 // This is a list of paths to be added to the `runpath` search path list for the image being created. At runtime, `dyld` uses the `runpath` when searching for dylibs whose load path begins with `@rpath/`.
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @loader_path/Frameworks

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "CocoaLumberjack",
     platforms: [
-        .iOS(.v8),
+        .iOS(.v9),
         .macOS(.v10_10),
         .watchOS(.v3),
         .tvOS(.v9),

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Then use `DDOSLogger` for iOS 10 and later, or `DDTTYLogger` and `DDASLLogger` f
 #### CocoaPods
 
 ```ruby
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 target 'SampleTarget' do
   use_frameworks!
@@ -35,7 +35,7 @@ For more details about how to use Swift with Lumberjack, see [this conversation]
 
 For Objective-C use the following:
 ```ruby
-platform :ios, '8.0'
+platform :ios, '9.0'
 
 target 'SampleTarget' do
     pod 'CocoaLumberjack'
@@ -169,13 +169,14 @@ Configure your logging however you want. Change log levels per file (perfect for
 The current version of Lumberjack requires:
 - Xcode 11 or later
 - Swift 5.0 or later
-- iOS 8 or later
+- iOS 9 or later
 - macOS 10.10 or later
 - watchOS 3 or later
 - tvOS 9 or later
 
 #### Backwards compatibility
 - for Xcode 10 and Swift 4.2, use the 3.5.2 version
+- for iOS 8, use the 3.6.1 version
 - for iOS 6, iOS 7, OS X 10.8, OS X 10.9 and Xcode 9, use the 3.4.2 version
 - for iOS 5 and OS X 10.7, use the 3.3 version
 - for Xcode 8 and Swift 3, use the 3.2 version

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1066,9 +1066,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 
         // Try to get the current queue's label
         _queueLabel = [[NSString alloc] initWithFormat:@"%s", dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)];
-
-        if (@available(macOS 10.10, iOS 8.0, *))
-            _qos = (NSUInteger) qos_class_self();
+        _qos = (NSUInteger) qos_class_self();
     }
     return self;
 }

--- a/Sources/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Sources/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -228,9 +228,7 @@ static DDQualityOfServiceName _qos_name(NSUInteger qos) {
     NSString *timestamp = [self stringFromDate:(logMessage->_timestamp)];
     NSString *queueThreadLabel = [self queueThreadLabelForLogMessage:logMessage];
 
-    if (@available(macOS 10.10, iOS 8.0, *))
-        return [NSString stringWithFormat:@"%@ [%@ (QOS:%@)] %@", timestamp, queueThreadLabel, _qos_name(logMessage->_qos), logMessage->_message];
-    return [NSString stringWithFormat:@"%@ [%@] %@", timestamp, queueThreadLabel, logMessage->_message];
+    return [NSString stringWithFormat:@"%@ [%@ (QOS:%@)] %@", timestamp, queueThreadLabel, _qos_name(logMessage->_qos), logMessage->_message];
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: none

### Pull Request Description
As per discussion in https://github.com/CocoaLumberjack/CocoaLumberjack/pull/1148 with @ffried - soon iOS 8 won't be available in Xcode (in Xcode 12).

This PR prepares CocoaLumberJack for upcoming release of iOS and Xcode and simply just drops iOS 9.
Following PRs in future will also update SPM and project itself to Swift 5.3.
- Drop iOS 8 in order to prepare for September and iOS 14 with Xcode 12 and his minimum deployment target as iOS 8
- Remove availability macros that are not necessary as CocoaLumberJack supports macOS 10.10 and iOS 9.0 and higher

This fixed warnings for Xcode 12 without updating the codebase and Swift version itself and without affecting master and stable Xcode itself - which sounds like a good step to me.

