### PR TITLE
#532 Fix tag selectors name and type conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Public
 
+- Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
 - _TBD_
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)

--- a/Documentation/CustomContext.md
+++ b/Documentation/CustomContext.md
@@ -33,7 +33,7 @@ Every log message that goes through the Lumberjack framework is turned into a DD
 @property (readonly, nonatomic) NSString *fileName;
 @property (readonly, nonatomic) NSString *function;
 @property (readonly, nonatomic) NSUInteger line;
-@property (readonly, nonatomic) id tag;
+@property (readonly, nonatomic) id representedObject;
 @property (readonly, nonatomic) DDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID

--- a/Documentation/CustomLoggers.md
+++ b/Documentation/CustomLoggers.md
@@ -128,7 +128,7 @@ The DDLogMessage object encapsulates the information about a log message. It is 
 @property (readonly, nonatomic) NSString *fileName;
 @property (readonly, nonatomic) NSString *function;
 @property (readonly, nonatomic) NSUInteger line;
-@property (readonly, nonatomic) id tag;
+@property (readonly, nonatomic) id representedObject;
 @property (readonly, nonatomic) DDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID

--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ DDLogInfo(@"Info");
 DDLogWarn(@"Warn");
 DDLogError(@"Error");
 ```
+#### Objective-C ARC Semantic Issue
 
+When integrating Lumberjack into an existing Objective-C it is possible to run into `Multiple methods named 'tag' found with mismatched result, parameter type or attributes` build error.
+
+Add `#define DD_LEGACY_MESSAGE_TAG 0` before importing CocoaLumberjack or add `#define DD_LEGACY_MESSAGE_TAG 0` or add `-DDD_LEGACY_MESSAGE_TAG=0` to *Other C Flags*/*OTHER_CFLAGS* in your Xcode project.
 
 ### [swift-log](https://github.com/apple/swift-log) backend
 

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1044,7 +1044,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
         _function = copyFunction ? [function copy] : function;
 
         _line         = line;
-        _tag          = tag;
+        _representedObject = tag;
         _options      = options;
         _timestamp    = timestamp ?: [NSDate new];
 
@@ -1086,7 +1086,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
         && [otherMsg->_fileName isEqualToString:_fileName]
         && [otherMsg->_function isEqualToString:_function]
         && otherMsg->_line == _line
-        && (([otherMsg->_tag respondsToSelector:@selector(isEqual:)] && [otherMsg->_tag isEqual:_tag]) || otherMsg->_tag == _tag)
+        && (([otherMsg->_representedObject respondsToSelector:@selector(isEqual:)] && [otherMsg->_representedObject isEqual:_representedObject]) || otherMsg->_representedObject == _representedObject)
         && otherMsg->_options == _options
         && [otherMsg->_timestamp isEqualToDate:_timestamp]
         && [otherMsg->_threadID isEqualToString:_threadID] // If the thread ID is the same, the name will likely be the same as well.
@@ -1105,7 +1105,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     ^ _fileName.hash
     ^ _function.hash
     ^ _line
-    ^ ([_tag respondsToSelector:@selector(hash)] ? [_tag hash] : 0)
+    ^ ([_representedObject respondsToSelector:@selector(hash)] ? [_representedObject hash] : 0)
     ^ _options
     ^ _timestamp.hash
     ^ _threadID.hash
@@ -1124,7 +1124,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     newMessage->_fileName = _fileName;
     newMessage->_function = _function;
     newMessage->_line = _line;
-    newMessage->_tag = _tag;
+    newMessage->_representedObject = _representedObject;
     newMessage->_options = _options;
     newMessage->_timestamp = _timestamp;
     newMessage->_threadID = _threadID;
@@ -1135,14 +1135,9 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     return newMessage;
 }
 
-- (void)setRepresentedObject:(id)representedObject {
-    if (_tag != representedObject) {
-        _tag = representedObject;
-    }
-}
-
-- (id)representedObject {
-    return _tag;
+// ensure compatibility even when build with DD_LEGACY_MESSAGE_TAG to 0.
+- (id)tag {
+    return _representedObject;
 }
 
 @end

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1015,6 +1015,10 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 
 @implementation DDLogMessage
 
+// Fix @selectors name and type conflict from AppKit/UIKit (e.g. views NSInteger tag property)
+// without refactoring DDLog interal code.
+@synthesize representedObject = _tag;
+
 - (instancetype)init {
     self = [super init];
     return self;

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1015,10 +1015,6 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 
 @implementation DDLogMessage
 
-// Fix @selectors name and type conflict from AppKit/UIKit (e.g. views NSInteger tag property)
-// without refactoring DDLog interal code.
-@synthesize representedObject = _tag;
-
 - (instancetype)init {
     self = [super init];
     return self;
@@ -1137,6 +1133,16 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     newMessage->_qos = _qos;
 
     return newMessage;
+}
+
+- (void)setRepresentedObject:(id)representedObject {
+    if (_tag != representedObject) {
+        _tag = representedObject;
+    }
+}
+
+- (id)representedObject {
+    return _tag;
 }
 
 @end

--- a/Sources/CocoaLumberjack/DDTTYLogger.m
+++ b/Sources/CocoaLumberjack/DDTTYLogger.m
@@ -1184,8 +1184,8 @@ static DDTTYLogger *sharedInstance;
         DDTTYLoggerColorProfile *colorProfile = nil;
 
         if (_colorsEnabled) {
-            if (logMessage->_tag) {
-                colorProfile = _colorProfilesDict[logMessage->_tag];
+            if (logMessage->_representedObject) {
+                colorProfile = _colorProfilesDict[logMessage->_representedObject];
             }
 
             if (colorProfile == nil) {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -845,7 +845,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
 @property (readonly, nonatomic) NSString *fileName;
 @property (readonly, nonatomic, nullable) NSString * function;
 @property (readonly, nonatomic) NSUInteger line;
-@property (readonly, nonatomic, nullable) id tag;
+@property (readonly, nonatomic, nullable) id representedObject;
 @property (readonly, nonatomic) DDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;
 @property (readonly, nonatomic) NSString *threadID; // ID as it appears in NSLog calculated from the machThreadID

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -25,6 +25,10 @@
     #import <CocoaLumberjack/DDLegacyMacros.h>
 #endif
 
+#ifndef DD_LEGACY_MESSAGE_TAG
+    #define DD_LEGACY_MESSAGE_TAG 1
+#endif
+
 // Names of loggers.
 #import <CocoaLumberjack/DDLoggerNames.h>
 
@@ -845,6 +849,9 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
 @property (readonly, nonatomic) NSString *fileName;
 @property (readonly, nonatomic, nullable) NSString * function;
 @property (readonly, nonatomic) NSUInteger line;
+#if DD_LEGACY_MESSAGE_TAG
+@property (readonly, nonatomic, nullable) id tag __attribute__((deprecated("Use representedObject instead", "representedObject")));
+#endif
 @property (readonly, nonatomic, nullable) id representedObject;
 @property (readonly, nonatomic) DDLogMessageOptions options;
 @property (readonly, nonatomic) NSDate *timestamp;

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -782,7 +782,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSString *_fileName;
     NSString *_function;
     NSUInteger _line;
-    id _tag;
+    id _representedObject;
     DDLogMessageOptions _options;
     NSDate * _timestamp;
     NSString *_threadID;

--- a/Tests/CocoaLumberjackTests/DDLogMessageTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogMessageTests.m
@@ -136,7 +136,7 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.file, @"DDLogMessageTests.m");
     XCTAssertEqualObjects(self.message.function, @"testInitSetsAllPassedParameters");
     XCTAssertEqual(self.message.line, 50);
-    XCTAssertEqualObjects(self.message.tag, NULL);
+    XCTAssertEqualObjects(self.message.representedObject, NULL);
     XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
     XCTAssertEqualObjects(self.message.timestamp, referenceDate);
 }
@@ -221,7 +221,7 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.fileName, copy.fileName);
     XCTAssertEqualObjects(self.message.function, copy.function);
     XCTAssertEqual(self.message.line, copy.line);
-    XCTAssertEqualObjects(self.message.tag, copy.tag);
+    XCTAssertEqualObjects(self.message.representedObject, copy.representedObject);
     XCTAssertEqual(self.message.options, copy.options);
     XCTAssertEqualObjects(self.message.timestamp, copy.timestamp);
     XCTAssertEqualObjects(self.message.threadID, copy.threadID);

--- a/Tests/CocoaLumberjackTests/DDLogMessageTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogMessageTests.m
@@ -137,7 +137,10 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.function, @"testInitSetsAllPassedParameters");
     XCTAssertEqual(self.message.line, 50);
     XCTAssertEqualObjects(self.message.representedObject, NULL);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqualObjects(self.message.tag, NULL);
+#pragma clang diagnostic pop
     XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
     XCTAssertEqualObjects(self.message.timestamp, referenceDate);
 }
@@ -223,7 +226,10 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.function, copy.function);
     XCTAssertEqual(self.message.line, copy.line);
     XCTAssertEqualObjects(self.message.representedObject, copy.representedObject);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqualObjects(self.message.tag, copy.tag);
+#pragma clang diagnostic pop
     XCTAssertEqual(self.message.options, copy.options);
     XCTAssertEqualObjects(self.message.timestamp, copy.timestamp);
     XCTAssertEqualObjects(self.message.threadID, copy.threadID);

--- a/Tests/CocoaLumberjackTests/DDLogMessageTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogMessageTests.m
@@ -137,6 +137,7 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.function, @"testInitSetsAllPassedParameters");
     XCTAssertEqual(self.message.line, 50);
     XCTAssertEqualObjects(self.message.representedObject, NULL);
+    XCTAssertEqualObjects(self.message.tag, NULL);
     XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
     XCTAssertEqualObjects(self.message.timestamp, referenceDate);
 }
@@ -222,6 +223,7 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.function, copy.function);
     XCTAssertEqual(self.message.line, copy.line);
     XCTAssertEqualObjects(self.message.representedObject, copy.representedObject);
+    XCTAssertEqualObjects(self.message.tag, copy.tag);
     XCTAssertEqual(self.message.options, copy.options);
     XCTAssertEqualObjects(self.message.timestamp, copy.timestamp);
     XCTAssertEqualObjects(self.message.threadID, copy.threadID);

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -55,6 +55,13 @@
 			remoteGlobalIDString = 19FF460F1B8B4D1400B43179;
 			remoteInfo = CocoaLumberjackSwift;
 		};
+		D1CBDE5C2549A686001F63F7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0A7D8FC7217A1E9000B496D7 /* Lumberjack.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 19FF46011B8B4CF400B43179;
+			remoteInfo = CocoaLumberjack;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -201,6 +208,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D1CBDE5D2549A686001F63F7 /* PBXTargetDependency */,
 			);
 			name = "OS X Tests";
 			productName = "OS X Tests";
@@ -382,6 +390,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		D1CBDE5D2549A686001F63F7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CocoaLumberjack;
+			targetProxy = D1CBDE5C2549A686001F63F7 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		432B532A1AAE40EB00843E69 /* Debug */ = {


### PR DESCRIPTION
### New Pull Request Checklist

* [X] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [X] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [X] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [X] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [X] I have updated the documentation (if necessary)
* [X] I have run the tests and they pass
* [X] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Fix for issue #532 

> this is a simple issue where CocoaLumberjack has a property whose name and type conflicts with the name and type used throughout AppKit and UIKit. 

I agree with @akac, and given that DDLogMessage is an internal class, the rename of the property should not cause any conflicts.

While there may be no real convention on how to use tag, the fact remains that CocoaLumberjack is breaking a lot of very common code of the cocoa target-action pattern.

And I strongly think that CocoaLumberjack should acknowledge this pattern usage and just rename the
property. This way it would be easier to integrated into large existing code bases.

Cheers,
Christopher