### PR TITLE
Fix warning about cast from Nullable to Nonnull

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1787,13 +1787,19 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
 - (NSComparisonResult)reverseCompareByCreationDate:(DDLogFileInfo *)another {
     __auto_type us = [self creationDate];
     __auto_type them = [another creationDate];
-    return [them compare:us];
+    if (us != nil) {
+        return [them compare:(NSDate * _Nonnull)us];
+    }
+    return NSOrderedSame;
 }
 
 - (NSComparisonResult)reverseCompareByModificationDate:(DDLogFileInfo *)another {
     __auto_type us = [self modificationDate];
     __auto_type them = [another modificationDate];
-    return [them compare:us];
+    if (us != nil) {
+        return [them compare:(NSDate * _Nonnull)us];
+    }
+    return NSOrderedSame;
 }
 
 @end


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

Xcode warns of an implicit cast from Nullable to Nonnull. Indeed, these properties are specified as nullable, and the `-compare:` method accepts a nonnull parameter.