### PR TITLE
Use dispatch_walltime for scheduling log file rolling timer

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -830,7 +830,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     static NSTimeInterval const kDDMaxTimerDelay = LLONG_MAX / NSEC_PER_SEC;
     int64_t delay = (int64_t)(MIN([logFileRollingDate timeIntervalSinceNow], kDDMaxTimerDelay) * (NSTimeInterval) NSEC_PER_SEC);
     __auto_type fireTime = dispatch_walltime(NULL, delay); // `NULL` uses `gettimeofday` internally
-    
+
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, (uint64_t)kDDRollingLeeway * NSEC_PER_SEC);
 
     if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -829,7 +829,12 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 
     static NSTimeInterval const kDDMaxTimerDelay = LLONG_MAX / NSEC_PER_SEC;
     int64_t delay = (int64_t)(MIN([logFileRollingDate timeIntervalSinceNow], kDDMaxTimerDelay) * (NSTimeInterval) NSEC_PER_SEC);
-    dispatch_time_t fireTime = dispatch_time(DISPATCH_TIME_NOW, delay);
+
+    dispatch_time_t fireTime;
+    if (@available(macOS 10.14, ios 12.0, tvos 12.0, watchos 5.0, *))
+        fireTime = dispatch_walltime(DISPATCH_WALLTIME_NOW, delay);
+    else
+        fireTime = dispatch_walltime(NULL, delay); // passing NULL has the same effect as `DISPATCH_WALLTIME_NOW`.
 
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, (uint64_t)kDDRollingLeeway * NSEC_PER_SEC);
 

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -829,13 +829,8 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
 
     static NSTimeInterval const kDDMaxTimerDelay = LLONG_MAX / NSEC_PER_SEC;
     int64_t delay = (int64_t)(MIN([logFileRollingDate timeIntervalSinceNow], kDDMaxTimerDelay) * (NSTimeInterval) NSEC_PER_SEC);
-
-    dispatch_time_t fireTime;
-    if (@available(macOS 10.14, ios 12.0, tvos 12.0, watchos 5.0, *))
-        fireTime = dispatch_walltime(DISPATCH_WALLTIME_NOW, delay);
-    else
-        fireTime = dispatch_walltime(NULL, delay); // passing NULL has the same effect as `DISPATCH_WALLTIME_NOW`.
-
+    __auto_type fireTime = dispatch_walltime(NULL, delay); // `NULL` uses `gettimeofday` internally
+    
     dispatch_source_set_timer(_rollingTimer, fireTime, DISPATCH_TIME_FOREVER, (uint64_t)kDDRollingLeeway * NSEC_PER_SEC);
 
     if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: Maybe (hopefully?) #1276 

### Pull Request Description

We were using `dispatch_time` for scheduling the log file rolling timer. However, `dispatch_time` pauses when the machine goes to sleep. Thus the log file rolling interval might be "strange" as in not being exactly the time that was specified as rolling interval on the logger.

This PR now makes the switch to `dispatch_walltime` which should yield better results.
[The documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/ConcurrencyProgrammingGuide/GCDWorkQueues/GCDWorkQueues.html) even explicitly recommends using `dispatch_walltime` for larger intervals:
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/1689782/185853932-a80b4d4e-f2ce-45a9-9ffd-5b989bd9c041.png">
