### PR TITLE
Fix DDFileLogger rollingFrequency and maximumFileSize not being honored

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -703,7 +703,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     dispatch_block_t block = ^{
         @autoreleasepool {
             self->_maximumFileSize = newMaximumFileSize;
-            if (self->_currentLogFileHandle != nil || [self lt_currentLogFileHandle] != nil) {
+            if (self->_currentLogFileHandle != nil) {
                 [self lt_maybeRollLogFileDueToSize];
             }
         }
@@ -762,7 +762,7 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
     dispatch_block_t block = ^{
         @autoreleasepool {
             self->_rollingFrequency = newRollingFrequency;
-            if (self->_currentLogFileHandle != nil || [self lt_currentLogFileHandle] != nil) {
+            if (self->_currentLogFileHandle != nil) {
                 [self lt_maybeRollLogFileDueToAge];
             }
         }


### PR DESCRIPTION
@ffried Since you opted for removing the lt_currentLogFileHandle, here is my PR to fix #1357

### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1357

### Pull Request Description

...
