### PR TITLE
Fix "DDFileLogger: Failed to get offset" when setting maximumFileSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Public
 
-- _REPLACE ME_
+- Fix "DDFileLogger: Failed to get offset" when setting maximumFileSize (#1234)
 
 ### Internal
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -947,15 +947,16 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 
     if (_maximumFileSize > 0) {
         unsigned long long fileSize;
+        NSFileHandle *handle = [self lt_currentLogFileHandle];
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
-            BOOL succeed = [_currentLogFileHandle getOffset:&fileSize error:&error];
+            BOOL succeed = [handle getOffset:&fileSize error:&error];
             if (!succeed) {
                 NSLogError(@"DDFileLogger: Failed to get offset: %@", error);
                 return;
             }
         } else {
-            fileSize = [_currentLogFileHandle offsetInFile];
+            fileSize = [handle offsetInFile];
         }
 
         if (fileSize >= _maximumFileSize) {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

DDFileLogger will fail to get the offset of the log file when `_currentLogFileHandle` isn't initialized, and the log error message "DDFileLogger: Failed to get offset: (null)" will appear.

This happens when the `maximumFileSize` of a DDFileLogger instance is set immediately after the instance is created, for example:
```objc
fileLogger = [[DDFileLogger alloc] init];
    
fileLogger.maximumFileSize = 1024 * 1;  //  1 KB
fileLogger.rollingFrequency = 60;       // 60 Seconds
```
The code is copied from `Demos/RollingTestMac`, and I believe this is a common usage. The issue can also be reproduced in the demo.


