### PR TITLE
Improve DDOSLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [3.8.5 - Xcode 15.2 on Feb ??, 2024](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tags/3.8.5)
+
+### Public
+
+- Fix build failure due to privacy manifest when using static linking with CocoaPods (#1408)
+- Allow custom mapping of `DDLogFlag` to `os_log_type_t`, fix default mapping for `DDLogFlagWarn` (#1410)
+
+
 # [3.8.4 - Xcode 15.2 on Feb 8th, 2024](https://github.com/CocoaLumberjack/CocoaLumberjack/releases/tags/3.8.4)
 
 ### Public

--- a/Sources/CocoaLumberjack/DDOSLogger.m
+++ b/Sources/CocoaLumberjack/DDOSLogger.m
@@ -25,8 +25,8 @@
     return self;
 }
 
-- (os_log_type_t)osLogTypeForLogMessageFlag:(DDLogFlag)logMessageFlag {
-    switch (logMessageFlag) {
+- (os_log_type_t)osLogTypeForLogFlag:(DDLogFlag)logFlag {
+    switch (logFlag) {
         case DDLogFlagError:
         case DDLogFlagWarning:
             return OS_LOG_TYPE_ERROR;
@@ -45,8 +45,8 @@
 #if TARGET_OS_SIMULATOR
 @implementation DDOSLogLevelMapperSimulatorConsoleAppWorkaround
 
-- (os_log_type_t)osLogTypeForLogMessageFlag:(DDLogFlag)logMessageFlag {
-    __auto_type defaultMapping = [super osLogTypeForLogMessageFlag:logMessageFlag];
+- (os_log_type_t)osLogTypeForLogFlag:(DDLogFlag)logFlag {
+    __auto_type defaultMapping = [super osLogTypeForLogFlag:logFlag];
     return (defaultMapping == OS_LOG_TYPE_DEBUG) ? OS_LOG_TYPE_DEFAULT : defaultMapping;
 }
 
@@ -149,7 +149,7 @@ static DDOSLogger *sharedInstance;
     if (@available(iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0, *)) {
         __auto_type message = _logFormatter ? [_logFormatter formatLogMessage:logMessage] : logMessage->_message;
         if (message != nil) {
-            __auto_type logType = [self.logLevelMapper osLogTypeForLogMessageFlag:logMessage->_flag];
+            __auto_type logType = [self.logLevelMapper osLogTypeForLogFlag:logMessage->_flag];
             os_log_with_type(self.logger, logType, "%{public}s", message.UTF8String);
         }
     }

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
@@ -13,7 +13,9 @@
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
+#import <TargetConditionals.h>
 #import <Foundation/Foundation.h>
+#import <os/log.h>
 
 // Disable legacy macros
 #ifndef DD_LEGACY_MACROS
@@ -24,32 +26,80 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-/**
- * This class provides a logger for the Apple os_log facility.
- **/
+/// Describes a type that maps CocoaLumberjack log levels to os\_log levels (`os_log_type_t`).
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+DD_SENDABLE
+@protocol DDOSLogLevelMapper <NSObject>
+
+/// Maps the given `DDLogFlag` to a `os_log_type_t`.
+/// - Parameter logMessageFlag: `DDLogFlag` with which the message was logged.
+- (os_log_type_t)osLogTypeForLogMessageFlag:(DDLogFlag)logMessageFlag;
+
+@end
+
+/// The default os\_log level mapper.
+/// Uses the following mapping:
+/// - `DDLogFlagError` -> `OS_LOG_TYPE_ERROR`
+/// - `DDLogFlagWarning` -> `OS_LOG_TYPE_ERROR`
+/// - `DDLogFlagInfo` -> `OS_LOG_TYPE_INFO`
+/// - `DDLogFlagDebug` -> `OS_LOG_TYPE_DEBUG`
+/// - `DDLogFlagVerbose` -> `OS_LOG_TYPE_DEBUG`
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+DD_SENDABLE
+@interface DDOSLogLevelMapperDefault : NSObject <DDOSLogLevelMapper>
+
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
+
+@end
+
+#if TARGET_OS_SIMULATOR
+/// An os\_log level mapper that works around the fact that `OS_LOG_TYPE_DEBUG` messages logged in the simulator do not show up in the Console.app.
+/// Performs the same mapping as ``DDOSLogLevelMapperDefault``, except that `OS_LOG_TYPE_DEBUG` is raised to `OS_LOG_TYPE_DEFAULT`.
+/// See [this thread](https://developer.apple.com/forums/thread/82736?answerId=761544022#761544022) in the Apple Developer Forums.
+API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
+DD_SENDABLE
+@interface DDOSLogLevelMapperSimulatorConsoleAppWorkaround : DDOSLogLevelMapperDefault
+@end
+#endif
+
+/// This class provides a logger for the Apple os\_log facility.
 API_AVAILABLE(macos(10.12), ios(10.0), watchos(3.0), tvos(10.0))
 DD_SENDABLE
 @interface DDOSLogger : DDAbstractLogger <DDLogger>
 
-/**
- *  Singleton method
- *
- *  @return the shared instance with OS_LOG_DEFAULT.
- */
+/// The shared instance using `OS_LOG_DEFAULT`.
 @property (nonatomic, class, readonly, strong) DDOSLogger *sharedInstance;
 
-/**
- Designated initializer
- 
- @param subsystem Desired subsystem in log. E.g. "org.example"
- @param category Desired category in log. E.g. "Point of interests."
- @return New instance of DDOSLogger.
- 
- @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
- If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
- If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
- */
-- (instancetype)initWithSubsystem:(nullable NSString *)subsystem category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
+/// The log level mapper, that maps ``DDLogFlag``s to ``os_log_type_t`` for this logger.
+@property (nonatomic, strong, readonly) id<DDOSLogLevelMapper> logLevelMapper;
+
+/// The designated initializer, using `DDOSLogLevelMapperDefault`.
+/// @param subsystem Desired subsystem in log. E.g. "org.example"
+/// @param category Desired category in log. E.g. "Point of interests."
+/// @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+///             If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+///             If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`.
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem 
+                         category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
+
+/// Creates an instance that uses `OS_LOG_DEFAULT` and `DDOSLogLevelMapperDefault`.
+- (instancetype)init;
+
+/// An initializer that in addition to subsystem and category also allows providing the log level mapper.
+/// @param subsystem Desired subsystem in log. E.g. "org.example"
+/// @param category Desired category in log. E.g. "Point of interests."
+/// @param logLevelMapper The log level mapper to use.
+/// @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+///             If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+///             If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem
+                         category:(nullable NSString *)category
+                   logLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper;
+// FIXME: This should actually be the designated initializer, but that would be a breaking change. Adjust in next version bump.
+
+/// Creates an instance that uses `OS_LOG_DEFAULT`.
+/// @param logLevelMapper The log level mapper to use.
+- (instancetype)initWithLogLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper;
 
 @end
 

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
@@ -32,8 +32,8 @@ DD_SENDABLE
 @protocol DDOSLogLevelMapper <NSObject>
 
 /// Maps the given `DDLogFlag` to a `os_log_type_t`.
-/// - Parameter logMessageFlag: `DDLogFlag` with which the message was logged.
-- (os_log_type_t)osLogTypeForLogMessageFlag:(DDLogFlag)logMessageFlag;
+/// - Parameter logFlag: `DDLogFlag` for which to return the os log type.
+- (os_log_type_t)osLogTypeForLogFlag:(DDLogFlag)logFlag;
 
 @end
 

--- a/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
+++ b/Sources/CocoaLumberjackSwiftLogBackend/DDLogHandler.swift
@@ -16,7 +16,7 @@
 import CocoaLumberjack
 import Logging
 
-extension Logger.Level {
+extension Logging.Logger.Level {
     @inlinable
     var ddLogLevelAndFlag: (DDLogLevel, DDLogFlag) {
         switch self {
@@ -38,9 +38,9 @@ extension DDLogMessage {
             /// Currently this can be the logger itself, as well as its metadata provider
             public struct MetadataSources: Equatable, Sendable {
                 /// The metadata of the swift-log logger that logged this message.
-                public let logger: Logger.Metadata
+                public let logger: Logging.Logger.Metadata
                 /// The metadata of the metadata provider on the swift-log logger that logged this message.
-                public let provider: Logger.Metadata?
+                public let provider: Logging.Logger.Metadata?
             }
 
             /// The label of the swift-log logger that logged this message.
@@ -50,17 +50,17 @@ extension DDLogMessage {
 
             /// The metadata of the swift-log logger that logged this message.
             @available(*, deprecated, renamed: "metadataSources.logger")
-            public var metadata: Logger.Metadata { metadataSources.logger }
+            public var metadata: Logging.Logger.Metadata { metadataSources.logger }
         }
 
         /// Contains information about the swift-log message thas was logged.
         public struct MessageInformation: Equatable, Sendable {
             /// The original swift-log message.
-            public let message: Logger.Message
+            public let message: Logging.Logger.Message
             /// The original swift-log level of the message. This could be more fine-grained than `DDLogMessage.level` & `DDLogMessage.flag`.
-            public let level: Logger.Level
+            public let level: Logging.Logger.Level
             /// The original swift-log metadata of the message.
-            public let metadata: Logger.Metadata?
+            public let metadata: Logging.Logger.Metadata?
             /// The original swift-log source of the message.
             public let source: String
         }
@@ -76,7 +76,7 @@ extension DDLogMessage {
         /// Metadata from the logged message again trumps both the base and the metadata from the logger's metadata provider.
         /// Essentially: `logger.metadata < logger.metadataProvider < message.metadata`
         /// - Note: Accessing this property performs the merge! Accessing it multiple times can be a performance issue!
-        public var mergedMetadata: Logger.Metadata {
+        public var mergedMetadata: Logging.Logger.Metadata {
             var merged = logger.metadataSources.logger
             if let providerMetadata = logger.metadataSources.provider {
                 merged.merge(providerMetadata, uniquingKeysWith: { $1 })
@@ -105,11 +105,11 @@ final class SwiftLogMessage: DDLogMessage {
 
     @usableFromInline
     init(loggerLabel: String,
-         loggerMetadata: Logger.Metadata,
-         loggerProvidedMetadata: Logger.Metadata?,
-         message: Logger.Message,
-         level: Logger.Level,
-         metadata: Logger.Metadata?,
+         loggerMetadata: Logging.Logger.Metadata,
+         loggerProvidedMetadata: Logging.Logger.Metadata?,
+         message: Logging.Logger.Message,
+         level: Logging.Logger.Level,
+         metadata: Logging.Logger.Metadata?,
          source: String,
          file: String,
          function: String,
@@ -140,10 +140,10 @@ final class SwiftLogMessage: DDLogMessage {
     @usableFromInline
     @available(*, deprecated, renamed: "init(loggerLabel:loggerMetadata:loggerMetadata:message:level:metadata:source:file:function:line:)")
     convenience init(loggerLabel: String,
-                     loggerMetadata: Logger.Metadata,
-                     message: Logger.Message,
-                     level: Logger.Level,
-                     metadata: Logger.Metadata?,
+                     loggerMetadata: Logging.Logger.Metadata,
+                     message: Logging.Logger.Message,
+                     level: Logging.Logger.Level,
+                     metadata: Logging.Logger.Metadata?,
                      source: String,
                      file: String,
                      function: String,
@@ -172,9 +172,9 @@ public struct DDLogHandler: LogHandler {
         @usableFromInline
         struct SyncLogging: Sendable {
             @usableFromInline
-            let tresholdLevel: Logger.Level
+            let tresholdLevel: Logging.Logger.Level
             @usableFromInline
-            let metadataKey: Logger.Metadata.Key
+            let metadataKey: Logging.Logger.Metadata.Key
         }
 
         @usableFromInline
@@ -188,22 +188,22 @@ public struct DDLogHandler: LogHandler {
         @usableFromInline
         struct MetadataSources: Sendable {
             @usableFromInline
-            var provider: Logger.MetadataProvider?
+            var provider: Logging.Logger.MetadataProvider?
             @usableFromInline
-            var logger: Logger.Metadata = [:]
+            var logger: Logging.Logger.Metadata = [:]
         }
 
         @usableFromInline
         let label: String
         @usableFromInline
-        var logLevel: Logger.Level
+        var logLevel: Logging.Logger.Level
         @usableFromInline
         var metadataSources: MetadataSources
 
         // Not removed due to `@usableFromInline`
         @usableFromInline
         @available(*, deprecated, renamed: "metadataSources.logger")
-        var metadata: Logger.Metadata {
+        var metadata: Logging.Logger.Metadata {
             get { metadataSources.logger }
             set { metadataSources.logger = newValue }
         }
@@ -215,23 +215,23 @@ public struct DDLogHandler: LogHandler {
     var loggerInfo: LoggerInfo
 
     @inlinable
-    public var logLevel: Logger.Level {
+    public var logLevel: Logging.Logger.Level {
         get { loggerInfo.logLevel }
         set { loggerInfo.logLevel = newValue }
     }
     @inlinable
-    public var metadataProvider: Logger.MetadataProvider? {
+    public var metadataProvider: Logging.Logger.MetadataProvider? {
         get { loggerInfo.metadataSources.provider }
         set { loggerInfo.metadataSources.provider = newValue }
     }
     @inlinable
-    public var metadata: Logger.Metadata {
+    public var metadata: Logging.Logger.Metadata {
         get { loggerInfo.metadataSources.logger }
         set { loggerInfo.metadataSources.logger = newValue }
     }
 
     @inlinable
-    public subscript(metadataKey metadataKey: String) -> Logger.Metadata.Value? {
+    public subscript(metadataKey metadataKey: String) -> Logging.Logger.Metadata.Value? {
         get { metadata[metadataKey] }
         set { metadata[metadataKey] = newValue }
     }
@@ -247,7 +247,7 @@ public struct DDLogHandler: LogHandler {
     ///   - metadata: The metadata associated with the message.
     /// - Returns: Whether to log the message asynchronous.
     @usableFromInline
-    func _logAsync(level: Logger.Level, metadata: Logger.Metadata?) -> Bool {
+    func _logAsync(level: Logging.Logger.Level, metadata: Logging.Logger.Metadata?) -> Bool {
         if level >= config.syncLogging.tresholdLevel {
             // Easiest check -> level is above treshold. Not async.
             return false
@@ -261,9 +261,9 @@ public struct DDLogHandler: LogHandler {
     }
 
     @inlinable
-    public func log(level: Logger.Level,
-                    message: Logger.Message,
-                    metadata: Logger.Metadata?,
+    public func log(level: Logging.Logger.Level,
+                    message: Logging.Logger.Message,
+                    metadata: Logging.Logger.Metadata?,
                     source: String,
                     file: String,
                     function: String,
@@ -284,7 +284,7 @@ public struct DDLogHandler: LogHandler {
 
 extension DDLogHandler {
     /// The default key to control per message whether to log it synchronous or asynchronous.
-    public static var defaultSynchronousLoggingMetadataKey: Logger.Metadata.Key {
+    public static var defaultSynchronousLoggingMetadataKey: Logging.Logger.Metadata.Key {
         "log-synchronous"
     }
 
@@ -298,10 +298,10 @@ extension DDLogHandler {
     /// - SeeAlso: `DDLog`, `LoggingSystem.boostrap`
     public static func handlerFactory(
         for log: DDLog = .sharedInstance,
-        defaultLogLevel: Logger.Level = .info,
-        loggingSynchronousAsOf syncLoggingTreshold: Logger.Level = .error,
-        synchronousLoggingMetadataKey: Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey
-    ) -> (String, Logger.MetadataProvider?) -> LogHandler {
+        defaultLogLevel: Logging.Logger.Level = .info,
+        loggingSynchronousAsOf syncLoggingTreshold: Logging.Logger.Level = .error,
+        synchronousLoggingMetadataKey: Logging.Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey
+    ) -> (String, Logging.Logger.MetadataProvider?) -> LogHandler {
         let config = DDLogHandler.Configuration(
             log: log,
             syncLogging: .init(tresholdLevel: syncLoggingTreshold,
@@ -323,11 +323,11 @@ extension DDLogHandler {
     @inlinable
     public static func handlerFactory(
         for log: DDLog = .sharedInstance,
-        defaultLogLevel: Logger.Level = .info,
-        loggingSynchronousAsOf syncLoggingTreshold: Logger.Level = .error,
-        synchronousLoggingMetadataKey: Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey
+        defaultLogLevel: Logging.Logger.Level = .info,
+        loggingSynchronousAsOf syncLoggingTreshold: Logging.Logger.Level = .error,
+        synchronousLoggingMetadataKey: Logging.Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey
     ) -> (String) -> LogHandler {
-        let factory: (String, Logger.MetadataProvider?) -> LogHandler = handlerFactory(
+        let factory: (String, Logging.Logger.MetadataProvider?) -> LogHandler = handlerFactory(
             for: log,
             defaultLogLevel: defaultLogLevel,
             loggingSynchronousAsOf: syncLoggingTreshold,
@@ -349,10 +349,10 @@ extension LoggingSystem {
     @inlinable
     public static func bootstrapWithCocoaLumberjack(
         for log: DDLog = .sharedInstance,
-        defaultLogLevel: Logger.Level = .info,
-        loggingSynchronousAsOf syncLoggingTreshold: Logger.Level = .error,
-        synchronousLoggingMetadataKey: Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey,
-        metadataProvider: Logger.MetadataProvider? = nil
+        defaultLogLevel: Logging.Logger.Level = .info,
+        loggingSynchronousAsOf syncLoggingTreshold: Logging.Logger.Level = .error,
+        synchronousLoggingMetadataKey: Logging.Logger.Metadata.Key = DDLogHandler.defaultSynchronousLoggingMetadataKey,
+        metadataProvider: Logging.Logger.MetadataProvider? = nil
     ) {
         bootstrap(DDLogHandler.handlerFactory(for: log,
                                               defaultLogLevel: defaultLogLevel,

--- a/Tests/CocoaLumberjackSwiftLogBackendTests/DDLogHandlerTests.swift
+++ b/Tests/CocoaLumberjackSwiftLogBackendTests/DDLogHandlerTests.swift
@@ -52,8 +52,8 @@ final class DDLogHandlerTests: XCTestCase {
         // since another use of it will fail the precondition (multiple bootstrap calls)
         // All other tests must use `LoggingSystem.bootstrapInternal`.
         LoggingSystem.bootstrapWithCocoaLumberjack(for: mockDDLog)
-        let logger = Logger(label: "TestLogger")
-        let msg: Logger.Message = "test message"
+        let logger = Logging.Logger(label: "TestLogger")
+        let msg: Logging.Logger.Message = "test message"
         let logLine: UInt = #line + 1
         logger.info(msg)
         XCTAssertEqual(mockDDLog.loggedMessages.count, 1)
@@ -77,8 +77,8 @@ final class DDLogHandlerTests: XCTestCase {
 
     func testBootstrappingWithExplicitMethod() throws {
         LoggingSystem.bootstrapInternal(DDLogHandler.handlerFactory(for: mockDDLog))
-        let logger = Logger(label: "TestLogger")
-        let msg: Logger.Message = "test message"
+        let logger = Logging.Logger(label: "TestLogger")
+        let msg: Logging.Logger.Message = "test message"
         let logLine: UInt = #line + 1
         logger.info(msg)
         XCTAssertEqual(mockDDLog.loggedMessages.count, 1)
@@ -102,7 +102,7 @@ final class DDLogHandlerTests: XCTestCase {
 
     func testDefaults() throws {
         LoggingSystem.bootstrapInternal(DDLogHandler.handlerFactory())
-        let logger = Logger(label: "TestLogger")
+        let logger = Logging.Logger(label: "TestLogger")
         XCTAssertEqual(logger.logLevel, .info)
         XCTAssertTrue(logger.handler is DDLogHandler)
         let ddLogHandler = try XCTUnwrap(logger.handler as? DDLogHandler)
@@ -114,18 +114,18 @@ final class DDLogHandlerTests: XCTestCase {
     }
 
     func testLoggingAllLevels() throws {
-        let syncTresholdLevel = Logger.Level.warning
-        let syncLoggingMetadataKey: Logger.Metadata.Key = "test-log-sync"
+        let syncTresholdLevel = Logging.Logger.Level.warning
+        let syncLoggingMetadataKey: Logging.Logger.Metadata.Key = "test-log-sync"
         LoggingSystem.bootstrapInternal(DDLogHandler.handlerFactory(for: mockDDLog,
                                                                     loggingSynchronousAsOf: syncTresholdLevel,
                                                                     synchronousLoggingMetadataKey: syncLoggingMetadataKey))
-        var logger = Logger(label: "TestLogger")
+        var logger = Logging.Logger(label: "TestLogger")
         logger.logLevel = .trace // enable all logs
         logger[metadataKey: "test-data"] = "test-value"
         XCTAssertEqual(logger.logLevel, .trace)
         XCTAssertEqual(logger[metadataKey: "test-data"], "test-value")
-        let allLevels = Logger.Level.allCases
-        let message1Meta: Logger.Metadata = ["msg-data": "msg-value"]
+        let allLevels = Logging.Logger.Level.allCases
+        let message1Meta: Logging.Logger.Metadata = ["msg-data": "msg-value"]
         let message2Meta = message1Meta.merging([syncLoggingMetadataKey: .stringConvertible(true)], uniquingKeysWith: { $1 })
         let logLine1: UInt = #line + 3
         let logLine2 = logLine1 + 1
@@ -133,8 +133,8 @@ final class DDLogHandlerTests: XCTestCase {
             logger.log(level: level, "\(level)-msg", metadata: message1Meta)
             logger.log(level: level, "\(level)-msg-with-sync", metadata: message2Meta)
         }
-        XCTAssertEqual(mockDDLog.loggedMessages.count, Logger.Level.allCases.count * 2)
-        guard mockDDLog.loggedMessages.count >= Logger.Level.allCases.count * 2 else { return } // prevent test crashes
+        XCTAssertEqual(mockDDLog.loggedMessages.count, Logging.Logger.Level.allCases.count * 2)
+        guard mockDDLog.loggedMessages.count >= Logging.Logger.Level.allCases.count * 2 else { return } // prevent test crashes
 
         zip(allLevels, stride(from: mockDDLog.loggedMessages.startIndex, to: mockDDLog.loggedMessages.endIndex, by: 2)).forEach {
             let level = $0.0

--- a/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
@@ -15,7 +15,12 @@
 
 @import XCTest;
 
+#ifndef DD_LEGACY_MACROS
+    #define DD_LEGACY_MACROS 0
+#endif
+
 #import <os/log.h>
+#import <CocoaLumberjack/DDLog.h>
 #import <CocoaLumberjack/DDOSLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 

--- a/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
@@ -19,6 +19,32 @@
 #import <CocoaLumberjack/DDOSLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 
+@interface DDTestOSLogLevelMapper: NSObject <DDOSLogLevelMapper>
+
+@property (nonatomic, strong) id<DDOSLogLevelMapper> underlyingMapper;
+@property (nonatomic, strong) NSMutableArray<NSNumber *> *collectedLogFlags;
+
+@end
+
+@implementation DDTestOSLogLevelMapper
+
+- (instancetype)initWithUnderlyingMapper:(id<DDOSLogLevelMapper>)underlyingMapper
+{
+    self = [super init];
+    if (self) {
+        self.underlyingMapper = underlyingMapper;
+        self.collectedLogFlags = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (os_log_type_t)osLogTypeForLogFlag:(DDLogFlag)logFlag {
+    [self.collectedLogFlags addObject:@(logFlag)];
+    return [self.underlyingMapper osLogTypeForLogFlag:logFlag];
+}
+
+@end
+
 @interface DDOSLoggingTests : XCTestCase
 @end
 
@@ -30,6 +56,7 @@
 }
 
 - (void)tearDown {
+    [DDLog removeAllLoggers];
     [super tearDown];
 }
 
@@ -49,5 +76,48 @@
 #pragma clang diagnostic pop
     }
 }
+
+- (void)testDDOSLogLevelMapper {
+    __auto_type mapper = [[DDTestOSLogLevelMapper alloc] initWithUnderlyingMapper:[[DDOSLogLevelMapperDefault alloc] init]];
+    __auto_type logger = [[DDOSLogger alloc] initWithLogLevelMapper:mapper];
+    [DDLog addLogger:logger];
+
+    __auto_type ddLogLevel = DDLogLevelVerbose;
+    DDLogVerbose(@"VERBOSE");
+    DDLogDebug(@"DEBUG");
+    DDLogInfo(@"INFO");
+    DDLogWarn(@"WARN");
+    DDLogError(@"ERROR");
+
+    XCTAssertEqual(mapper.collectedLogFlags.count, 5);
+    if (mapper.collectedLogFlags.count < 5) return; // prevent test crashes
+    XCTAssertEqual(mapper.collectedLogFlags[0].unsignedIntegerValue, DDLogFlagVerbose);
+    XCTAssertEqual(mapper.collectedLogFlags[1].unsignedIntegerValue, DDLogFlagDebug);
+    XCTAssertEqual(mapper.collectedLogFlags[2].unsignedIntegerValue, DDLogFlagInfo);
+    XCTAssertEqual(mapper.collectedLogFlags[3].unsignedIntegerValue, DDLogFlagWarning);
+    XCTAssertEqual(mapper.collectedLogFlags[4].unsignedIntegerValue, DDLogFlagError);
+}
+
+- (void)testDDOSLogLevelMapperDefault {
+    __auto_type mapper = [[DDOSLogLevelMapperDefault alloc] init];
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagVerbose], OS_LOG_TYPE_DEBUG);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagDebug], OS_LOG_TYPE_DEBUG);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagInfo], OS_LOG_TYPE_INFO);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagWarning], OS_LOG_TYPE_ERROR);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagError], OS_LOG_TYPE_ERROR);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:NSUIntegerMax], OS_LOG_TYPE_DEFAULT);
+}
+
+#if TARGET_OS_SIMULATOR
+- (void)testDDOSLogLevelMapperSimulatorConsoleAppWorkaround {
+    __auto_type mapper = [[DDOSLogLevelMapperSimulatorConsoleAppWorkaround alloc] init];
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagVerbose], OS_LOG_TYPE_DEFAULT);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagDebug], OS_LOG_TYPE_DEFAULT);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagInfo], OS_LOG_TYPE_INFO);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagWarning], OS_LOG_TYPE_ERROR);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:DDLogFlagError], OS_LOG_TYPE_ERROR);
+    XCTAssertEqual([mapper osLogTypeForLogFlag:NSUIntegerMax], OS_LOG_TYPE_DEFAULT);
+}
+#endif
 
 @end

--- a/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
@@ -15,6 +15,7 @@
 
 @import XCTest;
 
+#import <os/log.h>
 #import <CocoaLumberjack/DDOSLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
 

--- a/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
+++ b/Tests/CocoaLumberjackTests/DDOSLoggingTests.m
@@ -15,14 +15,11 @@
 
 @import XCTest;
 
-#ifndef DD_LEGACY_MACROS
-    #define DD_LEGACY_MACROS 0
-#endif
-
 #import <os/log.h>
-#import <CocoaLumberjack/DDLog.h>
+
 #import <CocoaLumberjack/DDOSLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
+#import <CocoaLumberjack/DDLogMacros.h>
 
 @interface DDTestOSLogLevelMapper: NSObject <DDOSLogLevelMapper>
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: #1409 

### Pull Request Description

This improves the DDOSLogger implementation with points that were brought up in #1409.

- Cleanup properties and methods.
- Raise `DDLogFlagWarn` messages to the `.error` level in OSLog (which is what Apple does).
- Add `DDOSLogLevelMapper` to allow custom mapping from `DDLogFlag` -> `os_log_type_t`.