### PR TITLE
Fix code-level build warnings

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -205,7 +205,7 @@ MACOSX_DEPLOYMENT_TARGET = 10.10
 
 MARKETING_VERSION = 3.7.4
 
-OTHER_C_FLAGS = -Wextra
+WARNING_CFLAGS = -Wextra -Wextra-semi -Wdouble-promotion
 
 // Options defined in this setting are passed to invocations of the linker.
 OTHER_LDFLAGS = -ObjC

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1676,7 +1676,7 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
     NSMutableString *newFileName = [NSMutableString stringWithCapacity:estimatedNewLength];
 
     if (count > 0) {
-        [newFileName appendString:components.firstObject ?: @""];
+        [newFileName appendString:components[0]];
     }
 
     BOOL found = NO;

--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1676,7 +1676,7 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
     NSMutableString *newFileName = [NSMutableString stringWithCapacity:estimatedNewLength];
 
     if (count > 0) {
-        [newFileName appendString:components.firstObject];
+        [newFileName appendString:components.firstObject ?: @""];
     }
 
     BOOL found = NO;

--- a/Sources/CocoaLumberjack/DDTTYLogger.m
+++ b/Sources/CocoaLumberjack/DDTTYLogger.m
@@ -713,15 +713,15 @@ static DDTTYLogger *sharedInstance;
         CGContextFillRect(context, CGRectMake(0, 0, 1, 1));
 
         if (rPtr) {
-            *rPtr = pixel[0] / 255.0f;
+            *rPtr = pixel[0] / 255.0;
         }
 
         if (gPtr) {
-            *gPtr = pixel[1] / 255.0f;
+            *gPtr = pixel[1] / 255.0;
         }
 
         if (bPtr) {
-            *bPtr = pixel[2] / 255.0f;
+            *bPtr = pixel[2] / 255.0;
         }
 
         CGContextRelease(context);
@@ -758,7 +758,7 @@ static DDTTYLogger *sharedInstance;
     [self getRed:&inR green:&inG blue:&inB fromColor:inColor];
 
     NSUInteger bestIndex = 0;
-    CGFloat lowestDistance = 100.0f;
+    CGFloat lowestDistance = 100.0;
 
     NSUInteger i = 0;
 
@@ -1395,17 +1395,17 @@ static DDTTYLogger *sharedInstance;
         if (fgColor) {
             [DDTTYLogger getRed:&r green:&g blue:&b fromColor:fgColor];
 
-            fg_r = (uint8_t)(r * 255.0f);
-            fg_g = (uint8_t)(g * 255.0f);
-            fg_b = (uint8_t)(b * 255.0f);
+            fg_r = (uint8_t)(r * 255.0);
+            fg_g = (uint8_t)(g * 255.0);
+            fg_b = (uint8_t)(b * 255.0);
         }
 
         if (bgColor) {
             [DDTTYLogger getRed:&r green:&g blue:&b fromColor:bgColor];
 
-            bg_r = (uint8_t)(r * 255.0f);
-            bg_g = (uint8_t)(g * 255.0f);
-            bg_b = (uint8_t)(b * 255.0f);
+            bg_r = (uint8_t)(r * 255.0);
+            bg_g = (uint8_t)(g * 255.0);
+            bg_b = (uint8_t)(b * 255.0);
         }
 
         if (fgColor && isaColorTTY) {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -799,7 +799,7 @@ DD_SENDABLE
     NSString *_function;
     NSUInteger _line;
     #if DD_LEGACY_MESSAGE_TAG
-    id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));;
+    id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));
     #endif
     id _representedObject;
     DDLogMessageOptions _options;

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDTTYLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDTTYLogger.h
@@ -28,17 +28,17 @@
     // iOS or tvOS or watchOS
     #import <UIKit/UIColor.h>
     typedef UIColor DDColor;
-    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #elif defined(DD_CLI) || !__has_include(<AppKit/NSColor.h>)
     // OS X CLI
     #import <CocoaLumberjack/CLIColor.h>
     typedef CLIColor DDColor;
-    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #else
     // OS X with AppKit
     #import <AppKit/NSColor.h>
     typedef NSColor DDColor;
-    static inline DDColor  * _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0f) green:(g/255.0f) blue:(b/255.0f) alpha:1.0f];}
+    static inline DDColor  * _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithCalibratedRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
 #endif
 #pragma clang diagnostic pop
 

--- a/Tests/CocoaLumberjackTests/DDBasicLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDBasicLoggingTests.m
@@ -22,7 +22,7 @@
 #import "DDSampleFileManager.h"
 #import "DDSMocking.h"
 
-static const NSTimeInterval kAsyncExpectationTimeout = 3.0f;
+static const NSTimeInterval kAsyncExpectationTimeout = 3.0;
 
 static DDLogLevel ddLogLevel = DDLogLevelVerbose;
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

### Pull Request Description

This PR fixes a couple of build warnings, some of which show up whenever I build a project which uses CocoaLumberjack as an SPM package dependency:
- An implicit nullable to non-nullable conversion that is shown whenever CocoaLumberjack is built in Xcode.
- Warnings about promoting floats to doubles (when using float literals with CGFloat, which is a double on 64b platforms). These warnings show up when `-Wdouble-promotion` is on, even if the warning is just configured for client code that includes the CocoaLumberjack headers.
- A warning about an extra semicolon. This warning shows up when `-Wextra-semi` is on, even if the warning is just configured for client code that includes the CocoaLumberjack headers.

The full details can be found in the individual commit messages.

Let me know if you'd like me to add these warning flags to the `Module-Shared.xcconfig` file as `WARNING_CFLAGS` to prevent regressions.