### PR TITLE
Fixed -isEqual: and -hash methods for DDLogMessage class.

### DIFF
--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1052,7 +1052,7 @@ NS_INLINE BOOL _nullable_strings_equal(NSString* _Nullable lhs, NSString* _Nulla
     // See https://stackoverflow.com/questions/36593038/confused-about-the-default-isequal-and-hash-implements
     if (other == self) {
         return YES;
-    } else if (!other || ![other isKindOfClass:[self class]]) {
+    } else if (!other || ![other isKindOfClass:[DDLogMessage class]]) {
         return NO;
     } else {
         __auto_type otherMsg = (DDLogMessage *)other;

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1037,10 +1037,20 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     return self;
 }
 
+static __inline__ __attribute__((__always_inline__)) BOOL _nullable_strings_equal(NSString* _Nullable lhs, NSString* _Nullable rhs)
+{
+    if (lhs == nil) {
+        if (rhs == nil)
+            return YES;
+    } else if (rhs != nil && [lhs isEqualToString:rhs])
+        return YES;
+    return NO;
+}
+
 - (BOOL)isEqual:(id)other {
     if (other == self) {
         return YES;
-    } else if (![super isEqual:other] || ![other isKindOfClass:[self class]]) {
+    } else if (!other || ![other isKindOfClass:[self class]]) {
         return NO;
     } else {
         __auto_type otherMsg = (DDLogMessage *)other;
@@ -1049,11 +1059,9 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
         && otherMsg->_flag == _flag
         && otherMsg->_context == _context
         && [otherMsg->_file isEqualToString:_file]
-        && [otherMsg->_fileName isEqualToString:_fileName]
-        && [otherMsg->_function isEqualToString:_function]
+        && _nullable_strings_equal(otherMsg->_function, _function)
         && otherMsg->_line == _line
         && (([otherMsg->_representedObject respondsToSelector:@selector(isEqual:)] && [otherMsg->_representedObject isEqual:_representedObject]) || otherMsg->_representedObject == _representedObject)
-        && otherMsg->_options == _options
         && [otherMsg->_timestamp isEqualToDate:_timestamp]
         && [otherMsg->_threadID isEqualToString:_threadID] // If the thread ID is the same, the name will likely be the same as well.
         && [otherMsg->_queueLabel isEqualToString:_queueLabel]
@@ -1062,17 +1070,14 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 }
 
 - (NSUInteger)hash {
-    return [super hash]
-    ^ _message.hash
+    return _message.hash
     ^ _level
     ^ _flag
     ^ _context
     ^ _file.hash
-    ^ _fileName.hash
     ^ _function.hash
     ^ _line
-    ^ ([_representedObject respondsToSelector:@selector(hash)] ? [_representedObject hash] : 0)
-    ^ _options
+    ^ ([_representedObject respondsToSelector:@selector(hash)] ? [_representedObject hash] : (NSUInteger)_representedObject)
     ^ _timestamp.hash
     ^ _threadID.hash
     ^ _queueLabel.hash

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1048,6 +1048,8 @@ static __inline__ __attribute__((__always_inline__)) BOOL _nullable_strings_equa
 }
 
 - (BOOL)isEqual:(id)other {
+    // Subclasses of NSObject should not call [super isEqual:] here.
+    // See https://stackoverflow.com/questions/36593038/confused-about-the-default-isequal-and-hash-implements
     if (other == self) {
         return YES;
     } else if (!other || ![other isKindOfClass:[self class]]) {
@@ -1070,6 +1072,8 @@ static __inline__ __attribute__((__always_inline__)) BOOL _nullable_strings_equa
 }
 
 - (NSUInteger)hash {
+    // Subclasses of NSObject should not call [super hash] here.
+    // See https://stackoverflow.com/questions/36593038/confused-about-the-default-isequal-and-hash-implements
     return _message.hash
     ^ _level
     ^ _flag

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1037,7 +1037,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
     return self;
 }
 
-static __inline__ __attribute__((__always_inline__)) BOOL _nullable_strings_equal(NSString* _Nullable lhs, NSString* _Nullable rhs)
+NS_INLINE BOOL _nullable_strings_equal(NSString* _Nullable lhs, NSString* _Nullable rhs)
 {
     if (lhs == nil) {
         if (rhs == nil)

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -1042,7 +1042,7 @@ static __inline__ __attribute__((__always_inline__)) BOOL _nullable_strings_equa
     if (lhs == nil) {
         if (rhs == nil)
             return YES;
-    } else if (rhs != nil && [lhs isEqualToString:rhs])
+    } else if (rhs != nil && [lhs isEqualToString:(NSString* _Nonnull)rhs])
         return YES;
     return NO;
 }

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -780,7 +780,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSInteger _context;
     NSString *_file;
     NSString *_fileName;
-    NSString * _function;
+    NSString *_function;
     NSUInteger _line;
     #if DD_LEGACY_MESSAGE_TAG
     id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));;

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -780,7 +780,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSInteger _context;
     NSString *_file;
     NSString *_fileName;
-    NSString *_function;
+    NSString * _Nullable _function;
     NSUInteger _line;
     #if DD_LEGACY_MESSAGE_TAG
     id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));;

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -780,7 +780,7 @@ typedef NS_OPTIONS(NSInteger, DDLogMessageOptions){
     NSInteger _context;
     NSString *_file;
     NSString *_fileName;
-    NSString * _Nullable _function;
+    NSString * _function;
     NSUInteger _line;
     #if DD_LEGACY_MESSAGE_TAG
     id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));;

--- a/Tests/CocoaLumberjackTests/DDLogMessageTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogMessageTests.m
@@ -68,6 +68,19 @@ static NSString * const kDefaultMessage = @"Log message";
                                        timestamp:nil];
 }
 
++ (DDLogMessage *)test_messageWithWithoutFunction {
+    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
+                                           level:DDLogLevelDebug
+                                            flag:DDLogFlagError
+                                         context:1
+                                            file:@(__FILE__)
+                                        function:nil
+                                            line:__LINE__
+                                             tag:NULL
+                                         options:(DDLogMessageOptions)0
+                                       timestamp:nil];
+}
+
 + (DDLogMessage *)test_messageWithFile:(NSString *)file
                                options:(DDLogMessageOptions)options {
     return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
@@ -236,6 +249,15 @@ static NSString * const kDefaultMessage = @"Log message";
     XCTAssertEqualObjects(self.message.threadName, copy.threadName);
     XCTAssertEqualObjects(self.message.queueLabel, copy.queueLabel);
     XCTAssertEqual(self.message.qos, copy.qos);
+    XCTAssertEqual(self.message.hash, copy.hash);
+    XCTAssertEqualObjects(self.message, copy);
+}
+
+- (void)testEqualityCopyWithoutFunction {
+    __auto_type message = [DDLogMessage test_messageWithWithoutFunction];
+    __auto_type copy = (typeof(message))[message copy];
+    XCTAssertEqual(message.hash, copy.hash);
+    XCTAssertEqualObjects(message, copy);
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This PR will fix -isEqual: and -hash methods for DDLogMessage class:
1. `[super isEqual:other]` always returns `FALSE` since `[NSObject isEqual:]` compares pointers only.
2. `[otherMsg->_function isEqualToString:_function]` always returns `FALSE` if `otherMsg->_function` is `nil`. Added a test for that.
3. Removed the test for `_fileName` since it is a derivative of `_file`.
4. Removed the test for `_options` since it is not relevant for messages comparison.
