### PR TITLE
Fix file access issue in Catalyst apps

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -470,7 +470,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         NSError *currentError = nil;
         BOOL success = [fileHeader writeToFile:filePath options:NSDataWritingAtomic error:&currentError];
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IPHONE && !TARGET_OS_MACCATALYST
         if (success) {
             // When creating log file on iOS we're setting NSFileProtectionKey attribute to NSFileProtectionCompleteUnlessOpen.
             //


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: on Catalyst apps log files are inaccessible for the app to read/write.

### Pull Request Description

On Catalyst apps setting NSFileProtectionKey attribute to NSFileProtectionCompleteUnlessOpen for log files leads to `Can't open file` error. To prevent this I excluded the corresponding code from compiling on Catalyst environment.
