### PR TITLE
Preserve message format in DDLogMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# [3.8.1 - Xcode 14.3 on Feb ??, 2023](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.1)
+# [3.8.1 - Xcode 14.3 on ??, 2023](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tag/3.8.1)
 
 ### Public
 
 - Silence double conversion warnings for 32-bit watchOS (#1320)
 - Enable ALLOW_TARGET_PLATFORM_SPECIALIZATION (#1321)
 - Update to swift-log 1.5.2, implement metadata providers (#1329)
+- Preserve `messageFormat` in `DDLogMessage` (#1347)
 
 ### Internal
 

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDLog.h
@@ -791,6 +791,7 @@ DD_SENDABLE
     // Direct accessors to be used only for performance
     @public
     NSString *_message;
+    NSString *_messageFormat;
     DDLogLevel _level;
     DDLogFlag _flag;
     NSInteger _context;
@@ -798,9 +799,9 @@ DD_SENDABLE
     NSString *_fileName;
     NSString *_function;
     NSUInteger _line;
-    #if DD_LEGACY_MESSAGE_TAG
+#if DD_LEGACY_MESSAGE_TAG
     id _tag __attribute__((deprecated("Use _representedObject instead", "_representedObject")));
-    #endif
+#endif
     id _representedObject;
     DDLogMessageOptions _options;
     NSDate * _timestamp;
@@ -829,6 +830,64 @@ DD_SENDABLE
  * so it makes sense to optimize and skip the unnecessary allocations.
  * However, if you need them to be copied you may use the options parameter to specify this.
  *
+ *  @param messageFormat   the message format
+ *  @param message  the formatted message
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports DDLogMessageCopyFile and DDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                     formatted:(NSString *)message
+                         level:(DDLogLevel)level
+                          flag:(DDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(DDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp NS_DESIGNATED_INITIALIZER;
+
+/**
+ *     Convenience initializer taking a `va_list` as arguments to create the formatted message.
+ *
+ *  @param messageFormat   the message format
+ *  @param messageArgs   the message arguments.
+ *  @param level     the log level
+ *  @param flag      the log flag
+ *  @param context   the context (if any is defined)
+ *  @param file      the current file
+ *  @param function  the current function
+ *  @param line      the current code line
+ *  @param tag       potential tag
+ *  @param options   a bitmask which supports DDLogMessageCopyFile and DDLogMessageCopyFunction.
+ *  @param timestamp the log timestamp
+ *
+ *  @return a new instance of a log message model object
+ */
+- (instancetype)initWithFormat:(NSString *)messageFormat
+                          args:(va_list)messageArgs
+                         level:(DDLogLevel)level
+                          flag:(DDLogFlag)flag
+                       context:(NSInteger)context
+                          file:(NSString *)file
+                      function:(nullable NSString *)function
+                          line:(NSUInteger)line
+                           tag:(nullable id)tag
+                       options:(DDLogMessageOptions)options
+                     timestamp:(nullable NSDate *)timestamp;
+
+/**
+ *  Deprecated initialier. See initWithFormat:args:formatted:level:flag:context:file:function:line:tag:options:timestamp:.
+ *
  *  @param message   the message
  *  @param level     the log level
  *  @param flag      the log flag
@@ -851,16 +910,21 @@ DD_SENDABLE
                            line:(NSUInteger)line
                             tag:(nullable id)tag
                         options:(DDLogMessageOptions)options
-                      timestamp:(nullable NSDate *)timestamp NS_DESIGNATED_INITIALIZER;
+                      timestamp:(nullable NSDate *)timestamp
+__attribute__((deprecated("Use initializer taking unformatted message and args instead", "initWithFormat:formatted:level:flag:context:file:function:line:tag:options:timestamp:")));
 
 /**
  * Read-only properties
  **/
 
 /**
- *  The log message
+ *  The log message.
  */
 @property (readonly, nonatomic) NSString *message;
+/**
+ * The message format. When the deprecated initializer is used, this might be the same as `message`.
+ */
+@property (readonly, nonatomic) NSString *messageFormat;
 @property (readonly, nonatomic) DDLogLevel level;
 @property (readonly, nonatomic) DDLogFlag flag;
 @property (readonly, nonatomic) NSInteger context;

--- a/Sources/CocoaLumberjackSwift/CocoaLumberjack.swift
+++ b/Sources/CocoaLumberjackSwift/CocoaLumberjack.swift
@@ -77,8 +77,210 @@ public func resetDefaultDebugLevel() {
 /// If `true`, all logs (except errors) are logged asynchronously by default.
 public var asyncLoggingEnabled = true
 
+@frozen
+public struct DDLogMessageFormat: ExpressibleByStringInterpolation {
+    public typealias StringLiteralType = String
+
+    @usableFromInline
+    struct Storage {
+        @usableFromInline
+        var format: String
+        @usableFromInline
+        var args: Array<CVarArg>
+
+        @usableFromInline
+        init(format: String, args: Array<CVarArg>) {
+            self.format = format
+            self.args = args
+        }
+    }
+
+    @frozen
+    public struct StringInterpolation: StringInterpolationProtocol {
+        @usableFromInline
+        var storage: Storage
+
+        @inlinable
+        public init(literalCapacity: Int, interpolationCount: Int) {
+            var format = String()
+            format.reserveCapacity(literalCapacity)
+            var args = Array<CVarArg>()
+            args.reserveCapacity(interpolationCount)
+            storage = .init(format: format, args: args)
+        }
+
+        @inlinable
+        public mutating func appendLiteral(_ literal: StringLiteralType) {
+            storage.format.append(literal)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<S: StringProtocol>(_ string: S) {
+            storage.format.append("%@")
+            storage.args.append(String(string))
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: Int8) {
+            storage.format.append("%c")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: UInt8) {
+            storage.format.append("%c")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: Int16) {
+            storage.format.append("%i")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: UInt16) {
+            storage.format.append("%u")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: Int32) {
+            storage.format.append("%li")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: UInt32) {
+            storage.format.append("%lu")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: Int64) {
+            storage.format.append("%lli")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: UInt64) {
+            storage.format.append("%llu")
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: Int) {
+#if arch(arm64) || arch(x86_64)
+            storage.format.append("%lli")
+#else
+            storage.format.append("%li")
+#endif
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ int: UInt) {
+#if arch(arm64) || arch(x86_64)
+            storage.format.append("%llu")
+#else
+            storage.format.append("%lu")
+#endif
+            storage.args.append(int)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ flt: Float) {
+            storage.format.append("%f")
+            storage.args.append(flt)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ dbl: Double) {
+            storage.format.append("%lf")
+            storage.args.append(dbl)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation(_ bool: Bool) {
+            storage.format.append("%i") // bools are printed as ints
+            storage.args.append(bool)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<Convertible: ReferenceConvertible>(_ c: Convertible) {
+            storage.format.append("%@")
+            // This should be safe, sine the compiler should convert it to the reference.
+            storage.args.append(c as? CVarArg ?? c as! Convertible.ReferenceType)
+        }
+
+        @inlinable
+        public mutating func appendInterpolation<Obj: NSObject>(_ o: Obj) {
+            storage.format.append("%@")
+            storage.args.append(o)
+        }
+
+        @_disfavoredOverload
+        public mutating func appendInterpolation(_ any: Any) {
+            appendInterpolation(String(describing: any))
+        }
+    }
+
+    @usableFromInline
+    let storage: Storage
+
+    @inlinable
+    var format: String { storage.format }
+    @inlinable
+    var args: Array<CVarArg> { storage.args }
+
+    @inlinable
+    var formatted: String {
+        String(format: storage.format, arguments: storage.args)
+    }
+
+    @inlinable
+    public init(stringLiteral value: StringLiteralType) {
+        storage = .init(format: value, args: [])
+    }
+
+    @inlinable
+    public init(stringInterpolation: StringInterpolation) {
+        storage = stringInterpolation.storage
+    }
+
+    @inlinable
+    internal init(_formattedMessage: String) {
+        storage = .init(format: _formattedMessage, args: [])
+    }
+}
+
+extension DDLogMessage {
+    @inlinable
+    public convenience init(_ format: DDLogMessageFormat,
+                            level: DDLogLevel,
+                            flag: DDLogFlag,
+                            context: Int = 0,
+                            file: StaticString = #file,
+                            function: StaticString = #function,
+                            line: UInt = #line,
+                            tag: Any? = nil,
+                            timestamp: Date? = nil) {
+        self.init(format: format.format,
+                  formatted: format.formatted,
+                  level: level,
+                  flag: flag,
+                  context: context,
+                  file: String(describing: file),
+                  function: String(describing: function),
+                  line: line,
+                  tag: tag,
+                  options: [.dontCopyMessage],
+                  timestamp: timestamp)
+    }
+}
+
 @inlinable
-public func _DDLogMessage(_ message: @autoclosure () -> Any,
+public func _DDLogMessage(_ messageFormat: @autoclosure () -> DDLogMessageFormat,
                           level: DDLogLevel,
                           flag: DDLogFlag,
                           context: Int,
@@ -91,23 +293,20 @@ public func _DDLogMessage(_ message: @autoclosure () -> Any,
     // The `dynamicLogLevel` will always be checked here (instead of being passed in).
     // We cannot "mix" it with the `DDDefaultLogLevel`, because otherwise the compiler won't strip strings that are not logged.
     if level.rawValue & flag.rawValue != 0 && dynamicLogLevel.rawValue & flag.rawValue != 0 {
-        // Tell the DDLogMessage constructor to copy the C strings that get passed to it.
-        let logMessage = DDLogMessage(message: String(describing: message()),
+        let logMessage = DDLogMessage(messageFormat(),
                                       level: level,
                                       flag: flag,
                                       context: context,
-                                      file: String(describing: file),
-                                      function: String(describing: function),
+                                      file: file,
+                                      function: function,
                                       line: line,
-                                      tag: tag,
-                                      options: [.copyFile, .copyFunction],
-                                      timestamp: nil)
+                                      tag: tag)
         ddlog.log(asynchronous: asynchronous, message: logMessage)
     }
 }
 
 @inlinable
-public func DDLogDebug(_ message: @autoclosure () -> Any,
+public func DDLogDebug(_ message: @autoclosure () -> DDLogMessageFormat,
                        level: DDLogLevel = DDDefaultLogLevel,
                        context: Int = 0,
                        file: StaticString = #file,
@@ -129,7 +328,7 @@ public func DDLogDebug(_ message: @autoclosure () -> Any,
 }
 
 @inlinable
-public func DDLogInfo(_ message: @autoclosure () -> Any,
+public func DDLogInfo(_ message: @autoclosure () -> DDLogMessageFormat,
                       level: DDLogLevel = DDDefaultLogLevel,
                       context: Int = 0,
                       file: StaticString = #file,
@@ -151,7 +350,7 @@ public func DDLogInfo(_ message: @autoclosure () -> Any,
 }
 
 @inlinable
-public func DDLogWarn(_ message: @autoclosure () -> Any,
+public func DDLogWarn(_ message: @autoclosure () -> DDLogMessageFormat,
                       level: DDLogLevel = DDDefaultLogLevel,
                       context: Int = 0,
                       file: StaticString = #file,
@@ -173,7 +372,7 @@ public func DDLogWarn(_ message: @autoclosure () -> Any,
 }
 
 @inlinable
-public func DDLogVerbose(_ message: @autoclosure () -> Any,
+public func DDLogVerbose(_ message: @autoclosure () -> DDLogMessageFormat,
                          level: DDLogLevel = DDDefaultLogLevel,
                          context: Int = 0,
                          file: StaticString = #file,
@@ -195,6 +394,153 @@ public func DDLogVerbose(_ message: @autoclosure () -> Any,
 }
 
 @inlinable
+public func DDLogError(_ message: @autoclosure () -> DDLogMessageFormat,
+                       level: DDLogLevel = DDDefaultLogLevel,
+                       context: Int = 0,
+                       file: StaticString = #file,
+                       function: StaticString = #function,
+                       line: UInt = #line,
+                       tag: Any? = nil,
+                       asynchronous async: Bool = false,
+                       ddlog: DDLog = .sharedInstance) {
+    _DDLogMessage(message(),
+                  level: level,
+                  flag: .error,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: async,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
+public func _DDLogMessage(_ message: @autoclosure () -> Any,
+                          level: DDLogLevel,
+                          flag: DDLogFlag,
+                          context: Int,
+                          file: StaticString,
+                          function: StaticString,
+                          line: UInt,
+                          tag: Any?,
+                          asynchronous: Bool,
+                          ddlog: DDLog) {
+    // This will lead to `messageFormat` and `message` being equal on DDLogMessage,
+    // which is what the legacy initializer of DDLogMessage does as well.
+    _DDLogMessage(.init(_formattedMessage: String(describing: message())),
+                  level: level,
+                  flag: flag,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: asynchronous,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
+public func DDLogDebug(_ message: @autoclosure () -> Any,
+                       level: DDLogLevel = DDDefaultLogLevel,
+                       context: Int = 0,
+                       file: StaticString = #file,
+                       function: StaticString = #function,
+                       line: UInt = #line,
+                       tag: Any? = nil,
+                       asynchronous async: Bool = asyncLoggingEnabled,
+                       ddlog: DDLog = .sharedInstance) {
+    _DDLogMessage(message(),
+                  level: level,
+                  flag: .debug,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: async,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
+public func DDLogInfo(_ message: @autoclosure () -> Any,
+                      level: DDLogLevel = DDDefaultLogLevel,
+                      context: Int = 0,
+                      file: StaticString = #file,
+                      function: StaticString = #function,
+                      line: UInt = #line,
+                      tag: Any? = nil,
+                      asynchronous async: Bool = asyncLoggingEnabled,
+                      ddlog: DDLog = .sharedInstance) {
+    _DDLogMessage(message(),
+                  level: level,
+                  flag: .info,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: async,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
+public func DDLogWarn(_ message: @autoclosure () -> Any,
+                      level: DDLogLevel = DDDefaultLogLevel,
+                      context: Int = 0,
+                      file: StaticString = #file,
+                      function: StaticString = #function,
+                      line: UInt = #line,
+                      tag: Any? = nil,
+                      asynchronous async: Bool = asyncLoggingEnabled,
+                      ddlog: DDLog = .sharedInstance) {
+    _DDLogMessage(message(),
+                  level: level,
+                  flag: .warning,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: async,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
+public func DDLogVerbose(_ message: @autoclosure () -> Any,
+                         level: DDLogLevel = DDDefaultLogLevel,
+                         context: Int = 0,
+                         file: StaticString = #file,
+                         function: StaticString = #function,
+                         line: UInt = #line,
+                         tag: Any? = nil,
+                         asynchronous async: Bool = asyncLoggingEnabled,
+                         ddlog: DDLog = .sharedInstance) {
+    _DDLogMessage(message(),
+                  level: level,
+                  flag: .verbose,
+                  context: context,
+                  file: file,
+                  function: function,
+                  line: line,
+                  tag: tag,
+                  asynchronous: async,
+                  ddlog: ddlog)
+}
+
+@available(*, deprecated, message: "Use an interpolated DDLogMessageFormat instead")
+@inlinable
+@_disfavoredOverload
 public func DDLogError(_ message: @autoclosure () -> Any,
                        level: DDLogLevel = DDDefaultLogLevel,
                        context: Int = 0,

--- a/Sources/CocoaLumberjackSwift/DDAssert.swift
+++ b/Sources/CocoaLumberjackSwift/DDAssert.swift
@@ -30,6 +30,71 @@ import CocoaLumberjackSwiftSupport
  */
 @inlinable
 public func DDAssert(_ condition: @autoclosure () -> Bool,
+                     _ message: @autoclosure () -> DDLogMessageFormat = "",
+                     level: DDLogLevel = DDDefaultLogLevel,
+                     context: Int = 0,
+                     file: StaticString = #file,
+                     function: StaticString = #function,
+                     line: UInt = #line,
+                     tag: Any? = nil,
+                     asynchronous async: Bool = false,
+                     ddlog: DDLog = DDLog.sharedInstance) {
+    if !condition() {
+        DDLogError(message(),
+                   level: level,
+                   context: context,
+                   file: file,
+                   function: function,
+                   line: line,
+                   tag: tag,
+                   asynchronous: async,
+                   ddlog: ddlog)
+        Swift.assertionFailure(message().formatted, file: file, line: line)
+    }
+}
+
+/**
+ * Replacement for Swift's `assertionFailure` function that will output a log message even
+ * when assertions are disabled.
+ *
+ * - Parameters:
+ *   - message: A string to log (using `DDLogError`). The default is an empty string.
+ */
+@inlinable
+public func DDAssertionFailure(_ message: @autoclosure () -> DDLogMessageFormat = "",
+                               level: DDLogLevel = DDDefaultLogLevel,
+                               context: Int = 0,
+                               file: StaticString = #file,
+                               function: StaticString = #function,
+                               line: UInt = #line,
+                               tag: Any? = nil,
+                               asynchronous async: Bool = false,
+                               ddlog: DDLog = DDLog.sharedInstance) {
+    DDLogError(message(),
+               level: level,
+               context: context,
+               file: file,
+               function: function,
+               line: line,
+               tag: tag,
+               asynchronous: async,
+               ddlog: ddlog)
+    Swift.assertionFailure(message().formatted, file: file, line: line)
+}
+
+/**
+ * Replacement for Swift's `assert` function that will output a log message even when assertions
+ * are disabled.
+ *
+ * - Parameters:
+ *   - condition: The condition to test. Unlike `Swift.assert`, `condition` is always evaluated,
+ *     even when assertions are disabled.
+ *   - message: A string to log (using `DDLogError`) if `condition` evaluates to `false`.
+ *     The default is an empty string.
+ */
+@inlinable
+@available(*, deprecated, message: "Use an interpolated message.")
+public func DDAssert(_ condition: @autoclosure () -> Bool,
                      _ message: @autoclosure () -> String = "",
                      level: DDLogLevel = DDDefaultLogLevel,
                      context: Int = 0,
@@ -61,6 +126,7 @@ public func DDAssert(_ condition: @autoclosure () -> Bool,
  *   - message: A string to log (using `DDLogError`). The default is an empty string.
  */
 @inlinable
+@available(*, deprecated, message: "Use an interpolated message.")
 public func DDAssertionFailure(_ message: @autoclosure () -> String = "",
                                level: DDLogLevel = DDDefaultLogLevel,
                                context: Int = 0,

--- a/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
+++ b/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
@@ -122,7 +122,9 @@ final class SwiftLogMessage: DDLogMessage {
                                              metadata: metadata,
                                              source: source))
         let (ddLogLevel, ddLogFlag) = level.ddLogLevelAndFlag
-        super.init(message: String(describing: message),
+        let msg = String(describing: message)
+        super.init(format: msg,
+                   formatted: msg, // We have no chance in retrieving the original format here.
                    level: ddLogLevel,
                    flag: ddLogFlag,
                    context: 0,
@@ -138,14 +140,14 @@ final class SwiftLogMessage: DDLogMessage {
     @usableFromInline
     @available(*, deprecated, renamed: "init(loggerLabel:loggerMetadata:loggerMetadata:message:level:metadata:source:file:function:line:)")
     convenience init(loggerLabel: String,
-         loggerMetadata: Logger.Metadata,
-         message: Logger.Message,
-         level: Logger.Level,
-         metadata: Logger.Metadata?,
-         source: String,
-         file: String,
-         function: String,
-         line: UInt) {
+                     loggerMetadata: Logger.Metadata,
+                     message: Logger.Message,
+                     level: Logger.Level,
+                     metadata: Logger.Metadata?,
+                     source: String,
+                     file: String,
+                     function: String,
+                     line: UInt) {
         self.init(loggerLabel: loggerLabel,
                   loggerMetadata: loggerMetadata,
                   loggerProvidedMetadata: nil,

--- a/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
+++ b/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
@@ -165,7 +165,7 @@ final class DDLogCombineTests: XCTestCase {
                                        "2001/01/01 00:03:20:000  WARNING: this is incorrect"])
     }
     
-    func testQOSNameInstanciation() {
+    func testQOSNameInstantiation() {
         let name = "UI"
         let qos: qos_class_t = {
             switch DDQualityOfServiceName(rawValue: name) {

--- a/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
+++ b/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
@@ -17,6 +17,7 @@
 #if canImport(Combine)
 import XCTest
 import Combine
+import CocoaLumberjack
 @testable import CocoaLumberjackSwift
 
 @available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)

--- a/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
+++ b/Tests/CocoaLumberjackSwiftTests/DDLogCombineTests.swift
@@ -142,26 +142,22 @@ final class DDLogCombineTests: XCTestCase {
             .sink(receiveValue: { receivedValue.append($0) })
             .store(in: &subscriptions)
 
-        subject.send(DDLogMessage(message: "An error occurred",
+        subject.send(DDLogMessage("An error occurred",
                                   level: .all,
                                   flag: .error,
                                   context: 42,
                                   file: "Combine.swift",
                                   function: "PerformFailure",
                                   line: 67,
-                                  tag: nil,
-                                  options: [],
                                   timestamp: Date(timeIntervalSinceReferenceDate: 100)))
 
-        subject.send(DDLogMessage(message: "WARNING: this is incorrect",
+        subject.send(DDLogMessage("WARNING: this is incorrect",
                                   level: .all,
                                   flag: .warning,
                                   context: 23,
                                   file: "Combine.swift",
                                   function: "PerformWarning",
                                   line: 90,
-                                  tag: nil,
-                                  options: [],
                                   timestamp: Date(timeIntervalSinceReferenceDate: 200)))
 
         XCTAssertEqual(receivedValue, ["2001/01/01 00:01:40:000  An error occurred",

--- a/Tests/CocoaLumberjackSwiftTests/DDLogMessageFormatTests.swift
+++ b/Tests/CocoaLumberjackSwiftTests/DDLogMessageFormatTests.swift
@@ -1,0 +1,109 @@
+// Software License Agreement (BSD License)
+//
+// Copyright (c) 2010-2023, Deusty, LLC
+// All rights reserved.
+//
+// Redistribution and use of this software in source and binary forms,
+// with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+//
+// * Neither the name of Deusty nor the names of its contributors may be used
+//   to endorse or promote products derived from this software without specific
+//   prior written permission of Deusty, LLC.
+
+import XCTest
+@testable import CocoaLumberjackSwift
+
+final class DDLogMessageFormatTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+
+    func testMessageFormatCreationWithString() {
+        let str: String = "String"
+        let substr: Substring = "Substring"
+        let format: DDLogMessageFormat = "This is a string: \(str). And this a substring: \(substr)."
+        XCTAssertEqual(format.format, "This is a string: %@. And this a substring: %@.")
+        XCTAssertEqual(format.args.count, 2)
+        XCTAssertEqual(format.args.first as? String, str)
+        XCTAssertEqual(format.args.last as? String, String(substr))
+    }
+
+    func testMessageFormatCreationWithInts() {
+        let int8: Int8 = -7
+        let uint8: UInt8 = 7
+        let int16: Int16 = -42
+        let uint16: UInt16 = 42
+        let int32: Int32 = -472345
+        let uint32: UInt32 = 472345
+        let int64: Int64 = -47234532145
+        let uint64: UInt64 = 47234532145
+        let int: Int = -2345654
+        let uint: UInt = 2345654
+        let format: DDLogMessageFormat = "Int8: \(int8); UInt8: \(uint8); Int16: \(int16); UInt16: \(uint16); Int32: \(int32); UInt32: \(uint32); Int64: \(int64); UInt64: \(uint64); Int: \(int); UInt: \(uint)"
+        XCTAssertEqual(format.format, "Int8: %c; UInt8: %c; Int16: %i; UInt16: %u; Int32: %li; UInt32: %lu; Int64: %lli; UInt64: %llu; Int: %lli; UInt: %llu")
+        XCTAssertEqual(format.args.count, 10)
+        guard format.args.count >= 10 else { return } // prevent crashes
+        XCTAssertEqual(format.args[0] as? Int8, int8)
+        XCTAssertEqual(format.args[1] as? UInt8, uint8)
+        XCTAssertEqual(format.args[2] as? Int16, int16)
+        XCTAssertEqual(format.args[3] as? UInt16, uint16)
+        XCTAssertEqual(format.args[4] as? Int32, int32)
+        XCTAssertEqual(format.args[5] as? UInt32, uint32)
+        XCTAssertEqual(format.args[6] as? Int64, int64)
+        XCTAssertEqual(format.args[7] as? UInt64, uint64)
+        XCTAssertEqual(format.args[8] as? Int, int)
+        XCTAssertEqual(format.args[9] as? UInt, uint)
+    }
+
+    func testMessageFormatCreationWithFloats() {
+        let flt: Float = 42.4344
+        let dbl: Double = 42.1345512
+        let format: DDLogMessageFormat = "Float: \(flt); Double: \(dbl)"
+        XCTAssertEqual(format.format, "Float: %f; Double: %lf")
+        XCTAssertEqual(format.args.count, 2)
+        XCTAssertEqual(format.args.first as? Float, flt)
+        XCTAssertEqual(format.args.last as? Double, dbl)
+    }
+
+    func testMessageFormatCreationWithReferenceConvertibles() {
+        let date = Date()
+        let uuid = UUID()
+        let indexPath = IndexPath(indexes: [1, 2, 3])
+        let format: DDLogMessageFormat = "Date: \(date); UUID: \(uuid); IndexPath: \(indexPath)"
+        XCTAssertEqual(format.format, "Date: %@; UUID: %@; IndexPath: %@")
+        XCTAssertEqual(format.args.count, 3)
+        guard format.args.count >= 3 else { return } // prevent crashes
+        XCTAssertEqual((format.args[0] as? NSDate).map { $0 as Date }, date)
+        XCTAssertEqual((format.args[1] as? NSUUID).map { $0 as UUID }, uuid)
+        XCTAssertEqual((format.args[2] as? NSIndexPath).map { $0 as IndexPath }, indexPath)
+    }
+
+    func testMessageFormatCreationWithNSObjects() {
+        final class TestObject: NSObject {}
+
+        let obj = TestObject()
+        let format: DDLogMessageFormat = "Object: \(obj)"
+        XCTAssertEqual(format.format, "Object: %@")
+        XCTAssertEqual(format.args.count, 1)
+        XCTAssertIdentical(format.args.first as? NSObject, obj)
+    }
+
+    func testMessageFormatCreationWithOtherTypes() {
+        struct TestStruct: CustomStringConvertible {
+            var description: String { "STRUCT DESCRIPTION" }
+        }
+
+        let other = TestStruct()
+        let format: DDLogMessageFormat = "Other: \(other)"
+        XCTAssertEqual(format.format, "Other: %@")
+        XCTAssertEqual(format.args.count, 1)
+        XCTAssertEqual(format.args.first as? String, String(describing: other))
+    }
+}

--- a/Tests/CocoaLumberjackTests/DDContextFilterLogFormatter+DeprecatedTests.m
+++ b/Tests/CocoaLumberjackTests/DDContextFilterLogFormatter+DeprecatedTests.m
@@ -17,7 +17,8 @@
 #import <CocoaLumberjack/DDContextFilterLogFormatter+Deprecated.h>
 
 static DDLogMessage *testLogMessage() {
-    return [[DDLogMessage alloc] initWithMessage:@"test log message"
+    return [[DDLogMessage alloc] initWithFormat:@"test log message"
+                                      formatted:@"test log message"
                                            level:DDLogLevelDebug
                                             flag:DDLogFlagError
                                          context:1

--- a/Tests/CocoaLumberjackTests/DDContextFilterLogFormatterTests.m
+++ b/Tests/CocoaLumberjackTests/DDContextFilterLogFormatterTests.m
@@ -17,7 +17,8 @@
 #import <CocoaLumberjack/DDContextFilterLogFormatter.h>
 
 static DDLogMessage *testLogMessage() {
-    return [[DDLogMessage alloc] initWithMessage:@"test log message"
+    return [[DDLogMessage alloc] initWithFormat:@"test log message"
+                                      formatted:@"test log message"
                                            level:DDLogLevelDebug
                                             flag:DDLogFlagError
                                          context:1

--- a/Tests/CocoaLumberjackTests/DDLogMessageTests.m
+++ b/Tests/CocoaLumberjackTests/DDLogMessageTests.m
@@ -21,91 +21,144 @@
 static NSString * const kDefaultMessage = @"Log message";
 
 @interface DDLogMessage (TestHelpers)
-+ (DDLogMessage *)test_message;
-+ (DDLogMessage *)test_messageWithMessage:(NSString *)message;
-+ (DDLogMessage *)test_messageWithFunction:(NSString *)function options:(DDLogMessageOptions)options;
-+ (DDLogMessage *)test_messageWithFile:(NSString *)file options:(DDLogMessageOptions)options;
+- (instancetype)initWithNoArgsMessage:(NSString *)message
+                                level:(DDLogLevel)level
+                                 flag:(DDLogFlag)flag
+                              context:(NSInteger)context
+                                 file:(NSString *)file
+                             function:(nullable NSString *)function
+                                 line:(NSUInteger)line
+                                  tag:(nullable id)tag
+                              options:(DDLogMessageOptions)options
+                            timestamp:(nullable NSDate *)timestamp;
++ (instancetype)test_message;
++ (instancetype)test_messageWithMessage:(NSString *)message;
++ (instancetype)test_messageWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
++ (instancetype)test_messageWithFunction:(NSString *)function options:(DDLogMessageOptions)options;
++ (instancetype)test_messageWithFile:(NSString *)file options:(DDLogMessageOptions)options;
 @end
 
 @implementation DDLogMessage (TestHelpers)
-+ (DDLogMessage *)test_message {
-    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:@(__FILE__)
-                                        function:@(__func__)
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:(DDLogMessageOptions)0
-                                       timestamp:nil];
+- (instancetype)initWithNoArgsMessage:(NSString *)message
+                                level:(DDLogLevel)level
+                                 flag:(DDLogFlag)flag
+                              context:(NSInteger)context
+                                 file:(NSString *)file
+                             function:(nullable NSString *)function
+                                 line:(NSUInteger)line
+                                  tag:(nullable id)tag
+                              options:(DDLogMessageOptions)options
+                            timestamp:(nullable NSDate *)timestamp {
+    self = [self initWithFormat:message
+                      formatted:message
+                          level:level
+                           flag:flag
+                        context:context
+                           file:file
+                       function:function
+                           line:line
+                            tag:tag
+                        options:options
+                      timestamp:timestamp];
+    return self;
 }
 
-+ (DDLogMessage *)test_messageWithMessage:(NSString *)message {
-    return [[DDLogMessage alloc] initWithMessage:message
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:@(__FILE__)
-                                        function:@(__func__)
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:(DDLogMessageOptions)0
-                                       timestamp:nil];
++ (instancetype)test_message {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:@(__FILE__)
+                                              function:@(__func__)
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:(DDLogMessageOptions)0
+                                             timestamp:nil];
 }
 
-+ (DDLogMessage *)test_messageWithFunction:(NSString *)function
-                                   options:(DDLogMessageOptions)options {
-    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:@(__FILE__)
-                                        function:function
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:options
-                                       timestamp:nil];
++ (instancetype)test_messageWithMessage:(NSString *)message {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:message
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:@(__FILE__)
+                                              function:@(__func__)
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:(DDLogMessageOptions)0
+                                             timestamp:nil];
 }
 
-+ (DDLogMessage *)test_messageWithWithoutFunction {
-    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:@(__FILE__)
-                                        function:nil
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:(DDLogMessageOptions)0
-                                       timestamp:nil];
++ (instancetype)test_messageWithFormat:(NSString *)format, ... {
+    va_list args;
+    va_start(args, format);
+    __auto_type msg = [[DDLogMessage alloc] initWithFormat:format
+                                                      args:args
+                                                     level:DDLogLevelDebug
+                                                      flag:DDLogFlagError
+                                                   context:1
+                                                      file:@(__FILE__)
+                                                  function:@(__func__)
+                                                      line:__LINE__
+                                                       tag:NULL
+                                                   options:(DDLogMessageOptions)0
+                                                 timestamp:nil];
+    va_end(args);
+    return msg;
 }
 
-+ (DDLogMessage *)test_messageWithFile:(NSString *)file
-                               options:(DDLogMessageOptions)options {
-    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:file
-                                        function:@(__func__)
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:options
-                                       timestamp:nil];
++ (instancetype)test_messageWithFunction:(NSString *)function
+                                 options:(DDLogMessageOptions)options {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:@(__FILE__)
+                                              function:function
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:options
+                                             timestamp:nil];
 }
 
-+ (DDLogMessage *)test_messageWithTimestamp:(NSDate *)timestamp {
-    return [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                           level:DDLogLevelDebug
-                                            flag:DDLogFlagError
-                                         context:1
-                                            file:@(__FILE__)
-                                        function:@(__func__)
-                                            line:__LINE__
-                                             tag:NULL
-                                         options:(DDLogMessageOptions)0
-                                       timestamp:timestamp];
++ (instancetype)test_messageWithWithoutFunction {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:@(__FILE__)
+                                              function:nil
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:(DDLogMessageOptions)0
+                                             timestamp:nil];
+}
+
++ (instancetype)test_messageWithFile:(NSString *)file
+                             options:(DDLogMessageOptions)options {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:file
+                                              function:@(__func__)
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:options
+                                             timestamp:nil];
+}
+
++ (instancetype)test_messageWithTimestamp:(NSDate *)timestamp {
+    return [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                 level:DDLogLevelDebug
+                                                  flag:DDLogFlagError
+                                               context:1
+                                                  file:@(__FILE__)
+                                              function:@(__func__)
+                                                  line:__LINE__
+                                                   tag:NULL
+                                               options:(DDLogMessageOptions)0
+                                             timestamp:timestamp];
 }
 
 @end
@@ -131,17 +184,16 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testInitSetsAllPassedParameters {
     __auto_type referenceDate = [NSDate dateWithTimeIntervalSince1970:0];
-    self.message =
-        [[DDLogMessage alloc] initWithMessage:kDefaultMessage
-                                        level:DDLogLevelDebug
-                                         flag:DDLogFlagError
-                                      context:1
-                                         file:@"DDLogMessageTests.m"
-                                     function:@"testInitSetsAllPassedParameters"
-                                         line:50
-                                          tag:NULL
-                                         options:DDLogMessageCopyFile
-                                         timestamp:referenceDate];
+    self.message = [[DDLogMessage alloc] initWithNoArgsMessage:kDefaultMessage
+                                                         level:DDLogLevelDebug
+                                                          flag:DDLogFlagError
+                                                       context:1
+                                                          file:@"DDLogMessageTests.m"
+                                                      function:@"testInitSetsAllPassedParameters"
+                                                          line:50
+                                                           tag:NULL
+                                                       options:DDLogMessageCopyFile
+                                                     timestamp:referenceDate];
     XCTAssertEqualObjects(self.message.message, @"Log message");
     XCTAssertEqual(self.message.level, DDLogLevelDebug);
     XCTAssertEqual(self.message.flag, DDLogFlagError);
@@ -156,6 +208,12 @@ static NSString * const kDefaultMessage = @"Log message";
 #pragma clang diagnostic pop
     XCTAssertEqual(self.message.options, DDLogMessageCopyFile);
     XCTAssertEqualObjects(self.message.timestamp, referenceDate);
+}
+
+- (void)testFormatPreserved {
+    self.message = [DDLogMessage test_messageWithFormat:@"Formatted with this %@ and this %d", @"Arg1", 42];
+    XCTAssertEqualObjects(self.message.message, @"Formatted with this Arg1 and this 42");
+    XCTAssertEqualObjects(self.message.messageFormat, @"Formatted with this %@ and this %d");
 }
 
 - (void)testInitCopyMessageParameter {
@@ -230,6 +288,7 @@ static NSString * const kDefaultMessage = @"Log message";
 
 - (void)testCopyWithZoneCreatesValidCopy {
     __auto_type copy = (typeof(self.message))[self.message copy];
+    XCTAssertEqualObjects(self.message.messageFormat, copy.messageFormat);
     XCTAssertEqualObjects(self.message.message, copy.message);
     XCTAssertEqual(self.message.level, copy.level);
     XCTAssertEqual(self.message.flag, copy.flag);

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07C15C512A5D677D00AF3B5B /* DDLogMessageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C15C4F2A5D677D00AF3B5B /* DDLogMessageFormatTests.swift */; };
 		0A0ED26322CEAB290037739B /* DDSampleFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A55DA2D22CE962B00686977 /* DDSampleFileManager.m */; };
 		0A55DA2E22CE962B00686977 /* DDSampleFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A55DA2D22CE962B00686977 /* DDSampleFileManager.m */; };
 		0A7D8FD4217A1E9800B496D7 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7D8FD0217A1E9000B496D7 /* CocoaLumberjack.framework */; };
@@ -76,6 +77,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		07C15C4F2A5D677D00AF3B5B /* DDLogMessageFormatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DDLogMessageFormatTests.swift; sourceTree = "<group>"; };
 		0A55DA2D22CE962B00686977 /* DDSampleFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DDSampleFileManager.m; sourceTree = "<group>"; };
 		0A55DA2F22CE962F00686977 /* DDSampleFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDSampleFileManager.h; sourceTree = "<group>"; };
 		0A7D8FC7217A1E9000B496D7 /* Lumberjack.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Lumberjack.xcodeproj; path = ../Lumberjack.xcodeproj; sourceTree = "<group>"; };
@@ -205,6 +207,7 @@
 			isa = PBXGroup;
 			children = (
 				4C4A367A243C418600410EF0 /* DDLogCombineTests.swift */,
+				07C15C4F2A5D677D00AF3B5B /* DDLogMessageFormatTests.swift */,
 			);
 			path = CocoaLumberjackSwiftTests;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4C4A3686243C48DB00410EF0 /* DDLogCombineTests.swift in Sources */,
+				07C15C512A5D677D00AF3B5B /* DDLogMessageFormatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Tests.xcodeproj/project.pbxproj
+++ b/Tests/Tests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		07C15C512A5D677D00AF3B5B /* DDLogMessageFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C15C4F2A5D677D00AF3B5B /* DDLogMessageFormatTests.swift */; };
+		07C15C552A5D83C000AF3B5B /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7D8FD0217A1E9000B496D7 /* CocoaLumberjack.framework */; };
 		0A0ED26322CEAB290037739B /* DDSampleFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A55DA2D22CE962B00686977 /* DDSampleFileManager.m */; };
 		0A55DA2E22CE962B00686977 /* DDSampleFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A55DA2D22CE962B00686977 /* DDSampleFileManager.m */; };
 		0A7D8FD4217A1E9800B496D7 /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7D8FD0217A1E9000B496D7 /* CocoaLumberjack.framework */; };
@@ -16,7 +17,7 @@
 		0A7E1D58217A86EF0011CFEB /* DDSMocking.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A7E1D56217A7A380011CFEB /* DDSMocking.m */; };
 		0AA9B47321CC0AE60036182F /* DDFileLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA9B47221CC0AE60036182F /* DDFileLoggerTests.m */; };
 		0AA9B47721CC0B060036182F /* DDFileLoggerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AA9B47221CC0AE60036182F /* DDFileLoggerTests.m */; };
-		4C4A3683243C463F00410EF0 /* CocoaLumberjackSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7D8FD2217A1E9000B496D7 /* CocoaLumberjackSwift.framework */; platformFilters = (ios, maccatalyst, macos, ); };
+		4C4A3683243C463F00410EF0 /* CocoaLumberjackSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A7D8FD2217A1E9000B496D7 /* CocoaLumberjackSwift.framework */; };
 		4C4A3686243C48DB00410EF0 /* DDLogCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C4A367A243C418600410EF0 /* DDLogCombineTests.swift */; };
 		6ECBFDB721E9A31500CBB679 /* DDFileLoggerPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ECBFDB321E9A31500CBB679 /* DDFileLoggerPerformanceTests.m */; };
 		6ECBFDB821E9A3BC00CBB679 /* DDFileLoggerPerformanceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ECBFDB321E9A31500CBB679 /* DDFileLoggerPerformanceTests.m */; };
@@ -124,6 +125,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				07C15C552A5D83C000AF3B5B /* CocoaLumberjack.framework in Frameworks */,
 				4C4A3683243C463F00410EF0 /* CocoaLumberjackSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: fixes #1346 

### Pull Request Description

This adds a new `messageFormat` property to `DDLogMessage`. While more or less trivial to implement in Objective-C, in Swift a new `DDLogMessageFormat` type was introduced, that composes the C-Format from an interpolation.
It should result in the same messages as before - just with the format being generated as well.

Since it's impossible to generate an `NSArray` from a `va_list`'s elements (without knowing the types inside the `va_list`), we currently cannot persist the format arguments in `DDLogMessage`. The Swift version would actually be able to do this (due to collecting the args as well).
However, due to possible side effects (objects living longer than they should, not being thread-safe), I've opted to not implement this in Swift either. The collected args are only used to generate the message.
