### PR TITLE
Fix app background-mode not correctly detected in app extensions

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1819,6 +1819,10 @@ static NSString *_xattrToExtensionName(NSString *attrName) {
  * NSFileProtectionCompleteUntilFirstUserAuthentication.
  */
 BOOL doesAppRunInBackground(void) {
+    if ([[[NSBundle mainBundle] executablePath] containsString:@".appex/"]) {
+        return YES;
+    }
+
     BOOL answer = NO;
 
     NSArray *backgroundModes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIBackgroundModes"];


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1358
