### PR TITLE
Revert "Merge pull request #1279 from kinarobin/optimization-date-for…

### DIFF
--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -20,7 +20,6 @@
 #import <pthread.h>
 #import <objc/runtime.h>
 #import <sys/qos.h>
-#import <sys/time.h>
 
 #if TARGET_OS_IOS
     #import <UIKit/UIDevice.h>
@@ -1009,11 +1008,6 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
         _options      = options;
         _timestamp    = timestamp ?: [NSDate new];
 
-        struct timeval time;
-        gettimeofday(&time, NULL);
-        sys_timeval.tv_sec = time.tv_sec;
-        sys_timeval.tv_usec = time.tv_usec;
-        
         __uint64_t tid;
         if (pthread_threadid_np(NULL, &tid) == 0) {
             _threadID = [[NSString alloc] initWithFormat:@"%llu", tid];

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -788,7 +788,6 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     id _representedObject;
     DDLogMessageOptions _options;
     NSDate * _timestamp;
-    struct timeval sys_timeval;
     NSString *_threadID;
     NSString *_threadName;
     NSString *_queueLabel;


### PR DESCRIPTION
…matter-cost"

This reverts commit ce2b1a1dd25b0576300f8256f2c3064a8ee6a6b9, reversing
changes made to 24e7ff35961694e87abe5e446f271d5fb390e95c.

### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

Please revert PR #1279 which have the following issues:
1. sys_timeval and _timestamp differ if timestamp is provided when creating DDLogMessage.
2. _timeStringBuffer is not NUL terminated in DDLogFileFormatterDefault.
3. timestamps are converted to local time zone instead of UTC when _dateFormatter is used.
4. calculation of minutes is wrong, always leading to zero in -formatLogTimestamp: method.
5. use of _timeStringBuffer is not thread safe.
