### PR TITLE
Fixed nullability conflict in DDDispatchQueueLogFormatter.h #1250

### DIFF
--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h
@@ -202,11 +202,6 @@ FOUNDATION_EXPORT DDQualityOfServiceName const DDQualityOfServiceUnspecified NS_
  */
 - (NSString *)queueThreadLabelForLogMessage:(DDLogMessage *)logMessage;
 
-/**
- *  The actual method that formats a message (transforms a `DDLogMessage` model into a printable string)
- */
-- (NSString *)formatLogMessage:(DDLogMessage *)logMessage;
-
 @end
 
 #pragma mark - DDAtomicCountable


### PR DESCRIPTION
method is already declared in protocol with nullable result type

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [ ] I have added the required tests to prove the fix/feature I am adding
* [ ] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description
Fixes nullability conflict in DDDispatchQueueLogFormatter.h #1250
