### PR TITLE
Enable ALLOW_TARGET_PLATFORM_SPECIALIZATION

### DIFF
--- a/Configs/Module-Shared.xcconfig
+++ b/Configs/Module-Shared.xcconfig
@@ -1,6 +1,9 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 
+// Allow building for multiple platforms with a single build
+ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES
+
 // This setting is deprecated as of Xcode 8.3 and may not be supported in future versions. It is recommended that you disable the setting. If enabled, both `#include <header.h>`-style and `#include "header.h"`-style directives search the paths in `USER_HEADER_SEARCH_PATHS` before `HEADER_SEARCH_PATHS`
 ALWAYS_SEARCH_USER_PATHS = NO
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

This allows the framework to build for multiple platforms which fixes errors building when a project uses CocoaLumberjack in both iOS and watchOS targets.

Without this set we get errors when building with CocoaLumberjack added as a dependency directly through Xcode (rather than using pods, Carthage, or SPM).