### PR TITLE
Fix nullability violations

### DIFF
--- a/Configs/Module-Debug.xcconfig
+++ b/Configs/Module-Debug.xcconfig
@@ -23,6 +23,9 @@ ENABLE_NS_ASSERTIONS = YES
 // When this setting is activated, the product will be built with options appropriate for running automated tests, such as making private interfaces accessible to the tests.
 ENABLE_TESTABILITY = YES
 
+// Check for violations of nullability annotations in function calls, return statements, and assignments.
+CLANG_UNDEFINED_BEHAVIOR_SANITIZER_NULLABILITY = YES
+
 // Specifies the degree to which the generated code is optimized for speed and binary size.
 GCC_OPTIMIZATION_LEVEL = 0
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1081,6 +1081,9 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
                      @"Invalid log file manager! Responds neither to `-createNewLogFileWithError:` nor `-createNewLogFile`!");
             currentLogFilePath = [_logFileManager createNewLogFile];
             #pragma clang diagnostic pop
+            if (!currentLogFilePath) {
+                NSLogError(@"DDFileLogger: Failed to create new log file");
+            }
         }
         // Use static factory method here, since it checks for nil (and is unavailable to Swift).
         _currentLogFileInfo = [DDLogFileInfo logFileWithPath:currentLogFilePath];

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1328,6 +1328,8 @@ static int exception_count = 0;
     }
 
     @try {
+        NSFileHandle *handle = [self lt_currentLogFileHandle];
+
         if (implementsDeprecatedWillLog) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
@@ -1337,7 +1339,6 @@ static int exception_count = 0;
             [self willLogMessage:_currentLogFileInfo];
         }
 
-        NSFileHandle *handle = [self lt_currentLogFileHandle];
         if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)) {
             __autoreleasing NSError *error = nil;
             BOOL success = [handle seekToEndReturningOffset:nil error:&error];


### PR DESCRIPTION
### New Pull Request Checklist

* [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
* [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
* [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

* [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
* [x] I have added the required tests to prove the fix/feature I am adding
* [x] I have updated the documentation (if necessary)
* [x] I have run the tests and they pass
* [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

After enabling nullability violations checks, I found an issue where `_currentLogFileInfo` could be used before being initialized. This PR fixes that.

