### PR TITLE
Adding missing 'void' in function declarations

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1806,7 +1806,7 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
  * want (even if device is locked). Thats why that attribute have to be changed to
  * NSFileProtectionCompleteUntilFirstUserAuthentication.
  */
-BOOL doesAppRunInBackground() {
+BOOL doesAppRunInBackground(void) {
     BOOL answer = NO;
 
     NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];

--- a/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
+++ b/Sources/CocoaLumberjack/Extensions/DDFileLogger+Buffering.m
@@ -41,7 +41,7 @@ static inline NSUInteger p_DDGetDefaultBufferSizeBytesMax(const BOOL max) {
     return max ? kDDMaxBufferSize : kDDDefaultBufferSize;
 }
 
-static NSUInteger DDGetMaxBufferSizeBytes() {
+static NSUInteger DDGetMaxBufferSizeBytes(void) {
     static NSUInteger maxBufferSize = 0;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -50,7 +50,7 @@ static NSUInteger DDGetMaxBufferSizeBytes() {
     return maxBufferSize;
 }
 
-static NSUInteger DDGetDefaultBufferSizeBytes() {
+static NSUInteger DDGetDefaultBufferSizeBytes(void) {
     static NSUInteger defaultBufferSize = 0;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
* Addresses a build warning in Xcode 14.3

### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1338 

### Pull Request Description

Add "void" to function declarations that take no arguments (seems to be a new standard with Xcode 14.3)
