### PR TITLE
Change designated initializer on DDOSLogger

### DIFF
--- a/Sources/CocoaLumberjack/DDOSLogger.m
+++ b/Sources/CocoaLumberjack/DDOSLogger.m
@@ -84,30 +84,31 @@ static DDOSLogger *sharedInstance;
 }
 
 #pragma mark - Initialization
-- (instancetype)initWithSubsystem:(NSString *)subsystem category:(NSString *)category {
-    NSAssert((subsystem == nil) == (category == nil), 
+- (instancetype)initWithSubsystem:(NSString *)subsystem
+                         category:(NSString *)category
+                   logLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper {
+    NSAssert((subsystem == nil) == (category == nil),
              @"Either both subsystem and category or neither should be nil.");
+    NSParameterAssert(logLevelMapper);
     if (self = [super init]) {
         _subsystem = [subsystem copy];
         _category = [category copy];
-        _logLevelMapper = [[DDOSLogLevelMapperDefault alloc] init];
+        _logLevelMapper = logLevelMapper;
     }
     return self;
+}
+
+- (instancetype)initWithSubsystem:(NSString *)subsystem category:(NSString *)category {
+    return [self initWithSubsystem:subsystem
+                          category:category
+                    logLevelMapper:[[DDOSLogLevelMapperDefault alloc] init]];
 }
 
 - (instancetype)init {
     return [self initWithSubsystem:nil category:nil];
 }
 
-- (instancetype)initWithSubsystem:(NSString *)subsystem
-                         category:(NSString *)category
-                   logLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper {
-    if (self = [self initWithSubsystem:subsystem category:category]) {
-        NSParameterAssert(logLevelMapper);
-        _logLevelMapper = logLevelMapper;
-    }
-    return self;
-}
+
 
 - (instancetype)initWithLogLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper {
     return [self initWithSubsystem:nil category:nil logLevelMapper:logLevelMapper];

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDOSLogger.h
@@ -73,18 +73,6 @@ DD_SENDABLE
 /// The log level mapper, that maps ``DDLogFlag``s to ``os_log_type_t`` for this logger.
 @property (nonatomic, strong, readonly) id<DDOSLogLevelMapper> logLevelMapper;
 
-/// The designated initializer, using `DDOSLogLevelMapperDefault`.
-/// @param subsystem Desired subsystem in log. E.g. "org.example"
-/// @param category Desired category in log. E.g. "Point of interests."
-/// @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
-///             If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
-///             If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`.
-- (instancetype)initWithSubsystem:(nullable NSString *)subsystem 
-                         category:(nullable NSString *)category NS_DESIGNATED_INITIALIZER;
-
-/// Creates an instance that uses `OS_LOG_DEFAULT` and `DDOSLogLevelMapperDefault`.
-- (instancetype)init;
-
 /// An initializer that in addition to subsystem and category also allows providing the log level mapper.
 /// @param subsystem Desired subsystem in log. E.g. "org.example"
 /// @param category Desired category in log. E.g. "Point of interests."
@@ -94,12 +82,23 @@ DD_SENDABLE
 ///             If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`
 - (instancetype)initWithSubsystem:(nullable NSString *)subsystem
                          category:(nullable NSString *)category
-                   logLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper;
-// FIXME: This should actually be the designated initializer, but that would be a breaking change. Adjust in next version bump.
+                   logLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper NS_DESIGNATED_INITIALIZER;
+
+/// The designated initializer, using `DDOSLogLevelMapperDefault`.
+/// @param subsystem Desired subsystem in log. E.g. "org.example"
+/// @param category Desired category in log. E.g. "Point of interests."
+/// @discussion This method requires either both or no parameter to be set. Much like `(String, String)?` in Swift.
+///             If both parameters are nil, this method will return a logger configured with `OS_LOG_DEFAULT`.
+///             If both parameters are non-nil, it will return a logger configured with `os_log_create(subsystem, category)`.
+- (instancetype)initWithSubsystem:(nullable NSString *)subsystem 
+                         category:(nullable NSString *)category;
 
 /// Creates an instance that uses `OS_LOG_DEFAULT`.
 /// @param logLevelMapper The log level mapper to use.
 - (instancetype)initWithLogLevelMapper:(id<DDOSLogLevelMapper>)logLevelMapper;
+
+/// Creates an instance that uses `OS_LOG_DEFAULT` and `DDOSLogLevelMapperDefault`.
+- (instancetype)init;
 
 @end
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: -

### Pull Request Description

With #1410, the designated initializer of DDOSLogger _should_ have been changed, but couldn't since it would be a breaking change. After the version now being bumped to 3.9.0, this PR updates the designated initializer of DDOSLogger.
