### PR TITLE
Fix excluded archs in debug build when not mac catalyst

### DIFF
--- a/Configs/Module-Debug.xcconfig
+++ b/Configs/Module-Debug.xcconfig
@@ -9,8 +9,6 @@
 // This can be worked around by setting ONLY_ACTIVE_ARCH to NO (slow) or using the EXCLUDED_ARCHS trick
 // Inspired by https://github.com/Carthage/Carthage/issues/3019
 EXCLUDED_ARCHS__IS_MACCATALYST_YES__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8
-// This is for non-maccatalyst platforms (no value for IS_MACCATALYST)
-EXCLUDED_ARCHS__IS_MACCATALYST___NATIVE_ARCH_64_BIT_x86_64=
 EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__IS_MACCATALYST_$(IS_MACCATALYST)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))
 
 // Specifies whether binary files that are copied during the build, such as in a Copy Bundle Resources or Copy Files build phase, should be stripped of debugging symbols.


### PR DESCRIPTION
This fixes building debug configuration for non-mac-catalyst platforms. Previously `EXCLUDED_ARCHS__IS_MACCATALYST_YES__NATIVE_ARCH_64_BIT_x86_64` and `EXCLUDED_ARCHS__IS_MACCATALYST___NATIVE_ARCH_64_BIT_x86_64` were equal. I don't think any archs should be excluded for non-mac-catalyst platforms. Previously all archs were excluded and so the library wouldn't be built.