### PR TITLE
Don't log into symlink files

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1102,6 +1102,11 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         return NO;
     }
 
+    // Don't followw symlink
+    if (logFileInfo.isSymlink) {
+        return NO;
+    }
+
     // If we're resuming, we need to check if the log file is allowed for reuse or needs to be archived.
     if (isResuming && (_doNotReuseLogFiles || [self lt_shouldLogFileBeArchived:logFileInfo])) {
         logFileInfo.isArchived = YES;
@@ -1512,6 +1517,14 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 
 - (NSTimeInterval)age {
     return -[[self creationDate] timeIntervalSinceNow];
+}
+
+- (BOOL)isSymlink {
+    if (self.fileAttributes[NSFileType] == NSFileTypeSymbolicLink) {
+        return YES;
+    }
+
+    return NO;
 }
 
 - (NSString *)description {

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1102,7 +1102,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
         return NO;
     }
 
-    // Don't followw symlink
+    // Don't follow symlink
     if (logFileInfo.isSymlink) {
         return NO;
     }
@@ -1520,11 +1520,7 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 }
 
 - (BOOL)isSymlink {
-    if (self.fileAttributes[NSFileType] == NSFileTypeSymbolicLink) {
-        return YES;
-    }
-
-    return NO;
+    return self.fileAttributes[NSFileType] == NSFileTypeSymbolicLink;
 }
 
 - (NSString *)description {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -507,6 +507,8 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 @property (nonatomic, readonly) NSTimeInterval age;
 
+@property (nonatomic, readonly) BOOL isSymlink;
+
 @property (nonatomic, readwrite) BOOL isArchived;
 
 + (nullable instancetype)logFileWithPath:(nullable NSString *)filePath NS_SWIFT_UNAVAILABLE("Use init(filePath:)");

--- a/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
+++ b/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
@@ -293,4 +293,23 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     XCTAssertEqual([contents componentsSeparatedByString:@"\n"].count, 5 + 2);
 }
 
+- (void)testOverwriteSymlink {
+    NSString* customFileName = @"testIgnoreSymlink_file_name.log";
+    logFileManager.customLogFileName = customFileName;
+
+    NSString* logFileName = [logFileManager.logsDirectory stringByAppendingPathComponent:customFileName];
+    NSString *tempFilePath = [NSTemporaryDirectory() stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]];
+    [NSFileManager.defaultManager createFileAtPath:tempFilePath contents:nil attributes:nil];
+
+    [NSFileManager.defaultManager createDirectoryAtPath:logFileManager.logsDirectory
+                            withIntermediateDirectories:YES
+                                             attributes:nil
+                                                  error:nil];
+
+    [NSFileManager.defaultManager createSymbolicLinkAtPath:logFileName withDestinationPath:tempFilePath error:nil];
+    __auto_type info = logger.currentLogFileInfo;
+    XCTAssertEqualObjects(info.fileName, customFileName);
+    XCTAssertFalse(info.isSymlink);
+}
+
 @end

--- a/Tests/CocoaLumberjackTests/DDSampleFileManager.h
+++ b/Tests/CocoaLumberjackTests/DDSampleFileManager.h
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface DDSampleFileManager : DDLogFileManagerDefault
 
 @property (nonatomic) NSString *archivedLogFilePath;
+@property (nonatomic) NSString *customLogFileName;
 
 - (instancetype)initWithLogFileHeader:(NSString * __nullable)header NS_DESIGNATED_INITIALIZER;
 

--- a/Tests/CocoaLumberjackTests/DDSampleFileManager.m
+++ b/Tests/CocoaLumberjackTests/DDSampleFileManager.m
@@ -43,4 +43,20 @@
     _archivedLogFilePath = logFilePath;
 }
 
+- (NSString *)newLogFileName {
+    if (self.customLogFileName) {
+        return self.customLogFileName;
+    }
+
+    return [super newLogFileName];
+}
+
+- (BOOL)isLogFile:(NSString *)fileName {
+    if (self.customLogFileName) {
+        return [self.customLogFileName isEqualToString:fileName];
+    }
+
+    return [super isLogFile:fileName];
+}
+
 @end


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

When the logger is trying to reuse an older log file, if the log file is a symlink the logger will write into the link file. This can result in different issues, specially if the log file names are custom. 
To prevent this, first check if the file is symlink, and when it is recreate it as regular file.
