### PR TITLE
Fix: add try-catch fix System below iOS 13 synchronizeFile will raise…

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1228,14 +1228,18 @@ static int exception_count = 0;
 
 - (void)lt_flush {
     NSAssert([self isOnInternalLoggerQueue], @"flush should only be executed on internal queue.");
-    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-        __autoreleasing NSError *error;
-        BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
-        if (!succeed) {
-            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+    @try {
+        if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+            __autoreleasing NSError *error;
+            BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
+            if (!succeed) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            }
+        } else {
+            [_currentLogFileHandle synchronizeFile];
         }
-    } else {
-        [_currentLogFileHandle synchronizeFile];
+    } @catch (NSException *exception) {
+        NSLogError(@"DDFileLogger.lt_flush: %@", exception);
     }
 }
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1228,18 +1228,19 @@ static int exception_count = 0;
 
 - (void)lt_flush {
     NSAssert([self isOnInternalLoggerQueue], @"flush should only be executed on internal queue.");
-    @try {
-        if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-            __autoreleasing NSError *error;
-            BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
-            if (!succeed) {
-                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
-            }
-        } else {
-            [_currentLogFileHandle synchronizeFile];
+    
+    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+        __autoreleasing NSError *error;
+        BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
+        if (!succeed) {
+            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
         }
-    } @catch (NSException *exception) {
-        NSLogError(@"DDFileLogger.lt_flush: %@", exception);
+    } else {
+        @try {
+            [_currentLogFileHandle synchronizeFile];
+        } @catch (NSException *exception) {
+            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", exception);
+        }
     }
 }
 


### PR DESCRIPTION

### New Pull Request Checklist

*  [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)


### Pull Request Description

i has a crash when fileHandle call synchronizeFile。

`Application threw exception NSFileHandleOperationException: *** -[NSConcreteFileHandle synchronizeFile]:`

add try-catch `DDFileLogger lt_flush`

