### PR TITLE
Add per-message synchronous logging control for DDLogHandler

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,3 +8,6 @@ opt_in_rules:
 
 nesting:
   type_level: 4
+
+identifier_name:
+  allowed_symbols: "_"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,4 +11,3 @@ nesting:
 
 identifier_name:
   allowed_symbols: "_"
-  validates_start_with_lowercase: false

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,3 +11,4 @@ nesting:
 
 identifier_name:
   allowed_symbols: "_"
+  validates_start_with_lowercase: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Public
 
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
+- Add per-message synchronous logging control for messages logged via SwiftLog using `DDLogHandler` (#1209)
 
 ### Internal
 

--- a/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
+++ b/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
@@ -170,7 +170,7 @@ public struct DDLogHandler: LogHandler {
     ///   - metadata: The metadata associated with the message.
     /// - Returns: Whether to log the message asynchronous.
     @usableFromInline
-    func _logAsync(level: Logger.Level, metadata: Logger.Metadata?) -> Bool {
+    func _logAsync(level: Logger.Level, metadata: Logger.Metadata?) -> Bool { // swiftlint:disable:this identifier_name
         if level >= config.syncLogging.tresholdLevel {
             // Easiest check -> level is above treshold. Not async.
             return false


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: n/a

### Pull Request Description

With CocoaLumberjack and CocoaLumberjackSwift it's possible to control synchronous/asynchronous logging on a per-message basis. Our implementation of a SwiftLog backend currently couldn't do this.

With this PR it's possible to do this using a metadata-value on the message. The key for this metadata-value is configurable, but has a default of `"log-synchronous"`. Said default is accessible via `DDLogHandler.defaultSynchronousLoggingMetadataKey`.
