### PR TITLE
WIP: Add TargetConditionals Import (Xcode 12.5)

### DIFF
--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 1230;
+				LastUpgradeCheck = 1250;
 				TargetAttributes = {
 					18F3BFD61A81E06E00692297 = {
 						CreatedOnToolsVersion = 6.1.1;

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-Static.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack-Static.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjack.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
+++ b/Lumberjack.xcodeproj/xcshareddata/xcschemes/CocoaLumberjackSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1230"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/CocoaLumberjack/CLI/CLIColor.m
+++ b/Sources/CocoaLumberjack/CLI/CLIColor.m
@@ -13,6 +13,8 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
+#import <TargetConditionals.h>
+
 #if TARGET_OS_OSX
 
 #import <CocoaLumberjack/CLIColor.h>

--- a/Sources/CocoaLumberjack/DDASLLogCapture.m
+++ b/Sources/CocoaLumberjack/DDASLLogCapture.m
@@ -13,6 +13,8 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
+#import <TargetConditionals.h>
+
 #if !TARGET_OS_WATCH
 
 #include <asl.h>

--- a/Sources/CocoaLumberjack/DDASLLogger.m
+++ b/Sources/CocoaLumberjack/DDASLLogger.m
@@ -13,6 +13,8 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
+#import <TargetConditionals.h>
+
 #if !TARGET_OS_WATCH
 
 #if !__has_feature(objc_arc)

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/CLIColor.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/CLIColor.h
@@ -13,6 +13,8 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
+#import <TargetConditionals.h>
+
 #if TARGET_OS_OSX
 
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
  * There's one failing test, but it's red on `master`/Xcode 12.4 as well...?
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1208 

### Pull Request Description

As discussed in #1208, this PR adds the 
```objc
#import <TargetConditionals.h>
```
statements required for Xcode 12.5 Beta 1 to compile the SPM package.

Since this is an early beta and the [release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-beta-release-notes/) don't mention any change here, there's a possibility that the original problem of #1208 will disappear by itself, so please don't merge this PR yet.