### PR TITLE
Re-introduce _tag field and deprecate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.7.2 - Xcode 12.? on ??, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.2)
+## [3.7.3 - Xcode 12.? on ??, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.3)
 
 ### Public
 
@@ -7,6 +7,13 @@
 ### Internal
 
 - _REPLACE ME_
+
+
+## [3.7.2 - Xcode 12.4 on Apr 9th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.2)
+
+### Public
+
+- Re-introduce (and deprecate) `_tag` field to fix breakage in 3.7.1 (#1224)
 
 
 ## [3.7.1 - Xcode 12.4 on Apr 7th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.1)

--- a/CocoaLumberjack.podspec
+++ b/CocoaLumberjack.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name     = 'CocoaLumberjack'
-  s.version  = '3.7.1'
+  s.version  = '3.7.2'
   s.license  = 'BSD'
   s.summary  = 'A fast & simple, yet powerful & flexible logging framework for macOS, iOS, tvOS and watchOS.'
   s.homepage = 'https://github.com/CocoaLumberjack/CocoaLumberjack'

--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -200,7 +200,7 @@ LIBRARY_SEARCH_PATHS = $(inherited)
 // Code will load on this and later versions of macOS. Framework APIs that are unavailable in earlier versions will be weak-linked; your code should check for null function pointers or specific system versions before calling newer APIs.
 MACOSX_DEPLOYMENT_TARGET = 10.10
 
-MARKETING_VERSION = 3.7.1
+MARKETING_VERSION = 3.7.2
 
 OTHER_C_FLAGS = -Wextra
 

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -999,6 +999,12 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 
         _line         = line;
         _representedObject = tag;
+#if DD_LEGACY_MESSAGE_TAG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+        _tag = tag;
+#pragma clang diagnostic pop
+#endif
         _options      = options;
         _timestamp    = timestamp ?: [NSDate new];
 
@@ -1079,6 +1085,12 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     newMessage->_function = _function;
     newMessage->_line = _line;
     newMessage->_representedObject = _representedObject;
+#if DD_LEGACY_MESSAGE_TAG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    newMessage->_tag = _tag;
+#pragma clang diagnostic pop
+#endif
     newMessage->_options = _options;
     newMessage->_timestamp = _timestamp;
     newMessage->_threadID = _threadID;
@@ -1089,7 +1101,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     return newMessage;
 }
 
-// ensure compatibility even when build with DD_LEGACY_MESSAGE_TAG to 0.
+// ensure compatibility even when built with DD_LEGACY_MESSAGE_TAG to 0.
 - (id)tag {
     return _representedObject;
 }

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -782,6 +782,9 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSString *_fileName;
     NSString *_function;
     NSUInteger _line;
+    #if DD_LEGACY_MESSAGE_TAG
+    id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));;
+    #endif
     id _representedObject;
     DDLogMessageOptions _options;
     NSDate * _timestamp;


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1177 #1223 

### Pull Request Description

In #1177 the `tag` property was deprecated and superseded by `representedObject`. However, the underlying `_tag` field was removed completely instead of simply deprecated. This caused the change to become a breaking change.

This re-introduces the underlying `_tag` field and also marks it as deprecated.

