### PR TITLE
Only show warning for DDTTYLogger if it's not a CLI app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
-## [3.7.3 - Xcode 12.? on ??, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.3)
+## [3.7.3 - Xcode 13.2 on Dec ??, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.3)
 
 ### Public
 
 - Fix "DDFileLogger: Failed to get offset" when setting maximumFileSize (#1234)
-
-### Internal
-
-- _REPLACE ME_
+- Follow-up to add annotations to DDOSLogger (#1248)
+- Fixed nullability conflict in DDDispatchQueueLogFormatter.h (#1252)
+- Add Swift 5.5 support, fix archive build on Xcode 13 (#1253)
+- Fix file access issue in Catalyst apps (#1257)
+- Fix excluded archs in debug build when not mac catalyst (#1260)
+- Bump Xcode last upgraded version to 13.2 (#1265)
+- Don't log warnings for CLI apps in DDTTYLogger (#1269)
 
 
 ## [3.7.2 - Xcode 12.4 on Apr 9th, 2021](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.7.2)

--- a/Sources/CocoaLumberjack/DDTTYLogger.m
+++ b/Sources/CocoaLumberjack/DDTTYLogger.m
@@ -832,9 +832,11 @@ static DDTTYLogger *sharedInstance;
         return nil;
     }
 
+#if !defined(DD_CLI) || __has_include(<AppKit/NSColor.h>)
     if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
         NSLogWarn(@"CocoaLumberjack: Warning: Usage of DDTTYLogger detected when DDOSLogger is available and can be used! Please consider migrating to DDOSLogger.");
     }
+#endif
 
     if ((self = [super init])) {
         // Initialize 'app' variable (char *)


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: Fixes #1267

### Pull Request Description

For CLI apps, the TTY logger is still useful.

