### PR TITLE
Make file locking optional

### DIFF
--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -191,7 +191,12 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 @property (nonatomic, readonly, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
 
 /// Whether the log file should be locked by the file logger before writing to it (and unlocked after).
-/// @param logFilePath The path to the log file for which to decide locking.
+/// - Parameter logFilePath: The path to the log file for which to decide locking.
+/// - Remark: Logging from multiple processes (e.g. an app extensions) to the same log file without file locking will result in interleaved and possibly even overwritten log messages.
+///           Without locking, the resulting logfile could be described as "best effort" and might become corrupted.
+///           The downside of locking is that if the process holds the file lock when it gets suspended by the system, the system will kill the process.
+///           This could happen by inproper handling of app suspension (e.g. not properly calling `+[DDLog flushLog]` and waiting for its completion before suspension).
+///           Regardless of locking, you should always call `+[DDLog flushLog]` before your app gets suspended or terminated to make sure every log message makes it to your disk.
 - (BOOL)shouldLockLogFile:(NSString *)logFilePath;
 
 /// Manually perform a cleanup of the log files managed by this manager.

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -190,6 +190,10 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 /// The log message serializer.
 @property (nonatomic, readonly, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
 
+/// Whether the log file should be locked by the file logger before writing to it (and unlocked after).
+/// @param logFilePath The path to the log file for which to decide locking.
+- (BOOL)shouldLockLogFile:(NSString *)logFilePath;
+
 /// Manually perform a cleanup of the log files managed by this manager.
 /// This can be called from any queue!
 - (BOOL)cleanupLogFilesWithError:(NSError **)error;


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: Fixes #1424 

### Pull Request Description

File locking was introduced in #1367 but seems to be problematic when apps are e.g. suspended in the background. The system then checks for any file locks that are still held and if any, kills the process.
There are workarounds (like starting a background job that flushes the logs), but given that these are _always_ necessary, even though file locking is only necessary when logging to the same file from multiple processes (which is **not** the default), it makes sense to turn _off_ file locking by default, but allow users that customize the file name / path to also enable file locking.
