### PR TITLE
Using new API for `NSFileHandle` to show more infos when has error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Public
 
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
+- Using new API for `NSFileHandle` to show more infos when has error.(#1181)
 - _TBD_
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -977,6 +977,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
             BOOL succeed = [_currentLogFileHandle getOffset:&fileSize error:&error];
             if (!succeed) {
                 NSLogError(@"DDFileLogger: Failed to get offset: %@", error);
+                return;
             }
         } else {
             fileSize = [_currentLogFileHandle offsetInFile];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Some api in `NSFileHandle`  will be **DEPRECATED** , So It's time to update with new api.

