### PR TITLE
Flush data when app enter background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Use new API for `NSFileHandle` on supported platforms (#1181)
 - Remove unnecessary checks in `DDFileLogger` (#1182)
 - Add an assertion to avoid potential deadlock issues for `flushLog` (#1183)
-- Flush data when app enter background (#1184)
+- Flush data when app enter background (#1186)
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Use new API for `NSFileHandle` on supported platforms (#1181)
 - Remove unnecessary checks in `DDFileLogger` (#1182)
 - Add an assertion to avoid potential deadlock issues for `flushLog` (#1183)
+- Flush data when app enter background (#1184)
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
 


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1185 

### Pull Request Description

There is a risk in flushing data when the app is about to be terminated. 

`DDFileLogger+Buffering` should not rely heavily on flushing when the app is about to be terminated. Once the `applicationwillterminate:` method is not called, the log data had lost.  
I think we should flush data in background as soon as possible instead of app terminated. 

Because the background mechanism of AppKit and UIKit are different, we can not care about the background of AppKit.


