### PR TITLE
Fixed false positive error reports.

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -637,7 +637,11 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
                 NSLogError(@"DDFileLogger: Failed to close file: %@", error);
             }
         } else {
-            [_currentLogFileHandle synchronizeFile];
+            @try {
+                [_currentLogFileHandle synchronizeFile];
+            } @catch (NSException *exception) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", exception);
+            }
             [_currentLogFileHandle closeFile];
         }
         _currentLogFileHandle = nil;
@@ -887,7 +891,11 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
             NSLogError(@"DDFileLogger: Failed to close file: %@", error);
         }
     } else {
-        [_currentLogFileHandle synchronizeFile];
+        @try {
+            [_currentLogFileHandle synchronizeFile];
+        } @catch (NSException *exception) {
+            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", exception);
+        }
         [_currentLogFileHandle closeFile];
     }
     _currentLogFileHandle = nil;

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -705,7 +705,9 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     dispatch_block_t block = ^{
         @autoreleasepool {
             self->_maximumFileSize = newMaximumFileSize;
-            [self lt_maybeRollLogFileDueToSize];
+            if (_currentLogFileHandle != nil || [self lt_currentLogFileHandle] != nil) {
+                [self lt_maybeRollLogFileDueToSize];
+            }
         }
     };
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -625,19 +625,22 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 - (void)lt_cleanup {
     NSAssert([self isOnInternalLoggerQueue], @"lt_ methods should be on logger queue.");
 
-    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-        __autoreleasing NSError *error;
-        BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
-        if (!synchronized) {
-            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+    if (_currentLogFileHandle != nil) {
+        if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+            __autoreleasing NSError *error;
+            BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
+            if (!synchronized) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            }
+            BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
+            if (!closed) {
+                NSLogError(@"DDFileLogger: Failed to close file: %@", error);
+            }
+        } else {
+            [_currentLogFileHandle synchronizeFile];
+            [_currentLogFileHandle closeFile];
         }
-        BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
-        if (!closed) {
-            NSLogError(@"DDFileLogger: Failed to close file: %@", error);
-        }
-    } else {
-        [_currentLogFileHandle synchronizeFile];
-        [_currentLogFileHandle closeFile];
+        _currentLogFileHandle = nil;
     }
         
     if (_currentLogFileVnode) {
@@ -945,7 +948,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     // Note: Use direct access to maximumFileSize variable.
     // We specifically wrote our own getter/setter method to allow us to do this (for performance reasons).
 
-    if (_maximumFileSize > 0) {
+    if (_currentLogFileHandle != nil && _maximumFileSize > 0) {
         unsigned long long fileSize;
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
@@ -1148,20 +1151,20 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 - (NSFileHandle *)lt_currentLogFileHandle {
     NSAssert([self isOnInternalLoggerQueue], @"lt_ methods should be on logger queue.");
 
-    if (!_currentLogFileHandle) {
+    if (_currentLogFileHandle == nil) {
         NSString *logFilePath = [[self lt_currentLogFileInfo] filePath];
         _currentLogFileHandle = [NSFileHandle fileHandleForWritingAtPath:logFilePath];
-        if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-            __autoreleasing NSError *error;
-            BOOL succeed = [_currentLogFileHandle seekToEndReturningOffset:nil error:&error];
-            if (!succeed) {
-                NSLogError(@"DDFileLogger: Failed to seek to end of file: %@", error);
+        if (_currentLogFileHandle != nil) {
+            if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+                __autoreleasing NSError *error;
+                BOOL succeed = [_currentLogFileHandle seekToEndReturningOffset:nil error:&error];
+                if (!succeed) {
+                    NSLogError(@"DDFileLogger: Failed to seek to end of file: %@", error);
+                }
+            } else {
+                [_currentLogFileHandle seekToEndOfFile];
             }
-        } else {
-            [_currentLogFileHandle seekToEndOfFile];
-        }
 
-        if (_currentLogFileHandle) {
             [self lt_scheduleTimerToRollLogFileDueToAge];
             [self lt_monitorCurrentLogFileForExternalChanges];
         }
@@ -1229,17 +1232,19 @@ static int exception_count = 0;
 - (void)lt_flush {
     NSAssert([self isOnInternalLoggerQueue], @"flush should only be executed on internal queue.");
     
-    if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
-        __autoreleasing NSError *error;
-        BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
-        if (!succeed) {
-            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
-        }
-    } else {
-        @try {
-            [_currentLogFileHandle synchronizeFile];
-        } @catch (NSException *exception) {
-            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", exception);
+    if (_currentLogFileHandle != nil) {
+        if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
+            __autoreleasing NSError *error;
+            BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
+            if (!succeed) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            }
+        } else {
+            @try {
+                [_currentLogFileHandle synchronizeFile];
+            } @catch (NSException *exception) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", exception);
+            }
         }
     }
 }

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -705,7 +705,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     dispatch_block_t block = ^{
         @autoreleasepool {
             self->_maximumFileSize = newMaximumFileSize;
-            if (_currentLogFileHandle != nil || [self lt_currentLogFileHandle] != nil) {
+            if (self->_currentLogFileHandle != nil || [self lt_currentLogFileHandle] != nil) {
                 [self lt_maybeRollLogFileDueToSize];
             }
         }


### PR DESCRIPTION
There is a problem when we call new `NSFileHandle` APIs that return errors: if the `_currentLogFileHandle` is `nil`, it will return both `FALSE` for result and `nil` for the error. This will generate false error reports with `NSLogError()`.
There is two ways for fixing this:

1. Check both result set to `FALSE` and error being not `nil` before calling `NSLogError()`.
2. Don't call the API if `_currentLogFileHandle` is `nil` at first place!

I preferred the second solution because it will save CPU cycles.

I did also not include PR #1234 on purpose because I think my solution is better. Let me explain:

1. The way it is fixed in PR #1234, breaks the comment just above that says "Keep it FAST"!
2. If `_currentLogFileHandle` is `nil` when `-lt_maybeRollLogFileDueToSize` is called, it is either because `-lt_logData:` was not called or because `-lt_currentLogFileHandle` failed. In both cases, it means that the file size was not increased and don't need to be rolled. One side effect of this is that the file will be not rolled if `maximumFileSize` is set to something lower than previous `maximumFileSize` and actual file size is greater than the `maximumFileSize` being set, but it is the way it worked before using these new `NSFileHandle` APIs.
