### PR TITLE
Adding `DDAssertionFailure` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Deprecate `tag` property of `DDLogMessage`, use `representedObject` instead. (#1177, #532)
 - Add per-message synchronous logging control for messages logged via SwiftLog using `DDLogHandler` (#1209)
 - Prevent logging an error when archiving an already deleted file (#1212)
+- Add `DDAssertionFailure` macro for Objective-C (#1220)
 
 ### Internal
 

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAssertMacros.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAssertMacros.h
@@ -23,3 +23,8 @@
             NSAssert(NO, @"%@", description);                                         \
         }
 #define DDAssertCondition(condition) DDAssert(condition, @"Condition not satisfied: %s", #condition)
+
+/**
+ * Analog to `DDAssertionFailure` from DDAssert.swift for use in Objective C
+ */
+#define DDAssertionFailure(frmt, ...) DDAssert(NO, frmt, ##__VA_ARGS__)


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [-] I have added the required tests to prove the fix/feature I am adding
* [-] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
```
Test Suite 'All tests' passed at 2021-04-01 16:53:54.808.
	 Executed 62 tests, with 0 failures (0 unexpected) in 4.352 (4.356) seconds
```
* [x] I have run the lint and it passes (`pod lib lint`)
```
Moorea:CocoaLumberjack levi$ pod lib lint

 -> CocoaLumberjack (3.7.0)
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Using new build system
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Building targets in parallel
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Using codesigning identity override: -
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Planning build
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Constructing build description
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file and one is not being generated automatically. (in target 'App' from project 'App')
    - NOTE  | [CocoaLumberjack/Core,CocoaLumberjack/Swift] xcodebuild:  note: Using codesigning identity override: 

CocoaLumberjack passed validation.
```

This merge request fixes / refers to the following issues: N/A

### Pull Request Description

Adds `DDAssertionFailure` macro for use in Objective C codebases.

