### PR TITLE
Add an assertion to avoid potential deadlock issues for `flushLog`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Using setter to replace kvo for `NSFileLogger` (#1180)
 - Remove unnecessary checks in `DDFileLogger` (#1182)
+- Add an assertion to avoid potential deadlock issues for `flushLog` (#1183)
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
 

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -521,6 +521,9 @@ static NSUInteger _numProcessors;
 }
 
 - (void)flushLog {
+    NSAssert(!dispatch_get_specific(GlobalLoggingQueueIdentityKey),
+             @"This method shouldn't be run on the logging thread/queue that make flush fast enough");
+    
     dispatch_sync(_loggingQueue, ^{ @autoreleasepool {
         [self lt_flush];
     } });


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

The `loggerQueue` is public, once the user call `flushLog` in the `loggerQueue`, deadlock will occur.

...

