### PR TITLE
Replace %s with modern Objective-C string creation

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1737,15 +1737,15 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
 
     if (result < 0) {
         if (errno != ENOENT) {
-            NSLogError(@"DDLogFileInfo: setxattr(%@, %@): error = %s",
+            NSLogError(@"DDLogFileInfo: setxattr(%@, %@): error = %@",
                        attrName,
                        filePath,
-                       strerror(errno));
+                       @(strerror(errno)));
         } else {
-            NSLogDebug(@"DDLogFileInfo: File does not exist in setxattr(%@, %@): error = %s",
+            NSLogDebug(@"DDLogFileInfo: File does not exist in setxattr(%@, %@): error = %@",
                        attrName,
                        filePath,
-                       strerror(errno));
+                       @(strerror(errno)));
         }
     }
 #if TARGET_IPHONE_SIMULATOR
@@ -1762,10 +1762,10 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
     int result = removexattr(path, name, 0);
 
     if (result < 0 && errno != ENOATTR) {
-        NSLogError(@"DDLogFileInfo: removexattr(%@, %@): error = %s",
+        NSLogError(@"DDLogFileInfo: removexattr(%@, %@): error = %@",
                    attrName,
                    self.fileName,
-                   strerror(errno));
+                   @(strerror(errno)));
     }
 
 #if TARGET_IPHONE_SIMULATOR

--- a/Sources/CocoaLumberjack/DDLog.m
+++ b/Sources/CocoaLumberjack/DDLog.m
@@ -974,13 +974,13 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
 #pragma clang diagnostic pop
 #endif
         _options      = options;
-        _timestamp    = timestamp ?: [NSDate new];
+        _timestamp    = timestamp ?: [NSDate date];
 
         __uint64_t tid;
         if (pthread_threadid_np(NULL, &tid) == 0) {
             _threadID = [[NSString alloc] initWithFormat:@"%llu", tid];
         } else {
-            _threadID = @"missing threadId";
+            _threadID = @"N/A";
         }
         _threadName   = NSThread.currentThread.name;
 
@@ -993,7 +993,7 @@ NSString * __nullable DDExtractFileNameWithoutExtension(const char *filePath, BO
         }
 
         // Try to get the current queue's label
-        _queueLabel = [[NSString alloc] initWithFormat:@"%s", dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL)];
+        _queueLabel = @(dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL));
         _qos = (NSUInteger) qos_class_self();
     }
     return self;

--- a/Sources/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
+++ b/Sources/CocoaLumberjack/Extensions/DDDispatchQueueLogFormatter.m
@@ -216,7 +216,7 @@ static DDQualityOfServiceName _qos_name(NSUInteger qos) {
         memset(spaces, ' ', numSpaces);
         spaces[numSpaces] = '\0';
 
-        return [NSString stringWithFormat:@"%@%s", queueThreadLabel, spaces];
+        return [queueThreadLabel stringByAppendingString:@(spaces)];
     } else {
         // Exact
 

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAssertMacros.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDAssertMacros.h
@@ -22,7 +22,7 @@
             DDLogError(@"%@", description);                                           \
             NSAssert(NO, @"%@", description);                                         \
         }
-#define DDAssertCondition(condition) DDAssert(condition, @"Condition not satisfied: %s", #condition)
+#define DDAssertCondition(condition) DDAssert(condition, @"Condition not satisfied: %@", @(#condition))
 
 /**
  * Analog to `DDAssertionFailure` from DDAssert.swift for use in Objective C


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)


### Pull Request Description

[Apple's String Format docs](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW1) recommend avoiding `%s` whenever possible:
<img width="1234" alt="image" src="https://github.com/CocoaLumberjack/CocoaLumberjack/assets/1689782/ba551f5b-4717-4a49-b8e7-d0db93bccfb4">

I've also seen it cause issues when the underlying C-String has strange memory management. Using `@()` instead should solve that.
