### PR TITLE
Fix for "DDFileLogger: Failed to synchronize file: nil"

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -630,7 +630,9 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
             __autoreleasing NSError *error;
             BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
             if (!synchronized) {
-                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+                if (error) {
+                    NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+                }
             }
             BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
             if (!closed) {
@@ -886,7 +888,9 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         __autoreleasing NSError *error;
         BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
         if (!synchronized) {
-            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            if (error) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            }
         }
         BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
         if (!closed) {
@@ -1247,7 +1251,9 @@ static int exception_count = 0;
             __autoreleasing NSError *error;
             BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
             if (!succeed) {
-                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+                if (error) {
+                    NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+                }
             }
         } else {
             @try {

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -216,11 +216,11 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         for (NSUInteger i = firstIndexToDelete; i < sortedLogFileInfos.count; i++) {
             DDLogFileInfo *logFileInfo = sortedLogFileInfos[i];
 
-            NSError *error = nil;
+            __autoreleasing NSError *error;
             BOOL success = [[NSFileManager defaultManager] removeItemAtPath:logFileInfo.filePath error:&error];
             if (success) {
                 NSLogInfo(@"DDLogFileManagerDefault: Deleting file: %@", logFileInfo.fileName);
-            } else {
+            } else if (error) {
                 NSLogError(@"DDLogFileManagerDefault: Error deleting file %@", error);
             }
         }
@@ -254,16 +254,15 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 - (NSString *)logsDirectory {
     // We could do this check once, during initialization, and not bother again.
     // But this way the code continues to work if the directory gets deleted while the code is running.
-
     NSAssert(_logsDirectory.length > 0, @"Directory must be set.");
 
-    NSError *err = nil;
+    __autoreleasing NSError *error;
     BOOL success = [[NSFileManager defaultManager] createDirectoryAtPath:_logsDirectory
                                              withIntermediateDirectories:YES
                                                               attributes:nil
-                                                                   error:&err];
-    if (success == NO) {
-        NSLogError(@"DDFileLogManagerDefault: Error creating logsDirectory: %@", err);
+                                                                   error:&error];
+    if (!success && error) {
+        NSLogError(@"DDFileLogManagerDefault: Error creating logsDirectory: %@", error);
     }
 
     return _logsDirectory;
@@ -629,13 +628,12 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
             BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
-            if (!synchronized) {
-                if (error) {
-                    NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
-                }
+            if (!synchronized && error) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+                error = nil;
             }
             BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
-            if (!closed) {
+            if (!closed && error) {
                 NSLogError(@"DDFileLogger: Failed to close file: %@", error);
             }
         } else {
@@ -648,7 +646,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         }
         _currentLogFileHandle = nil;
     }
-        
+
     if (_currentLogFileVnode) {
         dispatch_source_cancel(_currentLogFileVnode);
         _currentLogFileVnode = NULL;
@@ -883,17 +881,16 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     if (_currentLogFileHandle == nil) {
         return;
     }
-    
+
     if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
         __autoreleasing NSError *error;
         BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
-        if (!synchronized) {
-            if (error) {
-                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
-            }
+        if (!synchronized && error) {
+            NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
+            error = nil;
         }
         BOOL closed = [_currentLogFileHandle closeAndReturnError:&error];
-        if (!closed) {
+        if (!closed && error) {
             NSLogError(@"DDFileLogger: Failed to close file: %@", error);
         }
     } else {
@@ -966,8 +963,8 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         unsigned long long fileSize;
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
-            BOOL succeed = [_currentLogFileHandle getOffset:&fileSize error:&error];
-            if (!succeed) {
+            BOOL succeeded = [_currentLogFileHandle getOffset:&fileSize error:&error];
+            if (!succeeded && error) {
                 NSLogError(@"DDFileLogger: Failed to get offset: %@", error);
                 return;
             }
@@ -1171,8 +1168,8 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         if (_currentLogFileHandle != nil) {
             if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
                 __autoreleasing NSError *error;
-                BOOL succeed = [_currentLogFileHandle seekToEndReturningOffset:nil error:&error];
-                if (!succeed) {
+                BOOL succeeded = [_currentLogFileHandle seekToEndReturningOffset:nil error:&error];
+                if (!succeeded && error) {
                     NSLogError(@"DDFileLogger: Failed to seek to end of file: %@", error);
                 }
             } else {
@@ -1245,15 +1242,13 @@ static int exception_count = 0;
 
 - (void)lt_flush {
     NSAssert([self isOnInternalLoggerQueue], @"flush should only be executed on internal queue.");
-    
+
     if (_currentLogFileHandle != nil) {
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
-            BOOL succeed = [_currentLogFileHandle synchronizeAndReturnError:&error];
-            if (!succeed) {
-                if (error) {
-                    NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
-                }
+            BOOL synchronized = [_currentLogFileHandle synchronizeAndReturnError:&error];
+            if (!synchronized && error) {
+                NSLogError(@"DDFileLogger: Failed to synchronize file: %@", error);
             }
         } else {
             @try {
@@ -1345,11 +1340,12 @@ static int exception_count = 0;
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error;
             BOOL sought = [handle seekToEndReturningOffset:nil error:&error];
-            if (!sought) {
+            if (!sought && error) {
                 NSLogError(@"DDFileLogger: Failed to seek to end of file: %@", error);
+                error = nil;
             }
-            BOOL written =  [handle writeData:data error:&error];
-            if (!written) {
+            BOOL written = [handle writeData:data error:&error];
+            if (!written && error) {
                 NSLogError(@"DDFileLogger: Failed to write data: %@", error);
             }
         } else {
@@ -1469,7 +1465,7 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 
 - (NSDictionary *)fileAttributes {
     if (_fileAttributes == nil && filePath != nil) {
-        NSError *error = nil;
+        __autoreleasing NSError *error;
         _fileAttributes = [[NSFileManager defaultManager] attributesOfItemAtPath:filePath error:&error];
 
         if (error) {
@@ -1571,13 +1567,12 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
         NSAssert(directory, @"Containing directory must exist.");
 #endif
 
-        NSError *error = nil;
-
+        __autoreleasing NSError *error;
         BOOL success = [fileManager removeItemAtPath:newFilePath error:&error];
-        if (!success && error.code != NSFileNoSuchFileError) {
+        if (!success && error && error.code != NSFileNoSuchFileError) {
             NSLogError(@"DDLogFileInfo: Error deleting archive (%@): %@", self.fileName, error);
         }
-
+        error = nil; // set it outside of above's if because it also checks the code.
         success = [fileManager moveItemAtPath:filePath toPath:newFilePath error:&error];
 
         // When a log file is deleted, moved or renamed on the simulator, we attempt to rename it as a
@@ -1585,9 +1580,9 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
         // We therefore ignore this error, and assert that the directory we are copying into exists (which
         // is the only other case where this error code can come up).
 #if TARGET_IPHONE_SIMULATOR
-        if (!success && error.code != NSFileNoSuchFileError)
+        if (!success && error && error.code != NSFileNoSuchFileError)
 #else
-        if (!success)
+        if (!success && error)
 #endif
         {
             NSLogError(@"DDLogFileInfo: Error renaming file (%@): %@", self.fileName, error);


### PR DESCRIPTION
[_currentLogFileHandle synchronizeAndReturnError:&error] can return NO without error.
DDFileLogger will put "DDFileLogger: Failed to synchronize file: nil" to console.
This patch prevents the problem.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

...

