### PR TITLE
Prepare Release 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
-## [3.7.1 - Xcode 12 on ???, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
+## [3.7.2 - Xcode 12.? on ??, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.2)
+
+### Public
+
+- _REPLACE ME_
+
+### Internal
+
+- _REPLACE ME_
+
+
+## [3.7.1 - Xcode 12.5 on Mar 5th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.1)
 
 ### Public
 
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
 - Add per-message synchronous logging control for messages logged via SwiftLog using `DDLogHandler` (#1209)
 - Prevent logging an error when archiving an already deleted file (#1212)
+- Add TargetConditionals import for Xcode 12.5 (#1210)
 
 ### Internal
 
@@ -12,6 +24,7 @@
 - Use new API for `NSFileHandle` on supported platforms (#1181)
 - Remove unnecessary checks in `DDFileLogger` (#1182)
 - Add an assertion to avoid potential deadlock issues for `flushLog` (#1183)
+
 
 ## [3.7.0 - Xcode 12 on Oct 2nd, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.0)
 
@@ -23,6 +36,7 @@
 - Specify CocoaPods version to ensure `swift_version` attribute works (#1167)
 - Simplify `DDLogFileManager` callbacks for archived log files (#1166)
 
+
 ## [3.6.2 - Xcode 11.6 on July 31st, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.2)
 
 ### Public
@@ -33,6 +47,7 @@
 
 ### Repository
 - Switch from Travis to GitHub Actions (#1135, #1140, #1150, #1152)
+
 
 ## [3.6.1 - Xcode 11.3.1 on Jan 25th, 2020](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.1)
 
@@ -48,6 +63,7 @@
 - Fix NSDateFormatter thread safety (#1121)
 - Fix -lt_dataForMessage: duplicated code (#1122)
 
+
 ## [3.6.0 - Xcode 11 on October 2nd, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.6.0)
 
 ### Public
@@ -57,6 +73,7 @@
 ### Internal
 - Fix issue with log archiving in the simulator (#1098)
 - Limit assertion to non-simulator build (#1100)
+
 
 ## [3.5.3 - Xcode 10.2 on Apr 24th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.3)
 
@@ -72,6 +89,7 @@
 - Add CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER & fix warnings (#1059)
 - Use LLONG_MAX instead of LONG_LONG_MAX (#1062)
 
+
 ## [3.5.2 - Xcode 10.1 on Mar 15th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.2)
 
 ### Public
@@ -84,10 +102,12 @@
 - Sync internal queues to prevent cleaning up log files too soon in tests (#1053)
 - DDLog checks for NULL values and for global queue dispatching has been added (#1045)
 
+
 ## [3.5.1 - Xcode 10 on Feb 4th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.1)
 
 ### Public
 - Fix high CPU usage because of empty fileAttributes and / or too high rollingFrequceny (#1028)
+
 
 ## [3.5.0 - Xcode 10 on Jan 25th, 2019](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.5.0)
 
@@ -123,6 +143,7 @@
 - Xcode (schemes) version bumps #938
 - Update demo and documentation about CustomLogLevels #1023
 
+
 ## [3.4.2 - Xcode 9.3 on Apr 17th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.2)
 - Update README.md #912
 - Fixed typo in pull request template #913
@@ -132,18 +153,22 @@
 - Add extern "C" for Objective-C++ #922
 - Add `flush` method to the `DDFileLogger` #928
 
+
 ## [3.4.1 - Xcode 9.1 on Jan 26th, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.1)
 - Fix `DDLogFileManagerDefault` `-isLogFile` #909
 - Fix locking the main thread #911
+
 
 ## [3.4.0 - Xcode 9.1 on Jan 3rd, 2018](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.4.0)
 - Fix Travis CI #895
 - Fix typos #896
 - Fix schemes and link errors #897 #899 #903 #907
 
+
 ## [3.3.0 - Xcode 9 on Oct 3rd, 2017](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.3.0)
 - Xcode 9 support and Swift 4 support #890 #893
 - Replace `OSSpinLock` with `pthread_mutex` #889
+
 
 ## [3.2.1 - Xcode 9 beta on Aug 21st, 2017](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.2.1)
 - Xcode 9 beta support #874 #873 #884 #883 #882
@@ -151,6 +176,7 @@
 - update 'Use Log Level per Logger' doc #888
 - Remove empty asset catalogs so that they don't show up in Open Quickly #877
 - Fixed typo in pull request template #880
+
 
 ## [3.2.0 - Swift 3.0.0, Xcode 8.3 on May 3rd, 2017](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.2.0)
 - Xcode 8.3 support #860 #853 
@@ -162,6 +188,7 @@
 - Fixed nullability of `DDLogMessage.function` #849 `DDExtractFileNameWithoutExtension` #845 
 - Ignore `Carthage/Build` directory #862 
 - Updated schemes #859 #857
+
 
 ## [3.1.0 - Swift 3.0.1, Xcode 8.1 on Feb 22nd, 2017](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.1.0)
 - Swift 3.0.1 and Xcode 8.1 support via #816
@@ -185,8 +212,10 @@
 - Fix Travis CI build #807
 - Updated docs #798 #808 #811 #810 #820
 
+
 ## [3.0.0 - Swift 3.0, Xcode 8 on Sep 21st, 2016](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.0.0)
 - Swift 3.0 and Xcode 8 support via #769, fixes #771 and #772. Many thanks to @ffried @max-potapov @chrisdoc @BarakRL @devxoul and the others who contributed
+
 
 ## [2.4.0 - Swift 2.3 on Sep 19th, 2016](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.4.0)
 - Swift 2.3 explicit so that the project compiles on Xcode 8 - #747 #773 fix #762 #763 #766
@@ -196,6 +225,7 @@
 - updated doc: #727 a9f54c9 #741, diagrams in 8bd128d
 - Added CONTRIBUTING, ISSUE and PULL_REQUEST TEMPLATE and added a small Communication section to the Readme
 - Fixed an issue with one demo #760
+
 
 ## [2.3.0 - Swift 2.2, Xcode7.3 on May 2nd, 2016](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.3.0)
 - Updated to Swift 2.2 - #704 
@@ -211,26 +241,32 @@
 - fixed typo in import - #693 
 - updated the docs - #646 #650 #656 #655 #661 #664 #667 #684 #724 
 
+
 ## [2.2.0 - TVOS, Xcode7.1 on Oct 28th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.2.0)
 - added `tvOS` support (thanks [@sinoru](https://github.com/sinoru)) - [#634](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/634) [#640](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/640) [#630](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/630) [#628](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/628) [#618](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/618) [#611](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/611)
 - Remove `(escaping)` from the Swift `@autoclosure` parameters - [#642](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/642)
 
+
 ## [2.1.0 - Swift 2.0, WatchOS, Xcode7 on Oct 23rd, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.1.0)
 - Fixed the version for the Carthage builds - see [#633](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/633)
 - Improved documentation
+
 
 ## [2.1.0 RC - Swift 2.0, WatchOS, Xcode7 on Oct 22nd, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.1.0-rc)
 - Refactored the `NSDateFormatter` related code to fix a bunch of issues: [#621](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/621)
 - Fix Issue [#488](https://github.com/CocoaLumberjack/CocoaLumberjack/issues/488): Support `DDLog` without `AppKit Dependency` (`#define DD_CLI`): [#627](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/627)
 - Re-add `NS_DESIGNATED_INITIALIZER` [#619](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/619)
 
+
 ## [2.1.0 Beta - Swift 2.0, WatchOS, Xcode7 on Oct 12th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.1.0-beta)
 - Updated the library to use Swift 2.0 and Xcode 7 [#617](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/617) [#545](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/545) [#534](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/534)
 - WatchOS support (2.0) [#583](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/583) [#581](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/581) [#579](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/579) 
 
+
 ## [2.0.3 Patch for 2.0.0 on Oct 13th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.3)
 
 - Compatibility with Xcode 6 that was broken by the 2.0.2 patch - [f042fd3](https://github.com/CocoaLumberjack/CocoaLumberjack/commit/f042fd3)
+
 
 ## [2.0.2 Patch for 2.0.0 on Oct 12th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.2)
 
@@ -258,6 +294,7 @@
 - Updated `GettingStarted.md` to include `ddLogLevel` [#602](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/602) 
 - Remove redundant check for `processorCount` availability [#604](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/604) 
 
+
 ## [2.0.1 Patch for 2.0.0 on Jun 25th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.1)
 
 - **Carthage support** [#521](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/521) [#526](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/526) 
@@ -277,6 +314,7 @@
 - Change code samples to use `DDLogFlagWarning` [#520](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/520) 
 - Fix seemingly obvious typo in the `toLogLevel` function [#508](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/508) 
 
+
 ## [CocoaLumberjack 2.0.0 on Mar 13th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0)
 
 The library was strongly refactored, with a few goals in mind:
@@ -286,6 +324,7 @@ The library was strongly refactored, with a few goals in mind:
 - better coding style
 
 See [Migration from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack#migrating-to-2x)
+
 
 ## [2.0.0-rc2 on Feb 20th, 2015](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-rc2)
 
@@ -297,10 +336,12 @@ See [Migration from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberja
 - Legacy checks updated - [#424](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/424) 
 - Documentation updates
 
+
 ## [2.0.0-rc on Dec 11th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-rc)
 
 - Fix `dispatch_queue_t` properties.
 - Fix `registeredClasses` crashes at launch.
+
 
 ## [2.0.0-beta4 on Nov 7th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-beta4)
 
@@ -309,6 +350,7 @@ See [Migration from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberja
 - Preliminary Swift support through `CocoaLumberjack.swift`.
 - Automatic 1.9.x legacy support when `DDLog.h` is imported instead of the new `CocoaLumberjack.h`.
 
+
 ## [2.0.0-beta3 on Oct 21st, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-beta3)
 
 - Modernize flag variables to be `NS_OPTIONS`/`NS_ENUM`.
@@ -316,15 +358,18 @@ See [Migration from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberja
 - Fix warning when compiled with assertions blocked.
 - Crash fixes.
 
+
 ## [2.0.0-beta2 on Sep 30th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-beta2)
 
 - Cleanup code.
 - Match `NSLog` read UID functionality in `DDASLLogger`.
 - Update framework and static libraries.
 
+
 ## [2.0.0 Beta on Aug 12th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/2.0.0-beta)
 
 See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack#migrating-to-2x)
+
 
 ## [1.9.2 Updated patch release for 1.9.0 on Aug 11th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.9.2)
 
@@ -337,6 +382,7 @@ See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack
 - Fixed `CompressingLogFileManager` compression bug - [#315](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/315)
 - Remove unnecessary `NULL` check before `free()` - [#316](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/316) 
 
+
 ## [1.9.1 Patch release for 1.9.0 on Jun 30th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.9.1)
 
 - Fixed issues in rolling frequency - [#243](https://github.com/CocoaLumberjack/CocoaLumberjack/issues/243) [#295](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/295) [@georgekola](https://github.com/georgekola)
@@ -344,6 +390,7 @@ See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack
 - Performance optimisation: use compiler macros to skip iOS version checks - [4656d3b](https://github.com/CocoaLumberjack/CocoaLumberjack/commit/4656d3b) [#298](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/298) [#291](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/291) [@robbiehanson](https://github.com/robbiehanson) [@liviur](https://github.com/liviur)
 - Changed the `Build Active Architecture Only` to `NO` [#294](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/294) [#293](https://github.com/CocoaLumberjack/CocoaLumberjack/issues/293) 
 - Optimisation by reusing `NSDateFormatter` instances [#296](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/296) [#301](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/301) 
+
 
 ## [1.9.0 New ASL capture module, several File logger fixes on May 23rd, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.9.0)
 
@@ -372,6 +419,7 @@ See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack
 - `DDTTYLogger`: Favour XcodeColors environment variable [#237](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/237) 
 - `DDLog`: calling `atexit_b` in CLI applications, that use Foundation framework [#234](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/234) 
 
+
 ## [1.8.1 AllLoggers and bugfixes on Feb 14th, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.8.1)
 
 - read access to all loggers - [#217](https://github.com/CocoaLumberjack/CocoaLumberjack/issues/217) [#219](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/219) 
@@ -380,6 +428,7 @@ See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack
 - Add a check for an archived log before overwriting - [#214](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/214) 
 - improved safety by using assertions instead of comments (`DDLog` in the core) - [#221](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/221) 
 - added Lumberjack logo :)
+
 
 ## [1.8.0 Better CL support, custom logfile name format, bugfixes on Jan 21st, 2014](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.8.0)
 
@@ -392,14 +441,17 @@ See [Migrate from 1.x to 2.x](https://github.com/CocoaLumberjack/CocoaLumberjack
 - `DDFileLogger`: fixed comment - [#199](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/199) 
 - Fix Travis - [#205](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/205) 
 
+
 ## [1.7.0 New log file naming convention and CocoaLumberjack organisation on Dec 10th, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.7.0)
 
 - new log file naming convention - [#191](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/191)
 - completed transition to **CocoaLumberjack** organisation - [#188](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/188)
 
+
 ## [1.6.5.1 Patch release for Xcode 4.4+ compatibility on Dec 4th, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.6.5.1)
 
 - fixed compatibility with Xcode 4.4+ [#187](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/187)
+
 
 ## [1.6.5 File Logger refactoring, Multi Formatter, preffixed extension classes on Dec 3rd, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.6.5)
 
@@ -420,12 +472,14 @@ Other:
 - Included `DDLog+LOGV.h` in Cocoapods sources [d253bd7](https://github.com/CocoaLumberjack/CocoaLumberjack/commit/d253bd7)
 - other fixes/improvements
 
+
 ## [1.6.4 Fix compatibility with 3rd party frameworks on Nov 21st, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.6.4)
 
 * "Fix" conflicts with 3rd party libraries using `CocoaLumberjack` [#172](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/172) 
 * Ignore deprecated warning for `dispatch_get_current_queue` [#167](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/167) 
 * Add new `DEBUG` log level support to included loggers [#166](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/166) 
 * Method declarations that make it easier to extend/modify `DispatchQueueLogFormatter` [#164](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/164) 
+
 
 ## [1.6.3 New macros, updated podspec and bug fixes on Apr 2nd, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.6.3)
 
@@ -451,6 +505,7 @@ Other:
 * Fixing colors in greyscale color-space not working [d019cfd](https://github.com/CocoaLumberjack/CocoaLumberjack/commit/d019cfd)
 * Guard around `dispatch_resume()` being called with null pointer [#107](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/107) 
 * `NULL` safety checks [#107](https://github.com/CocoaLumberjack/CocoaLumberjack/pull/107)
+
 
 ## [1.6.2 on Apr 2nd, 2013](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/1.6.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - _REPLACE ME_
 
 
-## [3.7.1 - Xcode 12.5 on Mar 5th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.1)
+## [3.7.1 - Xcode 12.4 on Apr 7th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.1)
 
 ### Public
 

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name     = 'CocoaLumberjack'
-  s.version  = '3.7.0'
+  s.version  = '3.7.1'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -200,7 +200,7 @@ LIBRARY_SEARCH_PATHS = $(inherited)
 // Code will load on this and later versions of macOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
 MACOSX_DEPLOYMENT_TARGET = 10.10
 
-MARKETING_VERSION = 3.7.0
+MARKETING_VERSION = 3.7.1
 
 OTHER_C_FLAGS = -Wextra
 


### PR DESCRIPTION
This prepares the release 3.7.1.

~Currently depends on #1216 (and contains the same changes, thus not worth a review until #1216 is merged)~