### PR TITLE
Follow-up to add annotations to `DDOSLogger`

### DIFF
--- a/Sources/CocoaLumberjack/DDOSLogger.m
+++ b/Sources/CocoaLumberjack/DDOSLogger.m
@@ -48,6 +48,7 @@
     return self;
 }
 
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
 static DDOSLogger *sharedInstance;
 
 - (instancetype)init {


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1243
Since `sharedInstance` is a  class property, it seems that we need to add the annotation to `DDOSLogger.m` , not `DDOSLogger.h`.

