### PR TITLE
Update/fix Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "CocoaLumberjack",
-            exclude: ["Supporting Files"],
+            // exclude: ["Supporting Files"], // contains the CocoaLumberjack.h and without this header file, using CL with SPM does not seem to work
             resources: [
                 .process("PrivacyInfo.xcprivacy"),
             ]),


### PR DESCRIPTION
Removing the exclude-"clause" from the CocoaLumberjack target, because the "Supporting Files"-folder contains the CocoaLumberjack.h and without this header file, using CL with SPM does not seem to work properly.

### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [ ] I have added the required tests to prove the fix/feature I am adding
- [ ] I have updated the documentation (if necessary)
- [ ] I have run the tests and they pass
- [ ] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: ...

### Pull Request Description

Fixing the SPM setup.
Feel free to reject this PR if I am missing something (or I am using CL via SPM wrong).
I am using CL for years (with an older version) and now I am updating to the latest version and switching to SPM. 
Without this/my change, I was not able to get it running.

PS: thanks for the great work with this project - been using it for years and it is rock-solid!

Greetings from Germany
