### PR TITLE
Allow custom NSFileManager's on DDLogFileManager's

### DIFF
--- a/Sources/CocoaLumberjack/DDFileLogger.m
+++ b/Sources/CocoaLumberjack/DDFileLogger.m
@@ -1109,11 +1109,13 @@ NSTimeInterval     const kDDRollingLeeway              = 1.0;              // 1s
                 NSLogError(@"DDFileLogger: Failed to create new log file");
             }
         }
-        const __auto_type logFileManagerProvidesFileManager = [_logFileManager respondsToSelector:@selector(fileManager)];
-        __auto_type fileManager = logFileManagerProvidesFileManager ? _logFileManager.fileManager : [NSFileManager defaultManager];
-
-        // Use static factory method here, since it checks for nil (and is unavailable to Swift).
-        _currentLogFileInfo = [DDLogFileInfo logFileWithPath:currentLogFilePath fileManager:fileManager];
+        if (!currentLogFilePath) {
+            _currentLogFileInfo = nil;
+        } else {
+            const __auto_type logFileManagerProvidesFileManager = [_logFileManager respondsToSelector:@selector(fileManager)];
+            __auto_type fileManager = logFileManagerProvidesFileManager ? _logFileManager.fileManager : [NSFileManager defaultManager];
+            _currentLogFileInfo = [[DDLogFileInfo alloc] initWithFilePath:currentLogFilePath fileManager:fileManager];
+        }
     }
 
     return _currentLogFileInfo;
@@ -1507,12 +1509,8 @@ static NSString * const kDDXAttrArchivedName = @"lumberjack.log.archived";
 #pragma mark Lifecycle
 
 + (instancetype)logFileWithPath:(NSString *)aFilePath {
-    return [self logFileWithPath:aFilePath fileManager:[NSFileManager defaultManager]];
-}
-
-+ (instancetype)logFileWithPath:(NSString *)aFilePath fileManager:(NSFileManager *)fileManager {
     if (!aFilePath) return nil;
-    return [[self alloc] initWithFilePath:aFilePath fileManager:fileManager];
+    return [[self alloc] initWithFilePath:aFilePath];
 }
 
 - (instancetype)initWithFilePath:(NSString *)aFilePath {

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -565,9 +565,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 @property (nonatomic, readwrite) BOOL isArchived;
 
-+ (nullable instancetype)logFileWithPath:(nullable NSString *)filePath NS_SWIFT_UNAVAILABLE("Use init(filePath:)");
 + (nullable instancetype)logFileWithPath:(nullable NSString *)filePath
-                             fileManager:(NSFileManager *)fileManager NS_SWIFT_UNAVAILABLE("Use init(filePath:fileManager:)");
+    __attribute__((deprecated("Check file path for nil and pass it to the initializer instead")))
+    NS_SWIFT_UNAVAILABLE("Use init(filePath:)");
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithFilePath:(NSString *)filePath NS_DESIGNATED_INITIALIZER;

--- a/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
+++ b/Sources/CocoaLumberjack/include/CocoaLumberjack/DDFileLogger.h
@@ -190,6 +190,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 /// The log message serializer.
 @property (nonatomic, readonly, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
 
+/// The file manager to  use. Defaults to `[NSFileManager defaultManager]`.
+@property (nonatomic, readonly, strong) NSFileManager *fileManager;
+
 /// Whether the log file should be locked by the file logger before writing to it (and unlocked after).
 /// - Parameter logFilePath: The path to the log file for which to decide locking.
 /// - Remark: Logging from multiple processes (e.g. an app extensions) to the same log file without file locking will result in interleaved and possibly even overwritten log messages.
@@ -327,6 +330,9 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 
 /// The log message serializer.
 @property (nonatomic, strong) id<DDFileLogMessageSerializer> logMessageSerializer;
+
+/// The file manager to  use. Defaults to `[NSFileManager defaultManager]`.
+@property (nonatomic, strong) NSFileManager *fileManager;
 
 /* Inherited from DDLogFileManager protocol:
 
@@ -560,9 +566,13 @@ extern unsigned long long const kDDDefaultLogFilesDiskQuota;
 @property (nonatomic, readwrite) BOOL isArchived;
 
 + (nullable instancetype)logFileWithPath:(nullable NSString *)filePath NS_SWIFT_UNAVAILABLE("Use init(filePath:)");
++ (nullable instancetype)logFileWithPath:(nullable NSString *)filePath
+                             fileManager:(NSFileManager *)fileManager NS_SWIFT_UNAVAILABLE("Use init(filePath:fileManager:)");
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithFilePath:(NSString *)filePath NS_DESIGNATED_INITIALIZER;
+// TODO: This should really become the designated initializer.
+- (instancetype)initWithFilePath:(NSString *)filePath fileManager:(NSFileManager *)fileManager;
 
 - (void)reset;
 - (void)renameFile:(NSString *)newFileName NS_SWIFT_NAME(renameFile(to:));

--- a/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
+++ b/Tests/CocoaLumberjackTests/DDFileLoggerTests.m
@@ -121,6 +121,7 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     [DDLog addLogger:logger];
     DDLogError(@"Some log in the old file");
     __auto_type oldLogFileInfo = [logger currentLogFileInfo];
+    XCTAssertNotNil(oldLogFileInfo);
     __auto_type expectation = [self expectationWithDescription:@"Waiting for the log file to be rolled"];
     [logger rollLogFileWithCompletionBlock:^{
         [expectation fulfill];
@@ -130,6 +131,7 @@ static const DDLogLevel ddLogLevel = DDLogLevelAll;
     }];
     DDLogError(@"Some log in the new file");
     __auto_type newLogFileInfo = [logger currentLogFileInfo];
+    XCTAssertNotNil(newLogFileInfo);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:oldLogFileInfo.filePath]);
     XCTAssertTrue([[NSFileManager defaultManager] fileExistsAtPath:newLogFileInfo.filePath]);
     __auto_type oldString = [NSString stringWithContentsOfFile:oldLogFileInfo.filePath


### PR DESCRIPTION
### New Pull Request Checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/.github/CONTRIBUTING.md)
- [x] I have read the [Documentation](http://cocoadocs.org/docsets/CocoaLumberjack/)
- [x] I have searched for a similar pull request in the [project](https://github.com/CocoaLumberjack/CocoaLumberjack/pulls) and found none

<br/>

- [x] I have updated this branch with the latest master to avoid conflicts (via merge from master or rebase)
- [x] I have added the required tests to prove the fix/feature I am adding
- [x] I have updated the documentation (if necessary)
- [x] I have run the tests and they pass
- [x] I have run the lint and it passes (`pod lib lint`)

This merge request fixes / refers to the following issues: Resolves #1434

### Pull Request Description

Add (optional) `fileManager` to `DDLogFileManager` protocol and a corresponding implementation to `DDLogFileManagerDefault` for convenience.

`DDLogFileInfo` also uses a file manager internally, which is why it also needs to store a file manager now.
