### PR TITLE
Update to swift-log 1.5.2, implement metadata providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [3.8.1 - Xcode 14.3 on Feb ??, 2023](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.1)
+
+### Public
+
+- Silence double conversion warnings for 32-bit watchOS (#1320)
+- Enable ALLOW_TARGET_PLATFORM_SPECIALIZATION (#1321)
+- Update to swift-log 1.5.2, implement metadata providers (#1329)
+
+### Internal
+
+- Update copyright for 2023
+
+
 ## [3.8.0 - Xcode 14.1 on Nov 2nd, 2022](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.0)
 
 ### Public

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
-        "version" : "1.4.4"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
             targets: ["CocoaLumberjackSwiftLogBackend"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.5.swift
+++ b/Package@swift-5.5.swift
@@ -24,7 +24,7 @@ let package = Package(
             targets: ["CocoaLumberjackSwiftLogBackend"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package@swift-5.6.swift
+++ b/Package@swift-5.6.swift
@@ -24,7 +24,7 @@ let package = Package(
             targets: ["CocoaLumberjackSwiftLogBackend"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Tests/CocoaLumberjackSwiftLogBackendTests/DDLogHandlerTests.swift
+++ b/Tests/CocoaLumberjackSwiftLogBackendTests/DDLogHandlerTests.swift
@@ -67,7 +67,8 @@ final class DDLogHandlerTests: XCTestCase {
         XCTAssertEqual(loggedMsg.message.line, logLine)
         XCTAssertNotNil(loggedMsg.message.swiftLogInfo)
         XCTAssertEqual(loggedMsg.message.swiftLogInfo, .init(logger: .init(label: logger.label,
-                                                                           metadata: logger.handler.metadata),
+                                                                           metadataSources: .init(logger: logger.handler.metadata,
+                                                                                                  provider: logger.metadataProvider?.get())),
                                                              message: .init(message: msg,
                                                                             level: .info,
                                                                             metadata: nil,
@@ -91,7 +92,8 @@ final class DDLogHandlerTests: XCTestCase {
         XCTAssertEqual(loggedMsg.message.line, logLine)
         XCTAssertNotNil(loggedMsg.message.swiftLogInfo)
         XCTAssertEqual(loggedMsg.message.swiftLogInfo, .init(logger: .init(label: logger.label,
-                                                                           metadata: logger.handler.metadata),
+                                                                           metadataSources: .init(logger: logger.handler.metadata,
+                                                                                                  provider: logger.metadataProvider?.get())),
                                                              message: .init(message: msg,
                                                                             level: .info,
                                                                             metadata: nil,
@@ -105,7 +107,7 @@ final class DDLogHandlerTests: XCTestCase {
         XCTAssertTrue(logger.handler is DDLogHandler)
         let ddLogHandler = try XCTUnwrap(logger.handler as? DDLogHandler)
         XCTAssertEqual(ddLogHandler.loggerInfo.label, logger.label)
-        XCTAssertTrue(ddLogHandler.loggerInfo.metadata.isEmpty)
+        XCTAssertTrue(ddLogHandler.loggerInfo.metadataSources.logger.isEmpty)
         XCTAssertTrue(ddLogHandler.config.log === DDLog.sharedInstance)
         XCTAssertEqual(ddLogHandler.config.syncLogging.tresholdLevel, .error)
         XCTAssertEqual(ddLogHandler.config.syncLogging.metadataKey, DDLogHandler.defaultSynchronousLoggingMetadataKey)
@@ -147,7 +149,8 @@ final class DDLogHandlerTests: XCTestCase {
             XCTAssertEqual(loggedMsg1.message.line, logLine1)
             XCTAssertNotNil(loggedMsg1.message.swiftLogInfo)
             XCTAssertEqual(loggedMsg1.message.swiftLogInfo, .init(logger: .init(label: logger.label,
-                                                                                metadata: logger.handler.metadata),
+                                                                                metadataSources: .init(logger: logger.handler.metadata,
+                                                                                                       provider: logger.metadataProvider?.get())),
                                                                   message: .init(message: "\(level)-msg",
                                                                                  level: level,
                                                                                  metadata: message1Meta,
@@ -163,7 +166,8 @@ final class DDLogHandlerTests: XCTestCase {
             XCTAssertEqual(loggedMsg2.message.line, logLine2)
             XCTAssertNotNil(loggedMsg2.message.swiftLogInfo)
             XCTAssertEqual(loggedMsg2.message.swiftLogInfo, .init(logger: .init(label: logger.label,
-                                                                                metadata: logger.handler.metadata),
+                                                                                metadataSources: .init(logger: logger.handler.metadata,
+                                                                                                       provider: logger.metadataProvider?.get())),
                                                                   message: .init(message: "\(level)-msg-with-sync",
                                                                                  level: level,
                                                                                  metadata: message2Meta,


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Swift-log recently added so-called `MetadataProvider`s. This updates the minimum swift-log version to 1.5.0 and implements the necessary changes to support those new providers. 
