### PR TITLE
Silence double conversion warnings for 32-bit watchOS

### DIFF
--- a/Sources/CocoaLumberjack/DDTTYLogger.m
+++ b/Sources/CocoaLumberjack/DDTTYLogger.m
@@ -775,7 +775,7 @@ static DDTTYLogger *sharedInstance;
     #endif
 
         NSLogVerbose(@"DDTTYLogger: %3lu : %.3f,%.3f,%.3f & %.3f,%.3f,%.3f = %.6f",
-                     (unsigned long)i, inR, inG, inB, r, g, b, distance);
+                     (unsigned long)i, (double)inR, (double)inG, (double)inB, (double)r, (double)g, (double)b, (double)distance);
 
         if (distance < lowestDistance) {
             bestIndex = i;
@@ -1395,17 +1395,17 @@ static DDTTYLogger *sharedInstance;
         if (fgColor) {
             [DDTTYLogger getRed:&r green:&g blue:&b fromColor:fgColor];
 
-            fg_r = (uint8_t)(r * 255.0);
-            fg_g = (uint8_t)(g * 255.0);
-            fg_b = (uint8_t)(b * 255.0);
+            fg_r = (uint8_t)(r * (CGFloat)255.0);
+            fg_g = (uint8_t)(g * (CGFloat)255.0);
+            fg_b = (uint8_t)(b * (CGFloat)255.0);
         }
 
         if (bgColor) {
             [DDTTYLogger getRed:&r green:&g blue:&b fromColor:bgColor];
 
-            bg_r = (uint8_t)(r * 255.0);
-            bg_g = (uint8_t)(g * 255.0);
-            bg_b = (uint8_t)(b * 255.0);
+            bg_r = (uint8_t)(r * (CGFloat)255.0);
+            bg_g = (uint8_t)(g * (CGFloat)255.0);
+            bg_b = (uint8_t)(b * (CGFloat)255.0);
         }
 
         if (fgColor && isaColorTTY) {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDTTYLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDTTYLogger.h
@@ -28,7 +28,7 @@
     // iOS or tvOS or watchOS
     #import <UIKit/UIColor.h>
     typedef UIColor DDColor;
-    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithRed:(r/255.0) green:(g/255.0) blue:(b/255.0) alpha:1.0];}
+    static inline DDColor* _Nonnull DDMakeColor(CGFloat r, CGFloat g, CGFloat b) {return [DDColor colorWithRed:(r/(CGFloat)255.0) green:(g/(CGFloat)255.0) blue:(b/(CGFloat)255.0) alpha:1.0];}
 #elif defined(DD_CLI) || !__has_include(<AppKit/NSColor.h>)
     // OS X CLI
     #import <CocoaLumberjack/CLIColor.h>


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

https://github.com/CocoaLumberjack/CocoaLumberjack/pull/1317 fixed double conversion warnings and also enabled `-Wdouble-promotion`. This created warnings when building for 32-bit watchOS, so I added explicit casts to silence the warnings.