### PR TITLE
Remove meaningless judgments in `DDFileLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Public
 
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
+- Remove meaningless judgments in `DDFileLogger` (#1182)
 - _TBD_
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -964,9 +964,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 - (BOOL)lt_shouldLogFileBeArchived:(DDLogFileInfo *)mostRecentLogFileInfo {
     NSAssert([self isOnInternalLoggerQueue], @"lt_ methods should be on logger queue.");
 
-    if (mostRecentLogFileInfo.isArchived) {
-        return NO;
-    } else if ([self shouldArchiveRecentLogFileInfo:mostRecentLogFileInfo]) {
+    if ([self shouldArchiveRecentLogFileInfo:mostRecentLogFileInfo]) {
         return YES;
     } else if (_maximumFileSize > 0 && mostRecentLogFileInfo.fileSize >= _maximumFileSize) {
         return YES;
@@ -984,7 +982,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     // If previous log was created when app wasn't running in background, but now it is - we archive it and create
     // a new one.
     //
-    // If user has overwritten to NSFileProtectionNone there is no neeed to create a new one.
+    // If user has overwritten to NSFileProtectionNone there is no need to create a new one.
     if (doesAppRunInBackground()) {
         NSFileProtectionType key = mostRecentLogFileInfo.fileAttributes[NSFileProtectionKey];
         BOOL isUntilFirstAuth = [key isEqualToString:NSFileProtectionCompleteUntilFirstUserAuthentication];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
[https://github.com/CocoaLumberjack/CocoaLumberjack/pull/1042/files#diff-c8a9bcf29dc1c5256c046b115400ea8ac3327f7200552637f62f8a49ae6f4109R1039](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/1042/files#diff-c8a9bcf29dc1c5256c046b115400ea8ac3327f7200552637f62f8a49ae6f4109R1039) 

This refactor had check if the log file is archived. Just return NO to create new log file. So in `lt_shouldLogFileBeArchived` method to check archived is meaningless. 

I guess the refactoring forgot to delete this judgment.

In other words, If the file has been archived, it's need to create new log file. this place should also return `YES` instead of `NO`.