### PR TITLE
Fixed nullability conflict or file parameter for DDLogMessage creation.

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -94,6 +94,9 @@ CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE
 // Warns about potentially unreachable code.
 CLANG_WARN_UNREACHABLE_CODE = YES
 
+// Warns about implicit conversion from nullable pointer to non-nullable pointer.
+CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES
+
 // The path to a file specifying code-signing entitlements.
 CODE_SIGN_ENTITLEMENTS =
 

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -989,8 +989,9 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
                             tag:(id)tag
                         options:(DDLogMessageOptions)options
                       timestamp:(NSDate *)timestamp {
-    NSParameterAssert(message && file);
-    
+    NSParameterAssert(message);
+    NSParameterAssert(file);
+
     if ((self = [super init])) {
         BOOL copyMessage = (options & DDLogMessageDontCopyMessage) == 0;
         _message      = copyMessage ? [message copy] : message;

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -462,11 +462,13 @@ static NSUInteger _numProcessors;
    function:(const char *)function
        line:(NSUInteger)line
         tag:(id)tag {
+    NSString* fileString = @(file);
+    NSAssert(fileString, @"Invalid file parameter");
     DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message
                                                                level:level
                                                                 flag:flag
                                                              context:context
-                                                                file:@(file) ?: @""
+                                                                file:fileString
                                                             function:@(function)
                                                                 line:line
                                                                  tag:tag

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -466,7 +466,7 @@ static NSUInteger _numProcessors;
                                                                level:level
                                                                 flag:flag
                                                              context:context
-                                                                file:@(file)
+                                                                file:@(file) ?: @""
                                                             function:@(function)
                                                                 line:line
                                                                  tag:tag

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -462,18 +462,20 @@ static NSUInteger _numProcessors;
    function:(const char *)function
        line:(NSUInteger)line
         tag:(id)tag {
-    NSString* fileString = @(file);
-    NSAssert(fileString, @"Invalid file parameter");
+// Nullity checks are handled by -initWithMessage:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullable-to-nonnull-conversion"
     DDLogMessage *logMessage = [[DDLogMessage alloc] initWithMessage:message
                                                                level:level
                                                                 flag:flag
                                                              context:context
-                                                                file:fileString
+                                                                file:@(file)
                                                             function:@(function)
                                                                 line:line
                                                                  tag:tag
                                                              options:(DDLogMessageOptions)0
                                                            timestamp:nil];
+#pragma clang diagnostic pop
 
     [self queueLogMessage:logMessage asynchronously:asynchronous];
 }
@@ -987,6 +989,8 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
                             tag:(id)tag
                         options:(DDLogMessageOptions)options
                       timestamp:(NSDate *)timestamp {
+    NSParameterAssert(message && file);
+    
     if ((self = [super init])) {
         BOOL copyMessage = (options & DDLogMessageDontCopyMessage) == 0;
         _message      = copyMessage ? [message copy] : message;

--- a/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
+++ b/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
@@ -258,9 +258,12 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     DDLogVerbose(@"%@", @"verbose");
 
     [DDLog flushLog];
+    
+    NSString* filePath = logger.currentLogFileInfo.filePath;
+    XCTAssertNotNil(filePath);
 
     NSError *error = nil;
-    NSData *data = [NSData dataWithContentsOfFile:logger.currentLogFileInfo.filePath options:NSDataReadingUncached error:&error];
+    NSData *data = [NSData dataWithContentsOfFile:filePath options:NSDataReadingUncached error:&error];
     XCTAssertNil(error);
 
     NSString *contents = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
@@ -278,9 +281,12 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     DDLogVerbose(@"%@", @"verbose");
 
     [DDLog flushLog];
+    
+    NSString* filePath = logger.currentLogFileInfo.filePath;
+    XCTAssertNotNil(filePath);
 
     NSError *error = nil;
-    NSData *data = [NSData dataWithContentsOfFile:logger.currentLogFileInfo.filePath options:NSDataReadingUncached error:&error];
+    NSData *data = [NSData dataWithContentsOfFile:filePath options:NSDataReadingUncached error:&error];
     XCTAssertNil(error);
 
     NSString *contents = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];

--- a/Tests/CocoaLumberjackTests/DDLogFileManagerTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogFileManagerTests.m
@@ -43,7 +43,7 @@
     __autoreleasing NSError *creationError;
     NSString *filePath = [self.logFileManager createNewLogFileWithError:&creationError];
     XCTAssertNil(creationError);
-    XCTAssertTrue([self.logFileManager isLogFile:[NSURL fileURLWithPath:filePath].lastPathComponent]);
+    XCTAssertTrue([self.logFileManager isLogFile:filePath.lastPathComponent]);
 
     __autoreleasing NSError *error = nil;
     NSData *data = [NSData dataWithContentsOfFile:filePath options:NSDataReadingUncached error:&error];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

In PR #1280, `@(file)` could now return nil value. I fixed the nullability conflict by setting file parameter to empty string in that case. Maybe we could use another constant string for that like `@"unknown"`?
