### PR TITLE
Specify CocoaPods version to ensure `swift_version` attribute works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking change**: Dropped support for iOS 8 (#1153)
 - Update SPM tools-version to 5.3 to enable Swift 5.3 support (#1148)
 - Add backend for swift-log (#1164)
+- Specify CocoaPods version to ensure `swift_version` attribute works (#1167)
 
 ## [3.6.2 - Xcode 11.6 on July 31st, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -22,6 +22,8 @@ Pod::Spec.new do |s|
   s.osx.deployment_target     = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target    = '9.0'
+
+  s.cocoapods_version = '>= 1.4.0'
   s.swift_version = '5.0'
 
   s.default_subspecs = 'Core'


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1161 

### Pull Request Description

Specify CocoaPods version to ensure `swift_version` attribute sets SWIFT_VERSOIN even when user does not set SWIFT_VERSION in his/her target project.
Reference: http://blog.cocoapods.org/CocoaPods-1.4.0/

