### PR TITLE
Remove workaround for `pod lib lint`

### DIFF
--- a/.github/workflows/validations.yml
+++ b/.github/workflows/validations.yml
@@ -18,13 +18,7 @@ jobs:
         with:
           xcode-version: ^14.1
       - uses: actions/checkout@v3
-      # watchOS is causing problems with the simulator.
-      # TODO: Remove platforms parameter and additional linting step
-      # once the issue is fixed (by either CocoaPods or Apple)
-      # See https://github.com/CocoaPods/CocoaPods/issues/11558
-      - run: pod lib lint --platforms=macos,ios,tvos
-      - run: pod lib lint --platforms=watchos
-        continue-on-error: true
+      - run: pod lib lint
 
   run-danger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`) 🎉

### Pull Request Description

Now we can remove workaround for `pod lib lint` on watchOS simulator.

The original issue was fixed by CocoaPods 1.12.0
See https://github.com/CocoaPods/CocoaPods/pull/11660. 
And `macos-latest` image includes this CocoaPods version.
