### PR TITLE
Simplify log file manager hooks to one hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking change**: Dropped support for iOS 8 (#1153)
 - Update SPM tools-version to 5.3 to enable Swift 5.3 support (#1148)
 - Add backend for swift-log (#1164)
+- Simplify `DDLogFileManager` callbacks for archived log files (#1166)
 
 ## [3.6.2 - Xcode 11.6 on July 31st, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -176,19 +176,31 @@ let filesWithInvalidCopyright = sourcefilesToCheck.lazy
     .filter { FileManager.default.fileExists(atPath: $0) }
     .filter {
         // Use correct copyright lines depending on source file location
-        let expectedLines: Array<String>
+        let (expectedLines, shouldMatchExactly): (Array<String>, Bool)
         if $0.isInDemos {
             expectedLines = copyrightLines.demos
+            shouldMatchExactly = false
         } else if $0.isInBenchmarking {
             expectedLines = copyrightLines.benchmarking
+            shouldMatchExactly = false
         } else {
             expectedLines = copyrightLines.source
+            shouldMatchExactly = true
         }
-        return !danger.utils.readFile($0).split(separator: "\n").lazy.map(String.init).starts(with: expectedLines)
+        let actualLines = danger.utils.readFile($0).split(separator: "\n").lazy.map(String.init)
+        if shouldMatchExactly {
+            return !actualLines.starts(with: expectedLines)
+        } else {
+            return !zip(actualLines, expectedLines).allSatisfy { $0.starts(with: $1) }
+        }
 }
 if !filesWithInvalidCopyright.isEmpty {
     filesWithInvalidCopyright.forEach {
         markdown(message: "Invalid copyright!", file: $0, line: 1)
     }
-    warn("Copyright is not valid. See our default copyright in all of our files (Sources, Demos and Benchmarking use different formats).")
+    warn("""
+        Copyright is not valid. See our default copyright in all of our files (Sources, Demos and Benchmarking use different formats).
+        Invalid files:
+        \(filesWithInvalidCopyright.map { "- \($0)" }.joined(separator: "\n"))")
+        """
 }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -201,6 +201,6 @@ if !filesWithInvalidCopyright.isEmpty {
     warn("""
          Copyright is not valid. See our default copyright in all of our files (Sources, Demos and Benchmarking use different formats).
          Invalid files:
-         \(filesWithInvalidCopyright.map { "- \($0)" }.joined(separator: "\n"))")
+         \(filesWithInvalidCopyright.map { "- \($0)" }.joined(separator: "\n"))
          """)
 }

--- a/Dangerfile.swift
+++ b/Dangerfile.swift
@@ -199,8 +199,8 @@ if !filesWithInvalidCopyright.isEmpty {
         markdown(message: "Invalid copyright!", file: $0, line: 1)
     }
     warn("""
-        Copyright is not valid. See our default copyright in all of our files (Sources, Demos and Benchmarking use different formats).
-        Invalid files:
-        \(filesWithInvalidCopyright.map { "- \($0)" }.joined(separator: "\n"))")
-        """
+         Copyright is not valid. See our default copyright in all of our files (Sources, Demos and Benchmarking use different formats).
+         Invalid files:
+         \(filesWithInvalidCopyright.map { "- \($0)" }.joined(separator: "\n"))")
+         """)
 }

--- a/Demos/LogFileCompressor/CompressingLogFileManager.m
+++ b/Demos/LogFileCompressor/CompressingLogFileManager.m
@@ -146,28 +146,13 @@
     [self performSelector:@selector(compressNextLogFile) withObject:nil afterDelay:delay];
 }
 
-- (void)didArchiveLogFile:(NSString *)logFilePath
-{
-    NSLogVerbose(@"CompressingLogFileManager: didArchiveLogFile: %@", [logFilePath lastPathComponent]);
-    
-    // If all other log files have been compressed,
-    // then we can get started right away.
-    // Otherwise we should just wait for the current compression process to finish.
-    
-    if (upToDate)
-    {
-        [self compressLogFile:[DDLogFileInfo logFileWithPath:logFilePath]];
-    }
-}
+- (void)didArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled {
+    NSLogVerbose(@"CompressingLogFileManager: didArchiveLogFile: %@ wasRolled: %@",
+                 [logFilePath lastPathComponent], (wasRolled ? @"YES" : @"NO"));
 
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath
-{
-    NSLogVerbose(@"CompressingLogFileManager: didRollAndArchiveLogFile: %@", [logFilePath lastPathComponent]);
-    
-    // If all other log files have been compressed,
-    // then we can get started right away.
+    // If all other log files have been compressed, then we can get started right away.
     // Otherwise we should just wait for the current compression process to finish.
-    
+
     if (upToDate)
     {
         [self compressLogFile:[DDLogFileInfo logFileWithPath:logFilePath]];

--- a/Documentation/LogFileManagement.md
+++ b/Documentation/LogFileManagement.md
@@ -47,20 +47,19 @@ Let's take a look at the DDLogFileManager protocol:
 
 // Private methods (only to be used by DDFileLogger)
 
-- (NSString *)createNewLogFile;
+- (NSString *)createNewLogFileWithError(NSError**)error;
 
 @optional
 
 // Notifications from DDFileLogger
 
-- (void)didArchiveLogFile:(NSString *)logFilePath;
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath;
+- (void)didRollAndArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled;
 
 @end
 ```
 
-There are methods to get the logs directory, and various methods to get the list of log files. Then there is a method to create a new log file (that returns the new log file path). And lastly, there are hooks from `DDFileLogger` to be notified of when a log file is rolled.
+There are methods to get the logs directory, and various methods to get the list of log files. Then there is a method to create a new log file (that returns the new log file path). And lastly, there is a hook from `DDFileLogger` to be notified of when a log file is rolled.
 
-The hooks are designed to allow you do something with those archived log files!
+This hook is designed to allow you do something with those archived log files!
 
 The framework comes with a sample Xcode project that demonstrates compressing archived log files to save disk space. (It performs the compression using gzip.) The Xcode project name is `LogFileCompressor`. The `CompressingLogFileManager` class is ready to be used in your project, or you can use it as a template, or simply learn from it so you can do your own custom log file management.

--- a/Documentation/LogFileManagement.md
+++ b/Documentation/LogFileManagement.md
@@ -53,13 +53,11 @@ Let's take a look at the DDLogFileManager protocol:
 
 // Notifications from DDFileLogger
 
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled;
+- (void)didArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled;
 
 @end
 ```
 
-There are methods to get the logs directory, and various methods to get the list of log files. Then there is a method to create a new log file (that returns the new log file path). And lastly, there is a hook from `DDFileLogger` to be notified of when a log file is rolled.
-
-This hook is designed to allow you do something with those archived log files!
+There are methods to get the logs directory, and various methods to get the list of log files. Then there is a method to create a new log file (that returns the new log file path). And lastly, there is a hook from `DDFileLogger` to be notified of when a log file is rolled. This hook is designed to allow you do something with those archived log files!
 
 The framework comes with a sample Xcode project that demonstrates compressing archived log files to save disk space. (It performs the compression using gzip.) The Xcode project name is `LogFileCompressor`. The `CompressingLogFileManager` class is ready to be used in your project, or you can use it as a template, or simply learn from it so you can do your own custom log file management.

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -588,7 +588,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 }
 
 - (NSString *)formatLogMessage:(DDLogMessage *)logMessage {
-    NSString *dateAndTime = [_dateFormatter stringFromDate:(logMessage->_timestamp)];
+    NSString *dateAndTime = [_dateFormatter stringFromDate:logMessage->_timestamp];
 
     return [NSString stringWithFormat:@"%@  %@", dateAndTime, logMessage->_message];
 }
@@ -891,14 +891,28 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     _currentLogFileHandle = nil;
 
     _currentLogFileInfo.isArchived = YES;
-    BOOL logFileManagerRespondsToSelector = [_logFileManager respondsToSelector:@selector(didRollAndArchiveLogFile:)];
+
+    const BOOL logFileManagerRespondsToNewArchiveSelector = [_logFileManager respondsToSelector:@selector(didArchiveLogFile:wasRolled:)];
+    const BOOL logFileManagerRespondsToSelector = (logFileManagerRespondsToNewArchiveSelector
+                                                   || [_logFileManager respondsToSelector:@selector(didRollAndArchiveLogFile:)]);
     NSString *archivedFilePath = (logFileManagerRespondsToSelector) ? [_currentLogFileInfo.filePath copy] : nil;
     _currentLogFileInfo = nil;
 
     if (logFileManagerRespondsToSelector) {
-        dispatch_async(_completionQueue, ^{
-            [self->_logFileManager didRollAndArchiveLogFile:archivedFilePath];
-        });
+        dispatch_block_t block;
+        if (logFileManagerRespondsToNewArchiveSelector) {
+            block = ^{
+                [self->_logFileManager didArchiveLogFile:archivedFilePath wasRolled:YES];
+            };
+        } else {
+            block = ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                [self->_logFileManager didRollAndArchiveLogFile:archivedFilePath];
+#pragma clang diagnostic pop
+            };
+        }
+        dispatch_async(_completionQueue, block);
     }
 
     if (_currentLogFileVnode) {
@@ -1069,11 +1083,23 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     if (isResuming && (_doNotReuseLogFiles || [self lt_shouldLogFileBeArchived:logFileInfo])) {
         logFileInfo.isArchived = YES;
 
-        if ([_logFileManager respondsToSelector:@selector(didArchiveLogFile:)]) {
+        const BOOL logFileManagerRespondsToNewArchiveSelector = [_logFileManager respondsToSelector:@selector(didArchiveLogFile:wasRolled:)];
+        if (logFileManagerRespondsToNewArchiveSelector || [_logFileManager respondsToSelector:@selector(didArchiveLogFile:)]) {
             NSString *archivedFilePath = [logFileInfo.filePath copy];
-            dispatch_async(_completionQueue, ^{
-                [self->_logFileManager didArchiveLogFile:archivedFilePath];
-            });
+            dispatch_block_t block;
+            if (logFileManagerRespondsToNewArchiveSelector) {
+                block = ^{
+                    [self->_logFileManager didArchiveLogFile:archivedFilePath wasRolled:YES];
+                };
+            } else {
+                block = ^{
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+                    [self->_logFileManager didArchiveLogFile:archivedFilePath];
+    #pragma clang diagnostic pop
+                };
+            }
+            dispatch_async(_completionQueue, block);
         }
 
         return NO;

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1089,7 +1089,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
             dispatch_block_t block;
             if (logFileManagerRespondsToNewArchiveSelector) {
                 block = ^{
-                    [self->_logFileManager didArchiveLogFile:archivedFilePath wasRolled:YES];
+                    [self->_logFileManager didArchiveLogFile:archivedFilePath wasRolled:NO];
                 };
             } else {
                 block = ^{

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -162,7 +162,7 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 // Notifications from DDFileLogger
 
 /// Called when a log file was archived. Executed on global queue with default priority.
-/// @param logFilePath TThe path to the log file that was archived.
+/// @param logFilePath The path to the log file that was archived.
 /// @param wasRolled Whether or not the archiving happend after rolling the log file.
 - (void)didArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled NS_SWIFT_NAME(didArchiveLogFile(atPath:wasRolled:));
 
@@ -290,7 +290,6 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
    - (NSArray *)sortedLogFilePaths;
    - (NSArray *)sortedLogFileNames;
    - (NSArray *)sortedLogFileInfos;
-
  */
 
 @end

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -161,16 +161,22 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 // Notifications from DDFileLogger
 
+/// Called when a log file was archived. Executed on global queue with default priority.
+/// @param logFilePath TThe path to the log file that was archived.
+/// @param wasRolled Whether or not the archiving happend after rolling the log file.
+- (void)didArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled NS_SWIFT_NAME(didArchiveLogFile(atPath:wasRolled:));
+
+// Deprecated APIs
 /**
  *  Called when a log file was archived. Executed on global queue with default priority.
  */
-- (void)didArchiveLogFile:(NSString *)logFilePath NS_SWIFT_NAME(didArchiveLogFile(atPath:));
+- (void)didArchiveLogFile:(NSString *)logFilePath NS_SWIFT_NAME(didArchiveLogFile(atPath:)) __attribute__((deprecated("Use -didArchiveLogFile:wasRolled:")));
 
 /**
  *  Called when the roll action was executed and the log was archived.
  *  Executed on global queue with default priority.
  */
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath NS_SWIFT_NAME(didRollAndArchiveLogFile(atPath:));
+- (void)didRollAndArchiveLogFile:(NSString *)logFilePath NS_SWIFT_NAME(didRollAndArchiveLogFile(atPath:)) __attribute__((deprecated("Use -didArchiveLogFile:wasRolled:")));
 
 @end
 
@@ -340,8 +346,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 /**
  *  Designated initializer, requires a `DDLogFileManager` instance.
- *  The completionQueue is used to execute `didArchiveLogFile`, `didRollAndArchiveLogFile`,
- *  and the callback in `rollLog`. If nil, a global queue w/ default priority is used.
+ *  The completionQueue is used to execute `didArchiveLogFile:wasRolled:`,
+ *  and the callback in `rollLogFileWithCompletionBlock:`.
+ *  If nil, a global queue w/ default priority is used.
  */
 - (instancetype)initWithLogFileManager:(id <DDLogFileManager>)logFileManager
                        completionQueue:(nullable dispatch_queue_t)dispatchQueue NS_DESIGNATED_INITIALIZER;

--- a/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
+++ b/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
@@ -66,7 +66,7 @@ extension DDLogMessage {
     }
 }
 
-/// This class (intentionally internal) is basically only an "encapsulation" layer above `DDLogMessage`.
+/// This class (intentionally internal) is only an "encapsulation" layer above `DDLogMessage`.
 /// It's basically an implementation detail of `DDLogMessage.swiftLogInfo`.
 @usableFromInline
 final class SwiftLogMessage: DDLogMessage {

--- a/Tests/CocoaLumberjackTests/DDSampleFileManager.m
+++ b/Tests/CocoaLumberjackTests/DDSampleFileManager.m
@@ -39,7 +39,7 @@
     return _header;
 }
 
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled {
+- (void)didArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled {
     _archivedLogFilePath = logFilePath;
 }
 

--- a/Tests/CocoaLumberjackTests/DDSampleFileManager.m
+++ b/Tests/CocoaLumberjackTests/DDSampleFileManager.m
@@ -39,11 +39,7 @@
     return _header;
 }
 
-- (void)didArchiveLogFile:(NSString *)logFilePath {
-    _archivedLogFilePath = logFilePath;
-}
-
-- (void)didRollAndArchiveLogFile:(NSString *)logFilePath {
+- (void)didRollAndArchiveLogFile:(NSString *)logFilePath wasRolled:(BOOL)wasRolled {
     _archivedLogFilePath = logFilePath;
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1165 

### Pull Request Description

Currently, there are two hooks in DDLogFileManager for managing archived log files (`didRollAndArchiveLogFile:` and `didArchiveLogFile:`). The only difference is the place where they are called.
This simplifies that by turning the two methods into one with an additional bool parameter that provides that distinction.
