### PR TITLE
Fix BAD_ACCESS when using the stack in TTYLogger #trivial

### DIFF
--- a/Sources/CocoaLumberjack/DDTTYLogger.m
+++ b/Sources/CocoaLumberjack/DDTTYLogger.m
@@ -1220,8 +1220,7 @@ static DDTTYLogger *sharedInstance;
 
         char *msg;
         if (useStack) {
-            char msgStack[msgLen + 1];
-            msg = msgStack;
+            msg = (char *)alloca(msgLen + 1);
         } else {
             msg = (char *)calloc(msgLen + 1, sizeof(char));
         }
@@ -1264,7 +1263,7 @@ static DDTTYLogger *sharedInstance;
                 v[iovec_len - 1].iov_len = 0;
             }
 
-            v[2].iov_base = (char *)msg;
+            v[2].iov_base = msg;
             v[2].iov_len = msgLen;
 
             if (iovec_len == 5) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1178 

### Pull Request Description

In #1178 I've moved the stack allocation inside an `if` scope. Unfortunately, ObjC clears the stack allocation when the variable goes out of *scope* (vs. when the function/method returns). Thus I've now changed the allocation to `alloca`.

(Thanks @sushichop, for the quick review! Sorry that the PR wasn't "ready")