### PR TITLE
Change `DDLogLevel` from enum to options

### DIFF
--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -142,7 +142,7 @@ typedef NS_OPTIONS(NSUInteger, DDLogFlag){
 /**
  *  Log levels are used to filter out logs. Used together with flags.
  */
-typedef NS_ENUM(NSUInteger, DDLogLevel){
+typedef NS_OPTIONS(NSUInteger, DDLogLevel){
     /**
      *  No logs
      */


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [ ] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: n/a

### Pull Request Description

As discussed in [this StackOverflow question](https://stackoverflow.com/questions/68854372/how-to-implement-custom-log-levels-in-cocoalumberjack-from-swift), there's not really a clean way to implement custom log levels in Swift.

As `DDLogFlag` is defined as `NS_OPTIONS`, absolutely any value is valid here, but with `DDLogLevel` defined as an enum, as far as Swift as concerned the existing levels are the only valid levels.  I can't even particularly cleanly write aliases for the existing levels.

Further, to me, it doesn't even make particular sense for `DDLogFlag` to be `NS_OPTIONS` while `DDLogLevel` is `NS_ENUM`.  If anything, shouldn't it almost be the opposite...?  Logically, it doesn't make sense that something might be logged as `[.error, .info]` from Swift, but you could log something using that flag... but what does that even mean?  Meanwhile, from Swift, I can not do as some CocoaLumberjack documentation suggests, and easily filter to say "show me `.info` level, but not `.warnings`, but do show me `.error` level".  This again comes back to the fact that `DDLogLevel` is an enum and from the Swift side I can not create any custom values for this.

By this logic, `DDLogFlag` itself should arguably be `NS_ENUM` rather than `NS_OPTION`, however, I recommend leaving it as `NS_OPTION`, because changing it to `NS_ENUM` once again would limit my ability to use custom log levels from Swift.

