### PR TITLE
Prepare Release 3.7.0 #trivial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## [3.7.0 - Xcode 12 on ???, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
+## [3.7.1 - Xcode 12 on ???, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
+
+### Public
+
+- _TBD_
+
+## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
 
 ### Public
 

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.name     = 'CocoaLumberjack'
   s.version  = '3.6.2'
   s.license  = 'BSD'
-  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac and iOS.'
+  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac, iOS, tvOS and watchOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
   s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',
@@ -14,8 +14,6 @@ Pod::Spec.new do |s|
                   'such as multi-threading, grand central dispatch (if available), lockless '      \
                   'atomic operations, and the dynamic nature of the objective-c runtime.'
 
-  s.requires_arc   = true
-
   s.preserve_paths = 'README.md'
 
   s.ios.deployment_target     = '9.0'
@@ -24,6 +22,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target    = '9.0'
 
   s.cocoapods_version = '>= 1.4.0'
+  s.requires_arc   = true
   s.swift_version = '5.0'
 
   s.default_subspecs = 'Core'
@@ -37,5 +36,4 @@ Pod::Spec.new do |s|
     ss.dependency 'CocoaLumberjack/Core'
     ss.source_files        = 'Sources/CocoaLumberjackSwift/**/*.swift', 'Sources/CocoaLumberjackSwiftSupport/include/**/*.{h}'
   end
-
 end

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.name     = 'CocoaLumberjack'
   s.version  = '3.7.0'
   s.license  = 'BSD'
-  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac, iOS, tvOS and watchOS.'
+  s.summary  = 'A fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'
   s.author   = { 'Robbie Hanson' => 'robbiehanson@deusty.com' }
   s.source   = { :git => 'https://github.com/CocoaLumberjack/CocoaLumberjack.git',

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name     = 'CocoaLumberjack'
-  s.version  = '3.6.2'
+  s.version  = '3.7.0'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for Mac, iOS, tvOS and watchOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -200,7 +200,7 @@ LIBRARY_SEARCH_PATHS = $(inherited)
 // Code will load on this and later versions of macOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
 MACOSX_DEPLOYMENT_TARGET = 10.10
 
-MARKETING_VERSION = 3.6.2
+MARKETING_VERSION = 3.7.0
 
 OTHER_C_FLAGS = -Wextra
 

--- a/Integration/Integration.xcodeproj/project.pbxproj
+++ b/Integration/Integration.xcodeproj/project.pbxproj
@@ -517,7 +517,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1000;
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = CocoaLumberjack;
 				TargetAttributes = {
 					0A87D3C32175E56200BD0C4C = {

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSFrameworkIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSFrameworkIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSStaticLibraryIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSStaticLibraryIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSSwiftIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/iOSSwiftIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/macOSSwiftIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/macOSSwiftIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/tvOSSwiftIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/tvOSSwiftIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/watchOSSwiftIntegration (Notification).xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/watchOSSwiftIntegration (Notification).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Integration/Integration.xcodeproj/xcshareddata/xcschemes/watchOSSwiftIntegration.xcscheme
+++ b/Integration/Integration.xcodeproj/xcshareddata/xcschemes/watchOSSwiftIntegration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -466,7 +466,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1200;
 				TargetAttributes = {
 					18F3BFD61A81E06E00692297 = {
 						CreatedOnToolsVersion = 6.1.1;

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-Static.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-Static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ CocoaLumberjack
 [![codebeat badge](https://codebeat.co/badges/840b714a-c8f3-4936-ada4-363473cd4e6b)](https://codebeat.co/projects/github-com-cocoalumberjack-cocoalumberjack-master)
 
 
-**CocoaLumberjack** is a fast & simple, yet powerful & flexible logging framework for Mac and iOS.
+**CocoaLumberjack** is a fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS.
 
 ### How to get started
 
@@ -60,7 +60,7 @@ As of CocoaLumberjack 3.6.0, you can use the Swift Package Manager as integratio
 If you want to use the Swift Package Manager as integration method, either use Xcode to add the package dependency or add the following dependency to your Package.swift:
 
 ```swift
-.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.6.0"),
+.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", from: "3.7.0"),
 ```
 
 Note that you may need to add both products, `CocoaLumberjack` and `CocoaLumberjackSwift` to your target since SPM sometimes fails to detect that `CocoaLumerjackSwift` depends on `CocoaLumberjack`.
@@ -180,14 +180,15 @@ Configure your logging however you want. Change log levels per file (perfect for
 
 ### Requirements
 The current version of Lumberjack requires:
-- Xcode 11 or later
-- Swift 5.0 or later
+- Xcode 12 or later
+- Swift 5.3 or later
 - iOS 9 or later
 - macOS 10.10 or later
 - watchOS 3 or later
 - tvOS 9 or later
 
 #### Backwards compatibility
+- for Xcode 11 and Swift up to 5.2, use the 3.6.2 version
 - for Xcode 10 and Swift 4.2, use the 3.5.2 version
 - for iOS 8, use the 3.6.1 version
 - for iOS 6, iOS 7, OS X 10.8, OS X 10.9 and Xcode 9, use the 3.4.2 version

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -248,7 +248,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1110;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = deusty;
 				TargetAttributes = {
 					432B53321AAE423E00843E69 = {

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/OS X Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/OS X Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Swift Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/Swift Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1130"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tests/Tests.xcodeproj/xcshareddata/xcschemes/iOS Tests.xcscheme
+++ b/Tests/Tests.xcodeproj/xcshareddata/xcschemes/iOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1110"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This prepares the release 3.7.0 by doing the following:

- Update schemes and project files with the current version of Xcode 12 (12.0.1 12A7300)
- Update versions in xcconfigs and podspec
- Finalize release date to Oct 2nd in CHANGELOG (and add new section for the next release)
- Update README with new requirements

While I was at it, I cleaned up (restructuring only) the podspec a bit and updated the description in the README and the podspec.
