### PR TITLE
Use setter to replace kvo for filelogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Public
 
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
+- Using setter to replace kvo for `NSFileLogger` (#1180)
 - _TBD_
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
@@ -14,7 +15,6 @@
 - Add backend for swift-log (#1164)
 - Specify CocoaPods version to ensure `swift_version` attribute works (#1167)
 - Simplify `DDLogFileManager` callbacks for archived log files (#1166)
-- Use setter to replace kvo for filelogger (#1180)
 
 ## [3.6.2 - Xcode 11.6 on July 31st, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Add backend for swift-log (#1164)
 - Specify CocoaPods version to ensure `swift_version` attribute works (#1167)
 - Simplify `DDLogFileManager` callbacks for archived log files (#1166)
+- Use setter to replace kvo for filelogger (#1180)
 
 ## [3.6.2 - Xcode 11.6 on July 31st, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -116,7 +116,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 
 #endif
 
-- (void)_deleteOldLogFiles {
+- (void)deleteOldFilesForConfigurationChange {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         @autoreleasepool {
             // See method header for queue reasoning.
@@ -129,7 +129,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     if (_logFilesDiskQuota != logFilesDiskQuota) {
         _logFilesDiskQuota = logFilesDiskQuota;
         NSLogInfo(@"DDFileLogManagerDefault: Responding to configuration change: logFilesDiskQuota");
-        [self _deleteOldLogFiles];
+        [self deleteOldFilesForConfigurationChange];
     }
 }
 
@@ -137,10 +137,9 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     if (_maximumNumberOfLogFiles != maximumNumberOfLogFiles) {
         _maximumNumberOfLogFiles = maximumNumberOfLogFiles;
         NSLogInfo(@"DDFileLogManagerDefault: Responding to configuration change: maximumNumberOfLogFiles");
-        [self _deleteOldLogFiles];
+        [self deleteOldFilesForConfigurationChange];
     }
 }
-
 
 #if TARGET_OS_IPHONE
 - (NSFileProtectionType)logFileProtection {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ... #463 

### Pull Request Description

`maximumNumberOfLogFiles` & `logFilesDiskQuota` of `DDLogFileManagerDefault` is not KVO, they are disabled intentionally.

 So it's a bug for user to reset `maximumNumberOfLogFiles` & `logFilesDiskQuota`. 

With KVO crash, I think `setter` is more better!


