### PR TITLE
[Proposal] Add `/run_checks` permission

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -39,29 +39,13 @@ jobs:
       && github.event.issue.pull_request != null
       && startsWith(github.event.comment.body, '/run_checks')
     steps:
-      - uses: actions/github-script@v2
+      - uses: sushichop/action-repository-permission@v1
         with:
-          script: |
-            github.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: "+1"
-            })
-      - uses: actions/github-script@v2
-        id: pr-details
-        with:
-          script: |
-            const { data: pullRequest } = await github.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-            return pullRequest;
+          required-permission: write
+          reaction-permitted: '+1'
       - uses: actions/checkout@v2
         with:
-          repository: ${{fromJSON(steps.pr-details.outputs.result).head.repo.full_name}}
-          ref: ${{fromJSON(steps.pr-details.outputs.result).head.ref}}
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
       - uses: danger/swift@3.3.2
         with:

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           required-permission: write
           reaction-permitted: '+1'
+          comment-not-permitted: "Sorry, you don't have enough permission to execute /run_checks..."
       - uses: actions/github-script@v2
         id: pr-details
         with:

--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -43,9 +43,20 @@ jobs:
         with:
           required-permission: write
           reaction-permitted: '+1'
+      - uses: actions/github-script@v2
+        id: pr-details
+        with:
+          script: |
+            const { data: pullRequest } = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return pullRequest;
       - uses: actions/checkout@v2
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          repository: ${{fromJSON(steps.pr-details.outputs.result).head.repo.full_name}}
+          ref: ${{fromJSON(steps.pr-details.outputs.result).head.ref}}
           fetch-depth: 0
       - uses: danger/swift@3.3.2
         with:


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

I'd like to limit the users who can execute `/run_checks` to collaborator and admin (I think it was the expected behavior?). I also simplified the action for checking out the pull requests from the fork. In fact, I have already implemented this method in some projects and they works fine.

Do you prefer this proposal? TBH, I'm not sure we really need this feature(limit the users who can execute `/run_checks`), but we can do it😅 and it gets better, I think.

As a reminder,  this change will work fine after the merge(not at pull request) due to GitHub Action issue_event specification.

Thanks.

