### PR TITLE
Allow different binary formats for DDFileLogger

### DIFF
--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -48,6 +48,32 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+
+/// The serializer is responsible for turning a log message into binary for writing into a file.
+/// It allows storing log messages in a non-text format.
+/// The serialier should not be used for filtering or formatting messages!
+/// Also, it must be fast!
+@protocol DDFileLogMessageSerializer <NSObject>
+@required
+
+/// Returns the binary representation of the message.
+/// - Parameter message: The formatted log message to serialize.
+- (NSData *)dataForMessage:(NSString *)message;
+
+@end
+
+/// The plain text (default) message serializer.
+@interface DDFileLogPlainTextMessageSerializer : NSObject <DDFileLogMessageSerializer>
+
+- (instancetype)init;
+
+@end
+
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+#pragma mark -
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 /**
  *  The LogFileManager protocol is designed to allow you to control all aspects of your log files.
  *
@@ -151,6 +177,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 - (nullable NSString *)createNewLogFileWithError:(NSError **)error;
 
 @optional
+
+/// The log message serializer.
+@property (nonatomic, readonly, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
 
 // Private methods (only to be used by DDFileLogger)
 /**
@@ -275,6 +304,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
  * you can set the initial log file contents by overriding `logFileHeader`
  **/
 @property (readonly, copy, nullable) NSString *logFileHeader;
+
+/// The log message serializer.
+@property (nonatomic, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
 
 /* Inherited from DDLogFileManager protocol:
 

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -58,11 +58,19 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 /// Returns the binary representation of the message.
 /// - Parameter message: The formatted log message to serialize.
-- (NSData *)dataForMessage:(NSString *)message;
+//
+
+/// Returns the binary representation of the message.
+/// - Parameters:
+///   - string: The string to serialize. Usually, this is the formatted message, but it can also be e.g. a log file header.
+///   - message: The message which represents the `string`. This is null, if `string` is e.g. a log file header.
+/// - Note: The `message` parameter should not be used for formatting! It should simply be used to extract the necessary metadata for serializing.
+- (NSData *)dataForString:(NSString *)string
+   originatingFromMessage:(nullable DDLogMessage *)message NS_SWIFT_NAME(dataForString(_:originatingFrom:));
 
 @end
 
-/// The plain text (default) message serializer.
+/// The (default) plain text message serializer.
 @interface DDFileLogPlainTextMessageSerializer : NSObject <DDFileLogMessageSerializer>
 
 - (instancetype)init;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1371  

### Pull Request Description

This adds a new `logMessageSerializer` property to the `DDLogFileManager` protocol. The serializer is of a new protocol `DDFileLogMessageSerializer` type that defines only one method `-dataForMessage:`. This type can be used to change the binary representation of messages in log files.

By default, the `DDFileLogPlainTextMessageSerializer` is used, that serializes messages in UTF-8 plain text (just as the file logger did internally up until today).